### PR TITLE
🔧 Fix CLI config structure inconsistencies

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -496,9 +496,7 @@ Configuration loaded via cosmiconfig in this order:
 
   // Comparison Configuration
   comparison: {
-    threshold: number,         // Pixel difference threshold (default: 0.01)
-    ignoreAntialiasing: boolean, // Ignore antialiasing (default: true)
-    ignoreColors: boolean      // Ignore color differences (default: false)
+    threshold: number         // Pixel difference threshold (default: 0.1)
   }
 }
 ```

--- a/docs/tdd-mode.md
+++ b/docs/tdd-mode.md
@@ -242,9 +242,7 @@ Configure in `vizzly.config.js`:
 ```javascript
 export default {
   comparison: {
-    threshold: 0.01,        // 1% difference tolerance
-    ignoreAntialiasing: true,
-    ignoreColors: false
+    threshold: 0.01        // 1% difference tolerance
   }
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2997,18 +2997,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "22.16.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
-      "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
@@ -5898,15 +5886,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -47,30 +47,36 @@ export class InitCommand {
     const configContent = `export default {
   // API configuration
   // Set VIZZLY_TOKEN environment variable or uncomment and set here:
-  // apiToken: 'your-token-here',
-  
-  // Screenshot configuration
-  screenshots: {
-    directory: './screenshots',
-    formats: ['png']
-  },
-  
-  // Server configuration
+  // apiKey: 'your-token-here',
+
+  // Server configuration (for run command)
   server: {
     port: 47392,
+    timeout: 30000,
     screenshotPath: '/screenshot'
   },
-  
+
+  // Build configuration
+  build: {
+    name: 'Build {timestamp}',
+    environment: 'test'
+  },
+
+  // Upload configuration (for upload command)
+  upload: {
+    screenshotsDir: './screenshots',
+    batchSize: 10,
+    timeout: 30000
+  },
+
   // Comparison configuration
   comparison: {
-    threshold: 0.1,
-    ignoreAntialiasing: true
+    threshold: 0.1
   },
-  
-  // Upload configuration
-  upload: {
-    concurrency: 5,
-    timeout: 30000
+
+  // TDD configuration
+  tdd: {
+    openReport: false // Whether to auto-open HTML report in browser
   }
 };
 `;

--- a/tests/commands/init.spec.js
+++ b/tests/commands/init.spec.js
@@ -135,12 +135,12 @@ describe('InitCommand', () => {
       );
       expect(fs.writeFile).toHaveBeenCalledWith(
         configPath,
-        expect.stringContaining('apiToken:'),
+        expect.stringContaining('apiKey:'),
         'utf8'
       );
       expect(fs.writeFile).toHaveBeenCalledWith(
         configPath,
-        expect.stringContaining('screenshots:'),
+        expect.stringContaining('build:'),
         'utf8'
       );
       expect(fs.writeFile).toHaveBeenCalledWith(

--- a/vizzly.config.js
+++ b/vizzly.config.js
@@ -1,29 +1,35 @@
 export default {
   // API configuration
   // Set VIZZLY_TOKEN environment variable or uncomment and set here:
-  // apiToken: 'your-token-here',
-  
-  // Screenshot configuration
-  screenshots: {
-    directory: './screenshots',
-    formats: ['png']
-  },
-  
-  // Server configuration
+  // apiKey: 'your-token-here',
+
+  // Server configuration (for run command)
   server: {
     port: 47392,
+    timeout: 30000,
     screenshotPath: '/screenshot'
   },
-  
+
+  // Build configuration
+  build: {
+    name: 'Build {timestamp}',
+    environment: 'test'
+  },
+
+  // Upload configuration (for upload command)
+  upload: {
+    screenshotsDir: './screenshots',
+    batchSize: 10,
+    timeout: 30000
+  },
+
   // Comparison configuration
   comparison: {
-    threshold: 0.1,
-    ignoreAntialiasing: true
+    threshold: 0.1
   },
-  
-  // Upload configuration
-  upload: {
-    concurrency: 5,
-    timeout: 30000
+
+  // TDD configuration
+  tdd: {
+    openReport: false // Whether to auto-open HTML report in browser
   }
 };


### PR DESCRIPTION
## Summary
- Fixed config initialization to match what config-loader actually expects
- Removed unused/invalid config options that were causing confusion
- Added missing essential config options for complete functionality

## Changes Made
- **Fixed config structure mismatch**: `screenshots.directory` → `upload.screenshotsDir`, `upload.concurrency` → `upload.batchSize`
- **Removed unused options**: `screenshots.formats`, `comparison.ignoreAntialiasing` (not implemented in CLI)
- **Added missing options**: `build` config section, `server.timeout`, `tdd.openReport`
- **Updated tests**: Fixed assertions to match new config structure
- **Updated docs**: Removed references to unsupported options

## Problem Solved
The `vizzly init` command was generating config files that didn't work with the actual config loader, creating a confusing developer experience where generated configs contained options that were ignored or caused errors.

## Test Plan
- [x] All existing tests pass with updated assertions
- [x] Generated config now matches what config-loader expects
- [x] Documentation reflects actual supported options

🎯 Generated configs now work correctly with the CLI out of the box.