### PR TITLE
🐛 Fix git commit capture

### DIFF
--- a/src/services/test-runner.js
+++ b/src/services/test-runner.js
@@ -125,13 +125,11 @@ export class TestRunner extends BaseService {
       const apiService = await this.createApiService();
       if (apiService) {
         const buildResult = await apiService.createBuild({
-          build: {
-            name: options.buildName || `Test Run ${new Date().toISOString()}`,
-            branch: options.branch || 'main',
-            environment: options.environment || 'test',
-            commit_sha: options.commit,
-            commit_message: options.message,
-          },
+          name: options.buildName || `Test Run ${new Date().toISOString()}`,
+          branch: options.branch || 'main',
+          environment: options.environment || 'test',
+          commit_sha: options.commit,
+          commit_message: options.message,
         });
         this.logger.debug(`Build created with ID: ${buildResult.id}`);
 

--- a/src/services/uploader.js
+++ b/src/services/uploader.js
@@ -106,8 +106,8 @@ export function createUploader(
       const buildInfo = {
         name: buildName || `Upload ${new Date().toISOString()}`,
         branch: branch || (await getDefaultBranch()) || 'main',
-        commitSha: commit,
-        commitMessage: message,
+        commit_sha: commit,
+        commit_message: message,
         environment,
         threshold,
       };

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -200,7 +200,25 @@ export async function detectBranch(override = null, cwd = process.cwd()) {
 export async function detectCommit(override = null, cwd = process.cwd()) {
   if (override) return override;
 
-  return await getCurrentCommitSha(cwd);
+  // Try git command first
+  const gitCommit = await getCurrentCommitSha(cwd);
+  if (gitCommit) return gitCommit;
+
+  // Fallback to environment variables commonly used in CI
+  const envCommit =
+    process.env.GITHUB_SHA || // GitHub Actions
+    process.env.CI_COMMIT_SHA || // GitLab CI
+    process.env.CIRCLE_SHA1 || // CircleCI
+    process.env.TRAVIS_COMMIT || // Travis CI
+    process.env.BUILDKITE_COMMIT || // Buildkite
+    process.env.DRONE_COMMIT_SHA || // Drone CI
+    process.env.CODEBUILD_RESOLVED_SOURCE_VERSION || // AWS CodeBuild
+    process.env.BUILD_VCS_NUMBER || // TeamCity
+    process.env.GIT_COMMIT || // Jenkins
+    process.env.COMMIT_SHA || // Generic
+    process.env.HEAD_COMMIT; // Alternative generic
+
+  return envCommit || null;
 }
 
 /**


### PR DESCRIPTION
## What is this?

I wasn't passing the commit sha, which would break the github integration from working. Of course.

---
This pull request improves consistency in commit metadata handling and enhances robustness for CI/CD environments. The main changes focus on standardizing field names for commit information and adding fallbacks for commit detection to support various CI systems.

**Commit metadata consistency:**

* Updated field names from `commitSha`/`commitMessage` to `commit_sha`/`commit_message` in `src/services/uploader.js` for consistency across services.
* Removed unnecessary nesting of the `build` object when creating builds in `TestRunner` to match the expected API format.

**CI/CD compatibility improvements:**

* Enhanced the `detectCommit` function in `src/utils/git.js` to fall back to common CI/CD environment variables if the git command fails, improving reliability in automated environments.