### PR TITLE
🐛 Fix baseline download filename matching in TDD mode

### DIFF
--- a/tests/services/tdd-baseline-download.spec.js
+++ b/tests/services/tdd-baseline-download.spec.js
@@ -171,6 +171,7 @@ describe('TDD Service - Baseline Download', () => {
             id: 'screenshot1',
             properties: {},
             path: join(testDir, '.vizzly', 'baselines', 'homepage.png'),
+            signature: 'homepage',
             originalUrl: 'https://example.com/homepage.png',
             fileSize: 12345,
             dimensions: {
@@ -185,6 +186,7 @@ describe('TDD Service - Baseline Download', () => {
             id: 'screenshot2',
             properties: {},
             path: join(testDir, '.vizzly', 'baselines', 'login.png'),
+            signature: 'login',
             originalUrl: 'https://example.com/login.png',
             fileSize: 67890,
             dimensions: {


### PR DESCRIPTION
## Summary
- Fixes baseline filename mismatch when using `--baseline-build` flag in TDD mode
- Downloaded baselines now use signature-based filenames matching comparison logic
- Resolves issue where UI showed "New Baseline" even after downloading baselines

## Problem
When using `npx vizzly tdd start --baseline-build <build-id>`, baselines were downloaded successfully but the UI showed them as "New Baseline" instead of comparing against them.

**Root Cause:**
- Downloaded baselines were saved as `{name}.png` (e.g., `homepage-desktop.png`)
- Comparison logic expected `{signature}.png` where signature = `name + viewport_width + browser` (e.g., `homepage-desktop_1920_firefox.png`)
- This mismatch caused the comparison to not find baselines and mark them as new

## Changes
- Generate signature when downloading baselines using the same logic as comparison
- Save downloaded files with signature-based filenames
- Store signature in baseline metadata for efficient SHA comparison  
- Update SHA map to use signature instead of name for lookups
- Update tests to include signature field in expected results

## Test Plan
- [x] All existing tests pass (532 tests)
- [x] Updated baseline download test to verify signature field
- [x] Verified downloaded baselines use correct signature-based filenames
- [x] Build succeeds with no errors

## Impact
Users can now use `--baseline-build` flag and downloaded baselines will be properly recognized and used for comparison instead of being marked as new baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)