### PR TITLE
⬆️ Require Node.js 22+ for honeydiff compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
     - uses: actions/checkout@v4
@@ -262,7 +262,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
     - uses: actions/checkout@v4
@@ -303,7 +303,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
     - uses: actions/checkout@v4
@@ -344,7 +344,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release-static-site-client.yml
+++ b/.github/workflows/release-static-site-client.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure git

--- a/.github/workflows/release-storybook-client.yml
+++ b/.github/workflows/release-storybook-client.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure git

--- a/.github/workflows/release-vitest-client.yml
+++ b/.github/workflows/release-vitest-client.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Configure git
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run tests
         working-directory: ./clients/vitest
-        run: npm test
+        run: npm run test:unit
 
       - name: Run linter
         working-directory: ./clients/vitest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The result? Visual quality integrated into development, not bolted on afterward.
 
 ## Quick Start
 
-Requirements: Node.js 20 or newer.
+**Requirements:** Node.js 22 or newer.
+
+> **Note:** Vizzly supports [active LTS versions](https://nodejs.org/en/about/previous-releases) of Node.js.
 
 ```bash
 # Install globally

--- a/clients/static-site/package.json
+++ b/clients/static-site/package.json
@@ -53,7 +53,7 @@
     "format:check": "prettier --check src"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/clients/storybook/package.json
+++ b/clients/storybook/package.json
@@ -49,7 +49,7 @@
     "format:check": "prettier --check src tests"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/clients/vitest/package.json
+++ b/clients/vitest/package.json
@@ -45,10 +45,10 @@
     "lint:fix": "eslint src tests --fix",
     "format": "prettier --write src tests",
     "format:check": "prettier --check src tests",
-    "prepublishOnly": "npm run lint && npm test"
+    "prepublishOnly": "npm run lint && npm run test:unit"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "format:check": "prettier --check src tests"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

This PR updates the minimum Node.js version requirement from 20 to 22 across all packages to ensure compatibility with `@vizzly-testing/honeydiff`, which requires Node 22+.

## Breaking Changes

- **Minimum Node version**: Now requires Node.js >=22.0.0 (previously >=20.0.0)
- Affects all packages:
  - Main CLI (`@vizzly-testing/cli`)
  - Vitest client (`@vizzly-testing/vitest`)
  - Storybook client (`@vizzly-testing/storybook`)
  - Static site client (`@vizzly-testing/static-site`)

## Additional Changes

- Updated vitest release workflow to use Node 22
- Removed e2e tests from vitest client `prepublishOnly` script (requires Playwright browser setup)
- Only unit tests run during publish workflow now

## Testing

- [ ] Verify all workflows pass with Node 22
- [ ] Confirm packages install correctly with Node 22+
- [ ] Test that Node <22 shows appropriate engine error

## Related Issues

Resolves engine compatibility warnings with honeydiff dependency.