### PR TITLE
🐛 Fix TDD baseline matching to use signature-based logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,7 @@
         "dotenv": "^17.2.1",
         "form-data": "^4.0.0",
         "glob": "^11.0.3",
-        "odiff-bin": "^3.2.1",
-        "wouter": "^3.7.1"
+        "odiff-bin": "^3.2.1"
       },
       "bin": {
         "vizzly": "bin/vizzly.js"
@@ -46,7 +45,8 @@
         "tailwindcss": "^4.1.13",
         "typescript": "^5.0.4",
         "vite": "^7.1.7",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "wouter": "^3.7.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6766,6 +6766,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -7284,6 +7285,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7401,6 +7403,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
       "integrity": "sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8531,6 +8534,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8886,6 +8890,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/wouter/-/wouter-3.7.1.tgz",
       "integrity": "sha512-od5LGmndSUzntZkE2R5CHhoiJ7YMuTIbiXsa0Anytc2RATekgv4sfWRAxLEULBrp7ADzinWQw8g470lkT8+fOw==",
+      "dev": true,
       "license": "Unlicense",
       "dependencies": {
         "mitt": "^3.0.1",

--- a/src/server/handlers/tdd-handler.js
+++ b/src/server/handlers/tdd-handler.js
@@ -157,47 +157,15 @@ export const createTddHandler = (
       };
     }
 
-    // Create unique screenshot name based on properties
-    let uniqueName = sanitizedName;
-    const relevantProps = [];
-
-    // Add browser to name if provided (already validated)
-    if (validatedProperties.browser) {
-      relevantProps.push(validatedProperties.browser);
-    }
-
-    // Add viewport info if provided (already validated)
-    if (
-      validatedProperties.viewport &&
-      validatedProperties.viewport.width &&
-      validatedProperties.viewport.height
-    ) {
-      relevantProps.push(
-        `${validatedProperties.viewport.width}x${validatedProperties.viewport.height}`
-      );
-    }
-
-    // Combine base name with relevant properties and sanitize the result
-    if (relevantProps.length > 0) {
-      let proposedUniqueName = `${sanitizedName}-${relevantProps.join('-')}`;
-      try {
-        uniqueName = sanitizeScreenshotName(proposedUniqueName);
-      } catch (error) {
-        // If the combined name is invalid, fall back to the base sanitized name
-        uniqueName = sanitizedName;
-        logger.warn(
-          `Combined screenshot name invalid (${error.message}), using base name: ${uniqueName}`
-        );
-      }
-    }
-
     const imageBuffer = Buffer.from(image, 'base64');
-    logger.debug(`Received screenshot: ${name} → unique: ${uniqueName}`);
+    logger.debug(`Received screenshot: ${name}`);
     logger.debug(`Image size: ${imageBuffer.length} bytes`);
     logger.debug(`Properties: ${JSON.stringify(validatedProperties)}`);
 
+    // Use the sanitized name as-is (no modification with browser/viewport)
+    // Baseline matching uses signature logic (name + viewport_width + browser)
     const comparison = await tddService.compareScreenshot(
-      uniqueName,
+      sanitizedName,
       imageBuffer,
       validatedProperties
     );


### PR DESCRIPTION
## Summary
Fixes critical bug in TDD mode where screenshots with different viewports or browsers were being compared against incorrect baselines.

## Changes
- **Signature-based baseline matching**: Implemented signature generation (name + viewport_width + browser) matching the Vizzly API's screenshot-identity logic
- **Browser version stripping**: Strip version numbers from browser strings (e.g., `Chrome/139.0.7258.138` → `Chrome`)
- **Signature-based filenames**: Use signatures for baseline/current/diff file paths to ensure proper isolation
- **Updated metadata matching**: All baseline metadata now uses signatures instead of just names
- **Simplified TDD handler**: Removed screenshot name modification - now uses user's test name as-is, letting signature logic handle matching
- **Comprehensive tests**: Added 5 new tests covering signature-based baseline matching scenarios
- **Package cleanup**: Moved wouter to devDependencies

## Test Plan
- ✅ All existing tests pass
- ✅ New tests verify:
  - Different viewports create separate baselines
  - Different browsers create separate baselines
  - Same signature reuses same baseline
  - Browser version stripping works correctly

## Why This Matters
Before this fix, screenshots with different dimensions could be matched to wrong baselines, causing false failures. This ensures TDD mode behaves consistently with `vizzly run` by using the same signature-based matching logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)