### PR TITLE
🐛 Fix sha over deduplication

### DIFF
--- a/tests/services/api-service.spec.js
+++ b/tests/services/api-service.spec.js
@@ -133,7 +133,15 @@ describe('ApiService', () => {
       expect(firstCall[1].method).toBe('POST');
       const firstRequestBody = JSON.parse(firstCall[1].body);
       expect(firstRequestBody.buildId).toBe(buildId);
-      expect(firstRequestBody.shas).toEqual([sha256]);
+      expect(firstRequestBody.screenshots).toEqual([
+        {
+          sha256,
+          name,
+          browser: metadata.browser || 'chrome',
+          viewport_width: metadata.viewport?.width || 1920,
+          viewport_height: metadata.viewport?.height || 1080,
+        },
+      ]);
 
       // Check that upload was called with correct data (second call)
       const secondCall = global.fetch.mock.calls[1];
@@ -185,7 +193,15 @@ describe('ApiService', () => {
       const firstCall = global.fetch.mock.calls[0];
       const firstRequestBody = JSON.parse(firstCall[1].body);
       expect(firstRequestBody.buildId).toBe(buildId);
-      expect(firstRequestBody.shas).toEqual([sha256]);
+      expect(firstRequestBody.screenshots).toEqual([
+        {
+          sha256,
+          name,
+          browser: 'chrome',
+          viewport_width: 1920,
+          viewport_height: 1080,
+        },
+      ]);
 
       // Check that upload was called with empty properties (second call)
       const secondCall = global.fetch.mock.calls[1];
@@ -239,7 +255,15 @@ describe('ApiService', () => {
       expect(firstCall[0]).toBe('https://vizzly.dev/api/sdk/check-shas');
       const requestBody = JSON.parse(firstCall[1].body);
       expect(requestBody.buildId).toBe(buildId);
-      expect(requestBody.shas).toEqual([sha256]);
+      expect(requestBody.screenshots).toEqual([
+        {
+          sha256,
+          name,
+          browser: 'chrome',
+          viewport_width: 1920,
+          viewport_height: 1080,
+        },
+      ]);
 
       expect(result).toEqual({
         message: 'Screenshot already exists, skipped upload',


### PR DESCRIPTION
## What is this?

We now use the name + sha to consider what needs to be deduplicated. 

---
This pull request introduces signature-based deduplication for screenshot uploads, improving how the system checks for existing screenshots by considering metadata such as browser and viewport dimensions. The main changes update the API service and uploader logic to support this new format, ensure backward compatibility, and add related test coverage.

**Signature-based deduplication and API changes:**

* Updated `ApiService.checkShas` to accept either an array of SHA strings (legacy) or an array of screenshot objects with metadata, and dynamically build the request body for the `/api/sdk/check-shas` endpoint.
* Improved error handling in `ApiService.checkShas` to extract SHA values from either format for consistent fallback behavior.
* Modified screenshot upload flow in `ApiService` to use the new signature-based format when checking for existing screenshots, including passing metadata such as browser and viewport. [[1]](diffhunk://#diff-35db277c4b1bd7577c6a6ae77fcb683696b154b2a93f8c7394f0cf1432a24e29L175-R220) [[2]](diffhunk://#diff-35db277c4b1bd7577c6a6ae77fcb683696b154b2a93f8c7394f0cf1432a24e29L195-R233)

**Uploader logic enhancements:**

* Refactored `checkExistingFiles` in `uploader.js` to batch and send screenshot objects with signature data (including browser and viewport) for deduplication, and added a helper to extract browser names from filenames. [[1]](diffhunk://#diff-8648aa90df287bc3a7eaf07f6f8d9a0243f8b46a9972bb94da8ee68258b6113dL301-R325) [[2]](diffhunk://#diff-8648aa90df287bc3a7eaf07f6f8d9a0243f8b46a9972bb94da8ee68258b6113dR345-R362)

**Test updates for new format:**

* Updated tests in `api-service.spec.js` to verify that requests use the new screenshot object format, including correct metadata extraction and fallback to defaults where necessary. [[1]](diffhunk://#diff-b42eca429b3d40549b6623640c048c1af75c9bd57e15acd0abfcceda1211fdb2L136-R144) [[2]](diffhunk://#diff-b42eca429b3d40549b6623640c048c1af75c9bd57e15acd0abfcceda1211fdb2L188-R204) [[3]](diffhunk://#diff-b42eca429b3d40549b6623640c048c1af75c9bd57e15acd0abfcceda1211fdb2L242-R266)