### PR TITLE
🐛 Fix --baseline-comparison to download only the comparison's baseline

### DIFF
--- a/src/services/api-service.js
+++ b/src/services/api-service.js
@@ -155,7 +155,8 @@ export class ApiService {
    * @returns {Promise<Object>} Comparison data
    */
   async getComparison(comparisonId) {
-    return this.request(`/api/sdk/comparisons/${comparisonId}`);
+    let response = await this.request(`/api/sdk/comparisons/${comparisonId}`);
+    return response.comparison;
   }
 
   /**

--- a/tests/services/tdd-baseline-download.spec.js
+++ b/tests/services/tdd-baseline-download.spec.js
@@ -408,35 +408,19 @@ describe('TDD Service - Baseline Download', () => {
     });
 
     it('should download baselines using comparison ID', async () => {
-      // Mock comparison API response
+      // Mock comparison API response - matches actual API structure
       const mockComparison = {
         id: 'comp123',
-        baselineBuild: {
-          id: 'baseline-build-789',
-          name: 'Comparison Baseline',
-          status: 'passed',
+        baseline_name: 'profile',
+        current_name: 'profile',
+        baseline_screenshot: {
+          id: 'screenshot1',
+          build_id: 'baseline-build-789',
         },
-      };
-
-      const mockBuildDetails = {
-        id: 'baseline-build-789',
-        screenshots: [
-          {
-            name: 'profile',
-            url: 'https://example.com/profile.png',
-            original_url: 'https://example.com/profile.png',
-            sha256: 'sha256-profile',
-            id: 'screenshot1',
-            file_size_bytes: 12345,
-            width: 1920,
-            height: 1080,
-            properties: { viewport: { width: 1920, height: 1080 } },
-          },
-        ],
+        baseline_screenshot_url: 'https://example.com/profile.png',
       };
 
       mockApiService.getComparison.mockResolvedValueOnce(mockComparison);
-      mockApiService.getBuild.mockResolvedValueOnce(mockBuildDetails);
 
       // Mock successful image download
       const mockImageBuffer = Buffer.from('profile-image-data');
@@ -455,10 +439,8 @@ describe('TDD Service - Baseline Download', () => {
 
       // Verify API calls
       expect(mockApiService.getComparison).toHaveBeenCalledWith('comp123');
-      expect(mockApiService.getBuild).toHaveBeenCalledWith(
-        'baseline-build-789',
-        'screenshots'
-      );
+      // Should NOT call getBuild when using comparison ID - we create a mock build
+      expect(mockApiService.getBuild).not.toHaveBeenCalled();
 
       // Verify download
       expect(global.fetch).toHaveBeenCalledWith(
@@ -470,9 +452,8 @@ describe('TDD Service - Baseline Download', () => {
 
       expect(result).not.toBeNull();
       expect(tddService.baselineData.buildId).toBe('baseline-build-789');
-      expect(tddService.baselineData.screenshots[0].properties).toEqual({
-        viewport: { width: 1920, height: 1080 },
-      });
+      expect(tddService.baselineData.screenshots).toHaveLength(1);
+      expect(tddService.baselineData.screenshots[0].name).toBe('profile');
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the `--baseline-comparison` flag which was broken due to incorrect API response handling and downloading entire builds instead of single screenshots.

## Issues Fixed

1. **API Response Structure**: The comparison API returns `{ comparison: {...} }` but the code was treating the whole response as the comparison object
2. **Property Access**: Code tried to access `comparison.baselineBuild` which never existed in the API response
3. **Over-fetching**: Was downloading all 98+ screenshots from the baseline build when only 1 was needed

## Changes

### `src/services/api-service.js`
- Unwrap `response.comparison` from API response in `getComparison()`

### `src/services/tdd-service.js`
- Use `comparison.baseline_screenshot` (actual API structure) instead of `comparison.baselineBuild`
- Create a mock build with only the single baseline screenshot from the comparison
- Avoid fetching entire build when using `--baseline-comparison`

### `tests/services/tdd-baseline-download.spec.js`
- Fix test to match actual API structure (was testing with incorrect mock)
- Verify only 1 screenshot is downloaded, not entire build
- Remove incorrect `getBuild` call expectations

## Testing

✅ All tests pass
✅ Manually tested with real comparison ID - downloads only 1 screenshot instead of 98

## Related

- Requires API changes from vizzly-testing/vizzly#af6646e to include `baseline_screenshot` object in comparison response