### PR TITLE
⬆️ Use honeydiff getDimensionsSync API instead of custom PNG parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@vizzly-testing/cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vizzly-testing/cli",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "@vizzly-testing/honeydiff": "^0.1.0",
+        "@vizzly-testing/honeydiff": "^0.1.1",
         "commander": "^14.0.0",
         "cosmiconfig": "^9.0.0",
         "dotenv": "^17.2.1",
@@ -52,7 +52,7 @@
         "wouter": "^3.7.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -3701,9 +3701,9 @@
       }
     },
     "node_modules/@vizzly-testing/honeydiff": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@vizzly-testing/honeydiff/-/honeydiff-0.1.0.tgz",
-      "integrity": "sha512-/Hvq7/tJ4gfS4Lp48RHBNetFRaGLkq37FNGsRHroz72xsShyWsUueZ0zM24hWNrd6g54Qx9LPk7AoswEgZoczw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@vizzly-testing/honeydiff/-/honeydiff-0.1.1.tgz",
+      "integrity": "sha512-9Bbu0iOgFBi8s2we37MISN1jDu4MmnD1ro8ztYKePdAoQO7uZllAp/stx81rVXbaNPkWC9Zo2N90sbTWEgUxpg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@vizzly-testing/honeydiff": "^0.1.0",
+    "@vizzly-testing/honeydiff": "^0.1.1",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",
     "dotenv": "^17.2.1",


### PR DESCRIPTION
## Summary

Replace manual PNG header parsing with honeydiff's official `getDimensionsSync` API for cleaner, more robust image dimension detection.

## Changes

- **Updated dependency**: `@vizzly-testing/honeydiff` from 0.1.0 to 0.1.1
- **Removed custom code**: Deleted 40+ lines of manual PNG header parsing (`detectPNGDimensions`)
- **Using official API**: Now using honeydiff's `getDimensionsSync()` function
- **Better error handling**: Added try-catch for graceful dimension detection failures
- **Format agnostic**: Works with any image format honeydiff supports, not just PNG

## Benefits

- **Cleaner code**: Removed manual PNG spec implementation
- **Better performance**: Rust-based dimension detection
- **More reliable**: Official API handles edge cases
- **More maintainable**: No custom parsing logic to maintain

## Testing

All 759 tests pass ✅