### PR TITLE
🐛 Fix finalize command

### DIFF
--- a/src/commands/finalize.js
+++ b/src/commands/finalize.js
@@ -43,7 +43,7 @@ export async function finalizeCommand(
     // Create service container and get API service
     ui.startSpinner('Finalizing parallel build...');
     const container = await createServiceContainer(config, 'finalize');
-    const apiService = await container.get('api');
+    const apiService = await container.get('apiService');
     ui.stopSpinner();
 
     // Call finalize endpoint


### PR DESCRIPTION
## What?

Wrong arg for the apiService container

---

This pull request updates the service container usage in the `finalizeCommand` function to improve clarity and consistency in service naming.

Service naming update:

* Changed the service retrieval from `container.get('api')` to `container.get('apiService')` in `src/commands/finalize.js`, ensuring consistency with the service's intended purpose and likely aligning with other parts of the codebase.