### PR TITLE
🍯 Upgrade from odiff to honeydiff for image comparison

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ thing*. It enables teams to collaborate on visual changes through an intuitive w
 
 **TDD Mode (Local Development):**
 - No API token required
-- Screenshots compared locally using `odiff`
+- Screenshots compared locally using `honeydiff` (high-performance Rust-based diffing)
 - Interactive dashboard at `http://localhost:47392`
 - Accept/reject baselines directly in UI
 - Fast iteration cycle
@@ -105,7 +105,7 @@ service container, config, and logger.
 **TDD Workflow:**
 1. Developer runs `vizzly tdd start` → Background server starts
 2. Developer runs tests in watch mode → `vizzlyScreenshot()` sends images to server
-3. Server compares using `odiff` → Saves results to `.vizzly/`
+3. Server compares using `honeydiff` → Saves results to `.vizzly/`
 4. Dashboard shows live comparisons → Developer accepts/rejects in UI
 5. Baselines updated → Tests pass on next run
 

--- a/docs/tdd-mode.md
+++ b/docs/tdd-mode.md
@@ -7,7 +7,7 @@ TDD (Test-Driven Development) Mode enables fast local development with an intera
 TDD Mode transforms your visual testing workflow with:
 
 - **Interactive Dashboard** - Real-time visual feedback as tests run
-- **Local Comparison** - Compares screenshots on your machine using `odiff`
+- **Local Comparison** - Compares screenshots on your machine using `honeydiff`
 - **Live Updates** - See comparisons instantly in the browser
 - **Baseline Management** - Accept/reject changes directly from the UI
 - **Fast Feedback** - No network uploads during development
@@ -90,7 +90,7 @@ TDD Mode provides two workflows:
 ### Single-Shot Workflow
 
 1. **Run tests** - `vizzly tdd run "npm test"` executes once
-2. **Compares locally** - Uses `odiff` for pixel-perfect comparison
+2. **Compares locally** - Uses `honeydiff` for high-performance comparison
 3. **Generates report** - Creates HTML report with visual comparisons
 4. **Exit with status** - Fails if differences exceed threshold
 
@@ -452,14 +452,14 @@ rm -rf .vizzly/baselines/
 npx vizzly tdd run "npm test"
 ```
 
-### Odiff Not Found
+### Honeydiff Not Found
 ```
-Error: odiff binary not found
+Error: Cannot find module '@vizzly-testing/honeydiff'
 ```
 
-**Solution**: The `odiff-bin` package should be installed automatically. Try:
+**Solution**: The `@vizzly-testing/honeydiff` package should be installed automatically. Try:
 ```bash
