### PR TITLE
🔧 Update default API base URL to app.vizzly.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Check if Vizzly is enabled in the current environment.
 
 ### Core Configuration
 - `VIZZLY_TOKEN`: API authentication token. Example: `export VIZZLY_TOKEN=your-token`.
-- `VIZZLY_API_URL`: Override API base URL. Default: `https://vizzly.dev`.
+- `VIZZLY_API_URL`: Override API base URL. Default: `https://app.vizzly.dev`.
 - `VIZZLY_LOG_LEVEL`: Logger level. One of `debug`, `info`, `warn`, `error`. Example: `export VIZZLY_LOG_LEVEL=debug`.
 
 ### Parallel Builds

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -470,7 +470,7 @@ Configuration loaded via cosmiconfig in this order:
 {
   // API Configuration
   apiKey: string,              // API token (from VIZZLY_TOKEN)
-  apiUrl: string,              // API base URL (default: 'https://vizzly.dev')
+  apiUrl: string,              // API base URL (default: 'https://app.vizzly.dev')
   project: string,             // Project ID override
 
   // Server Configuration (for run command)

--- a/docs/doctor-command.md
+++ b/docs/doctor-command.md
@@ -30,7 +30,7 @@ vizzly doctor --json
 
 ## Environment Variables
 
-- `VIZZLY_API_URL` — Override the API base URL (default: `https://vizzly.dev`)
+- `VIZZLY_API_URL` — Override the API base URL (default: `https://app.vizzly.dev`)
 - `VIZZLY_TOKEN` — API token used only when `--api` is provided
 
 ## Exit Codes

--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -30,7 +30,7 @@ import { VizzlyError } from '../errors/vizzly-error.js';
  *
  * const vizzly = await createVizzly({
  *   apiKey: process.env.VIZZLY_TOKEN,
- *   apiUrl: 'https://vizzly.dev',
+ *   apiUrl: 'https://app.vizzly.dev',
  *   server: {
  *     port: 3003,
  *     enabled: true

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -62,7 +62,7 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
   const envApiUrl = getApiUrl();
   const envParallelId = getParallelId();
   if (envApiKey) config.apiKey = envApiKey;
-  if (envApiUrl !== 'https://vizzly.dev') config.apiUrl = envApiUrl;
+  if (envApiUrl !== 'https://app.vizzly.dev') config.apiUrl = envApiUrl;
   if (envParallelId) config.parallelId = envParallelId;
 
   // 3. Apply CLI overrides (highest priority)

--- a/src/utils/environment-config.js
+++ b/src/utils/environment-config.js
@@ -16,7 +16,7 @@ export function getApiToken() {
  * @returns {string} API URL with default
  */
 export function getApiUrl() {
-  return process.env.VIZZLY_API_URL || 'https://vizzly.dev';
+  return process.env.VIZZLY_API_URL || 'https://app.vizzly.dev';
 }
 
 /**

--- a/tests/services/api-service-metadata.spec.js
+++ b/tests/services/api-service-metadata.spec.js
@@ -43,7 +43,7 @@ describe('ApiService - Metadata Handling', () => {
       // Verify the upload request has the correct structure (second call after SHA check)
       const secondCall = global.fetch.mock.calls[1];
       expect(secondCall[0]).toBe(
-        `https://vizzly.dev/api/sdk/builds/${buildId}/screenshots`
+        `https://app.vizzly.dev/api/sdk/builds/${buildId}/screenshots`
       );
       expect(secondCall[1].method).toBe('POST');
       expect(secondCall[1].headers['Content-Type']).toBe('application/json');

--- a/tests/services/api-service.spec.js
+++ b/tests/services/api-service.spec.js
@@ -37,7 +37,7 @@ describe('ApiService', () => {
       const result = await service.request('/test');
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://vizzly.dev/test',
+        'https://app.vizzly.dev/test',
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer test-token',
@@ -72,7 +72,7 @@ describe('ApiService', () => {
       const result = await service.createBuild(metadata);
 
       expect(global.fetch).toHaveBeenCalledWith(
-        'https://vizzly.dev/api/sdk/builds',
+        'https://app.vizzly.dev/api/sdk/builds',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ build: metadata }),
@@ -129,7 +129,7 @@ describe('ApiService', () => {
 
       // Check that SHA check was called first with buildId
       const firstCall = global.fetch.mock.calls[0];
-      expect(firstCall[0]).toBe('https://vizzly.dev/api/sdk/check-shas');
+      expect(firstCall[0]).toBe('https://app.vizzly.dev/api/sdk/check-shas');
       expect(firstCall[1].method).toBe('POST');
       const firstRequestBody = JSON.parse(firstCall[1].body);
       expect(firstRequestBody.buildId).toBe(buildId);
@@ -146,7 +146,7 @@ describe('ApiService', () => {
       // Check that upload was called with correct data (second call)
       const secondCall = global.fetch.mock.calls[1];
       expect(secondCall[0]).toBe(
-        `https://vizzly.dev/api/sdk/builds/${buildId}/screenshots`
+        `https://app.vizzly.dev/api/sdk/builds/${buildId}/screenshots`
       );
       const uploadBody = JSON.parse(secondCall[1].body);
       expect(uploadBody.properties).toEqual(metadata);
@@ -252,7 +252,7 @@ describe('ApiService', () => {
 
       // Verify the request included buildId
       const firstCall = global.fetch.mock.calls[0];
-      expect(firstCall[0]).toBe('https://vizzly.dev/api/sdk/check-shas');
+      expect(firstCall[0]).toBe('https://app.vizzly.dev/api/sdk/check-shas');
       const requestBody = JSON.parse(firstCall[1].body);
       expect(requestBody.buildId).toBe(buildId);
       expect(requestBody.screenshots).toEqual([
@@ -296,7 +296,7 @@ describe('ApiService', () => {
       const result = await service.finalizeParallelBuild(parallelId);
 
       expect(global.fetch).toHaveBeenCalledWith(
-        `https://vizzly.dev/api/sdk/parallel/${parallelId}/finalize`,
+        `https://app.vizzly.dev/api/sdk/parallel/${parallelId}/finalize`,
         {
           method: 'POST',
           headers: {


### PR DESCRIPTION
## Summary
- Updated default API base URL from `https://vizzly.dev` to `https://app.vizzly.dev`
- Changes applied across configuration files, documentation, and SDK examples
- Maintains backward compatibility via `VIZZLY_API_URL` environment variable

## Files Changed
- `src/utils/environment-config.js` - Main default URL configuration
- `src/utils/config-loader.js` - Config comparison logic  
- `src/sdk/index.js` - SDK documentation example
- `README.md` - Environment variables documentation
- `docs/api-reference.md` - API reference documentation
- `docs/doctor-command.md` - Doctor command documentation

## Test Plan
- [x] Verify default URL is updated in all locations
- [x] Test CLI functionality with new default URL
- [x] Ensure environment variable override still works