### PR TITLE
🔧 Relax client peer dependency version requirements

### DIFF
--- a/clients/static-site/package.json
+++ b/clients/static-site/package.json
@@ -60,7 +60,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@vizzly-testing/cli": "^0.9.0"
+    "@vizzly-testing/cli": ">=0.9.0"
   },
   "dependencies": {
     "cosmiconfig": "^9.0.0",

--- a/clients/storybook/package.json
+++ b/clients/storybook/package.json
@@ -56,7 +56,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "peerDependencies": {
-    "@vizzly-testing/cli": "^0.9.0"
+    "@vizzly-testing/cli": ">=0.9.0"
   },
   "dependencies": {
     "cosmiconfig": "^9.0.0",


### PR DESCRIPTION
## Summary

Fixes npm peer dependency conflicts by relaxing version requirements for `@vizzly-testing/cli` in client packages.

## Problem

Both `@vizzly-testing/static-site` and `@vizzly-testing/storybook` used `^0.9.0` as the peer dependency for the CLI. This caused installation failures when users had CLI version 0.10.x installed:

```
npm error Could not resolve dependency:
npm error peer @vizzly-testing/cli@"^0.9.0" from @vizzly-testing/static-site@0.0.2
npm error   Found: @vizzly-testing/cli@0.10.2
```

The `^0.9.0` range only accepts versions `0.9.x`, excluding `0.10.x` and higher.

## Solution

Changed peer dependencies from `^0.9.0` to `>=0.9.0` in both client packages:
- `@vizzly-testing/static-site`
- `@vizzly-testing/storybook`

## Why This Works

The `>=0.9.0` semver range:
- ✅ Still requires minimum version 0.9.0 (when plugin support was introduced)
- ✅ Accepts any version 0.9.0 or higher (0.10.x, 1.x, etc.)
- ✅ Allows the CLI to evolve without forcing client package updates
- ✅ Prevents npm peer dependency conflicts

## Test Plan

- [x] Tested installation with CLI 0.10.2
- [x] Verified both client packages work with current CLI version