### PR TITLE
🔥 Remove unused config options from init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,20 +233,10 @@ Create a `vizzly.config.js` file with `vizzly init` or manually:
 
 ```javascript
 export default {
-  // API configuration
-  // Set VIZZLY_TOKEN environment variable or uncomment and set here:
-  // apiToken: 'your-token-here',
-
-  // Screenshot configuration
-  screenshots: {
-    directory: './screenshots',
-    formats: ['png']
-  },
-
   // Server configuration
   server: {
     port: 47392,
-    screenshotPath: '/screenshot'
+    timeout: 30000
   },
 
   // Comparison configuration

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -476,8 +476,7 @@ Configuration loaded via cosmiconfig in this order:
   // Server Configuration (for run command)
   server: {
     port: number,              // Server port (default: 47392)
-    timeout: number,           // Timeout in ms (default: 30000)
-    screenshotPath: string     // Screenshot endpoint path
+    timeout: number            // Timeout in ms (default: 30000)
   },
 
   // Build Configuration

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -45,15 +45,10 @@ export class InitCommand {
 
   async generateConfigFile(configPath) {
     const configContent = `export default {
-  // API configuration
-  // Set VIZZLY_TOKEN environment variable or uncomment and set here:
-  // apiKey: 'your-token-here',
-
   // Server configuration (for run command)
   server: {
     port: 47392,
-    timeout: 30000,
-    screenshotPath: '/screenshot'
+    timeout: 30000
   },
 
   // Build configuration

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -11,7 +11,6 @@ const DEFAULT_CONFIG = {
   server: {
     port: 47392,
     timeout: 30000,
-    screenshotPath: '/screenshot',
   },
 
   // Build Configuration

--- a/tests/commands/init.spec.js
+++ b/tests/commands/init.spec.js
@@ -135,11 +135,6 @@ describe('InitCommand', () => {
       );
       expect(fs.writeFile).toHaveBeenCalledWith(
         configPath,
-        expect.stringContaining('apiKey:'),
-        'utf8'
-      );
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        configPath,
         expect.stringContaining('build:'),
         'utf8'
       );
@@ -156,6 +151,18 @@ describe('InitCommand', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         configPath,
         expect.stringContaining('upload:'),
+        'utf8'
+      );
+      // Ensure apiKey comment is NOT present
+      expect(fs.writeFile).not.toHaveBeenCalledWith(
+        configPath,
+        expect.stringContaining('apiKey'),
+        'utf8'
+      );
+      // Ensure screenshotPath is NOT present
+      expect(fs.writeFile).not.toHaveBeenCalledWith(
+        configPath,
+        expect.stringContaining('screenshotPath'),
         'utf8'
       );
 

--- a/vizzly.config.js
+++ b/vizzly.config.js
@@ -1,13 +1,8 @@
 export default {
-  // API configuration
-  // Set VIZZLY_TOKEN environment variable or uncomment and set here:
-  // apiKey: 'your-token-here',
-
   // Server configuration (for run command)
   server: {
     port: 47392,
-    timeout: 30000,
-    screenshotPath: '/screenshot'
+    timeout: 30000
   },
 
   // Build configuration


### PR DESCRIPTION
## Summary

Cleans up the `init` command configuration output by removing dead code and improving security practices.

## Changes

- **Removed `apiKey` comment** that encouraged storing tokens in config files (security improvement)
- **Removed `screenshotPath` option** - completely unused (endpoint is hardcoded at `/screenshot`)
- Updated tests to verify removed options are not present
- Updated documentation to reflect clean config schema

## Why?

1. **Security**: We should never encourage storing API tokens in config files that might be committed to git
2. **Dead code**: `screenshotPath` is defined but never used anywhere in the codebase - the endpoint is hardcoded in `src/services/screenshot-server.js:50`
3. **Clarity**: Config output should only show actually-used options

## Testing

✅ All 558 tests pass  
✅ No remaining references to removed options (verified with grep)  
✅ Init command generates clean, minimal config

## Files Changed

- `src/commands/init.js` - init command output
- `src/utils/config-loader.js` - default config
- `vizzly.config.js` - project config
- `docs/api-reference.md` - documentation
- `README.md` - example config
- `tests/commands/init.spec.js` - test updates