### PR TITLE
✨ Add npmignore file, reduce release size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,91 @@
+# Development files
+src/
+tests/
+coverage/
+node_modules/
+scripts/
+
+# Build artifacts
+*.tgz
+.nyc_output/
+
+# Configuration files
+.eslintrc*
+.prettierrc*
+eslint.config.js
+babel.config.json
+tsconfig.json
+vitest.config.js
+vizzly.config.js
+
+# Git files
+.git/
+.gitignore
+.gitattributes
+
+# CI/CD
+.github/
+.travis.yml
+.circleci/
+.jenkins/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+.nyc_output/
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.test
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Keep these files (explicitly not ignored):
+# README.md - documentation
+# LICENSE - license file
+# docs/ - documentation folder
+# dist/ - built files
+# bin/ - executable scripts
+
+# Ensure docs directory is included
+!docs/

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ We welcome contributions! Whether you're fixing bugs, adding features, or improv
 
 ### Getting Started
 
-1. Fork the repository on [GitHub](https://github.com/vizzly/cli)
+1. Fork the repository on [GitHub](https://github.com/vizzly-testing/cli)
 2. Clone your fork locally: `git clone https://github.com/your-username/cli.git`
 3. Install dependencies: `npm install`
 4. Run tests to ensure everything works: `npm test`
@@ -348,7 +348,7 @@ We welcome contributions! Whether you're fixing bugs, adding features, or improv
 
 ### Reporting Issues
 
-Found a bug or have a feature request? Please [open an issue](https://github.com/vizzly/cli/issues) with:
+Found a bug or have a feature request? Please [open an issue](https://github.com/vizzly-testing/cli/issues) with:
 
 - A clear description of the problem or request
 - Steps to reproduce (for bugs)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -600,4 +600,4 @@ For additional help:
 - Check [Getting Started Guide](./getting-started.md)
 - Review [Test Integration Guide](./test-integration.md)
 - Explore [TDD Mode Guide](./tdd-mode.md)
-- Report issues at [GitHub Issues](https://github.com/vizzly/cli/issues)
+- Report issues at [GitHub Issues](https://github.com/vizzly-testing/cli/issues)

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "cli"
   ],
   "homepage": "https://vizzly.dev",
-  "bugs": "https://github.com/vizzly/cli/issues",
+  "bugs": "https://github.com/vizzly-testing/cli/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/vizzly/cli.git"
+    "url": "https://github.com/vizzly-testing/cli.git"
   },
   "license": "MIT",
   "author": "Stubborn Mule Software <support@vizzly.dev>",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "files": [
     "bin",
     "dist",
+    "docs",
     "README.md",
     "LICENSE"
   ],

--- a/tests/integration/cli-options.spec.js
+++ b/tests/integration/cli-options.spec.js
@@ -165,7 +165,13 @@ describe('CLI Options Integration', () => {
 
     it('should handle port option parsing', async () => {
       const result = await runCLI(
-        ['run', 'echo "test successful"', '--port', '8080', '--allow-no-token'],
+        [
+          'run',
+          'echo "test successful"',
+          '--port',
+          '47501',
+          '--allow-no-token',
+        ],
         {
           env: { CI: 'true' },
         }
@@ -258,7 +264,7 @@ describe('CLI Options Integration', () => {
 
     it('should handle port option parsing', async () => {
       const result = await runCLI(
-        ['tdd', 'echo "test successful"', '--port', '8080'],
+        ['tdd', 'echo "test successful"', '--port', '47500'],
         {
           env: { CI: 'true' },
         }

--- a/tests/integration/tdd-command.spec.js
+++ b/tests/integration/tdd-command.spec.js
@@ -165,7 +165,7 @@ describe('TDD Command Integration', () => {
           '--tdd',
           'echo "test"',
           '--port',
-          '8080',
+          '47502',
           '--environment',
           'staging',
           '--threshold',
@@ -198,7 +198,7 @@ describe('TDD Command Integration', () => {
 
   describe('TDD Command Options and Configuration', () => {
     it('should accept valid port option', async () => {
-      const result = await runCLI(['tdd', 'echo "test"', '--port', '8080'], {
+      const result = await runCLI(['tdd', 'echo "test"', '--port', '47503'], {
         env: { CI: 'true' },
       });
 


### PR DESCRIPTION
## What is this?

The release has over 90 files in it, that shouldn't be happening. This adds an npmignore file to make sure we're not including any src, test, or other files.

I also slipped in a fix for bad URLs in docs/package.json