-npm install odiff-bin
+npm install @vizzly-testing/honeydiff
 ```
 
 ## Best Practices

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "@vizzly-testing/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vizzly-testing/cli",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
+        "@vizzly-testing/honeydiff": "^0.1.0",
         "commander": "^14.0.0",
         "cosmiconfig": "^9.0.0",
         "dotenv": "^17.2.1",
         "form-data": "^4.0.0",
         "glob": "^11.0.3",
-        "odiff-bin": "^3.2.1",
         "zod": "^4.1.12"
       },
       "bin": {
@@ -3698,6 +3698,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vizzly-testing/honeydiff": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vizzly-testing/honeydiff/-/honeydiff-0.1.0.tgz",
+      "integrity": "sha512-/Hvq7/tJ4gfS4Lp48RHBNetFRaGLkq37FNGsRHroz72xsShyWsUueZ0zM24hWNrd6g54Qx9LPk7AoswEgZoczw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/accepts": {
@@ -7487,16 +7496,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/odiff-bin": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/odiff-bin/-/odiff-bin-3.2.1.tgz",
-      "integrity": "sha512-28y48d9vOf4DqHcn3U0RXL5PVO9gVNgrjzlO3Yu47NeDWnoxiIjlXRiXX5GYh0TU7qfUnWU7KGMtpl2BLJWpsA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "odiff": "bin/odiff.exe"
       }
     },
     "node_modules/on-finished": {

--- a/package.json
+++ b/package.json
@@ -79,12 +79,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@vizzly-testing/honeydiff": "^0.1.0",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",
     "dotenv": "^17.2.1",
     "form-data": "^4.0.0",
     "glob": "^11.0.3",
-    "odiff-bin": "^3.2.1",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/tests/services/tdd-service.spec.js
+++ b/tests/services/tdd-service.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TddService } from '../../src/services/tdd-service.js';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { compare } from '@vizzly-testing/honeydiff';
 
 // Mock all external dependencies
 vi.mock('fs', () => ({
@@ -28,9 +29,22 @@ vi.mock('../../src/utils/logger.js', () => ({
 vi.mock('../../src/utils/git.js');
 vi.mock('../../src/utils/fetch-utils.js');
 
-// Mock odiff-bin dynamic import
-vi.mock('odiff-bin', () => ({
-  compare: vi.fn(async () => ({ match: true, reason: 'identical' })),
+// Mock @vizzly-testing/honeydiff dynamic import
+vi.mock('@vizzly-testing/honeydiff', () => ({
+  compare: vi.fn(async () => ({
+    isDifferent: false,
+    diffPercentage: 0,
+    totalPixels: 1000000,
+    diffPixels: 0,
+    aaPixelsIgnored: 0,
+    aaPercentage: 0,
+    boundingBox: null,
+    heightDiff: null,
+    diffPixelsList: null,
+    diffClusters: null,
+    intensityStats: null,
+    perceptualScore: null,
+  })),
 }));
 
 describe('TddService', () => {
@@ -145,10 +159,22 @@ describe('TddService', () => {
 
     it('compares screenshots successfully when they match', async () => {
       const { existsSync } = await import('fs');
-      const { compare } = await import('odiff-bin');
 
       existsSync.mockReturnValue(true);
-      compare.mockResolvedValue({ match: true, reason: 'identical' });
+      compare.mockResolvedValue({
+        isDifferent: false,
+        diffPercentage: 0,
+        totalPixels: 1000000,
+        diffPixels: 0,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
+        boundingBox: null,
+        heightDiff: null,
+        diffPixelsList: null,
+        diffClusters: null,
+        intensityStats: null,
+        perceptualScore: null,
+      });
 
       const result = await tddService.compareScreenshot(
         'test-screenshot',
@@ -163,6 +189,9 @@ describe('TddService', () => {
         diff: null,
         properties: {},
         threshold: 0.1,
+        totalPixels: 1000000,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
       });
 
       expect(tddService.comparisons).toHaveLength(1);
@@ -170,13 +199,21 @@ describe('TddService', () => {
 
     it('detects differences when screenshots do not match', async () => {
       const { existsSync } = await import('fs');
-      const { compare } = await import('odiff-bin');
 
       existsSync.mockReturnValue(true);
       compare.mockResolvedValue({
-        match: false,
-        reason: 'pixel-diff',
+        isDifferent: true,
         diffPercentage: 5.2,
+        totalPixels: 1000000,
+        diffPixels: 52000,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
+        boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+        heightDiff: null,
+        diffPixelsList: null,
+        diffClusters: null,
+        intensityStats: null,
+        perceptualScore: null,
       });
 
       const result = await tddService.compareScreenshot(
@@ -192,18 +229,24 @@ describe('TddService', () => {
         diff: join(testDir, '.vizzly', 'diffs', 'test-screenshot.png'),
         properties: {},
         threshold: 0.1,
-        diffCount: undefined,
+        diffCount: 52000,
         diffPercentage: 5.2,
         reason: 'pixel-diff',
+        totalPixels: 1000000,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
+        boundingBox: { x: 0, y: 0, width: 100, height: 100 },
+        heightDiff: null,
+        intensityStats: null,
+        diffClusters: null,
       });
     });
 
-    it('handles odiff execution errors', async () => {
+    it('handles honeydiff execution errors', async () => {
       const { existsSync } = await import('fs');
-      const { compare } = await import('odiff-bin');
 
       existsSync.mockReturnValue(true);
-      compare.mockRejectedValue(new Error('odiff not found'));
+      compare.mockRejectedValue(new Error('honeydiff not found'));
 
       const result = await tddService.compareScreenshot(
         'test-screenshot',
@@ -217,7 +260,7 @@ describe('TddService', () => {
         current: join(testDir, '.vizzly', 'current', 'test-screenshot.png'),
         diff: null,
         properties: {},
-        error: 'odiff not found',
+        error: 'honeydiff not found',
       });
     });
 
@@ -243,10 +286,22 @@ describe('TddService', () => {
 
     it('uses different baselines for same name with different viewport widths', async () => {
       const { existsSync } = await import('fs');
-      const { compare } = await import('odiff-bin');
 
       existsSync.mockReturnValue(false);
-      compare.mockResolvedValue({ match: true, reason: 'identical' });
+      compare.mockResolvedValue({
+        isDifferent: false,
+        diffPercentage: 0,
+        totalPixels: 1000000,
+        diffPixels: 0,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
+        boundingBox: null,
+        heightDiff: null,
+        diffPixelsList: null,
+        diffClusters: null,
+        intensityStats: null,
+        perceptualScore: null,
+      });
 
       // First screenshot at 1920px width
       const result1 = await tddService.compareScreenshot(
@@ -273,10 +328,22 @@ describe('TddService', () => {
 
     it('uses different baselines for same name with different browsers', async () => {
       const { existsSync } = await import('fs');
-      const { compare } = await import('odiff-bin');
 
       existsSync.mockReturnValue(false);
-      compare.mockResolvedValue({ match: true, reason: 'identical' });
+      compare.mockResolvedValue({
+        isDifferent: false,
+        diffPercentage: 0,
+        totalPixels: 1000000,
+        diffPixels: 0,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
+        boundingBox: null,
+        heightDiff: null,
+        diffPixelsList: null,
+        diffClusters: null,
+        intensityStats: null,
+        perceptualScore: null,
+      });
 
       // First screenshot in Chrome
       const result1 = await tddService.compareScreenshot(
@@ -303,7 +370,6 @@ describe('TddService', () => {
 
     it('uses same baseline for identical name, viewport, and browser', async () => {
       const { existsSync } = await import('fs');
-      const { compare } = await import('odiff-bin');
 
       let callCount = 0;
       existsSync.mockImplementation(() => {
@@ -311,7 +377,20 @@ describe('TddService', () => {
         // First call: baseline doesn't exist, second call: baseline exists
         return callCount > 1;
       });
-      compare.mockResolvedValue({ match: true, reason: 'identical' });
+      compare.mockResolvedValue({
+        isDifferent: false,
+        diffPercentage: 0,
+        totalPixels: 1000000,
+        diffPixels: 0,
+        aaPixelsIgnored: 0,
+        aaPercentage: 0,
+        boundingBox: null,
+        heightDiff: null,
+        diffPixelsList: null,
+        diffClusters: null,
+        intensityStats: null,
+        perceptualScore: null,
+      });
 
       let properties = {
         browser: 'Chrome',


### PR DESCRIPTION
## Summary
Upgrades the TDD comparison engine from `odiff-bin` to our own `@vizzly-testing/honeydiff` for faster, more powerful visual comparison.

## Motivation
- **Performance**: 6x faster on large screenshots (79ms vs 474ms)
- **Consistency**: Same diffing engine as the Vizzly product
- **Control**: Full ownership of the comparison algorithm
- **Features**: Rich metrics for future UI enhancements

## Changes
- ✅ Dependency swap: `odiff-bin@3.2.1` → `@vizzly-testing/honeydiff@0.1.0`
- ✅ Top-level imports (cleaner ESM code)
- ✅ Enabled spatial clustering for multi-region detection
- ✅ Capturing all honeydiff metrics (AA stats, bounding boxes, intensity, clusters, height diffs)
- ✅ Updated tests with proper mocks and expectations
- ✅ Updated documentation (CLAUDE.md, tdd-mode.md)
- ✅ Enhanced console logging shows cluster count

## API Consistency with Vizzly Product
Now using identical options to the Vizzly product backend:
```javascript
compare(baseline, current, {
  colorThreshold: 0.1,    // YIQ mode ✅
  antialiasing: true,     // ✅
  includeClusters: true,  // ✅ Spatial analysis
})
```

## Captured Metrics (Ready for UI)
All comparison objects now include rich honeydiff metrics:
- **`aaPixelsIgnored`, `aaPercentage`** - Anti-aliasing filtering statistics
- **`boundingBox`** - Rectangular region showing where changes are located
- **`heightDiff`** - Scrollable content height changes detection
- **`intensityStats`** - Change severity analysis (min/max/mean/median/stdDev)
- **`diffClusters`** - Spatial regions of change with center of mass

These metrics are captured in all comparison objects and saved to `.vizzly/report-data.json`, ready for future TDD reporter UI enhancements.

## Performance Impact
Based on honeydiff benchmarks on 18.3M pixel screenshots:
- **RGB comparison**: 79ms (231.8M pixels/sec)
- **With clustering**: 88ms (208M pixels/sec)
- **vs odiff**: 6x faster (79ms vs 474ms)
- **Parallel efficiency**: 2-3x CPU usage with work stealing

## Testing
- ✅ All 721 tests passing
- ✅ Clean build with no errors
- ✅ No breaking changes
- ✅ Backward compatible API

## Future Work
These captured metrics enable future TDD reporter UI enhancements:
- Show "X regions changed" badges
- Display bounding box locations in diff viewer
- Height change alerts for scrollable content
- AA filtering percentage indicators
- Intensity-based severity color coding