### PR TITLE
✅ Add tests for vitest setupFiles duplication fix

### DIFF
--- a/clients/vitest/src/index.js
+++ b/clients/vitest/src/index.js
@@ -54,7 +54,7 @@ import { existsSync, readFileSync } from 'fs';
 export function vizzlyPlugin(_options = {}) {
   return {
     name: 'vitest-vizzly',
-    config(config) {
+    config() {
       // Auto-detect Vizzly server (TDD mode or cloud mode)
       // Search for .vizzly/server.json from process.cwd() up to root
       let serverUrl = process.env.VIZZLY_SERVER_URL || '';
@@ -84,9 +84,7 @@ export function vizzlyPlugin(_options = {}) {
 
       return {
         test: {
-          setupFiles: [
-            resolve(import.meta.dirname || __dirname, 'setup.js'),
-          ],
+          setupFiles: [resolve(import.meta.dirname || __dirname, 'setup.js')],
           browser: {
             // Disable Vitest's native screenshot testing
             // Our custom matcher completely replaces it


### PR DESCRIPTION
## Summary
- Adds regression tests validating that the Vitest plugin doesn't duplicate user-provided `setupFiles`
- Tests both array and string `setupFiles` configurations

## Context
These tests validate the fix from #82. Vitest automatically merges plugin config with user config, so the plugin should only return its own setup file—not spread the user's files into its return value.

## Test plan
- [x] Merge #82 first
- [x] Rebase this branch onto main
- [ ] Tests should pass