### PR TITLE
✨ Add hotspot filtering to TDD mode for noise reduction

### DIFF
--- a/src/services/api-service.js
+++ b/src/services/api-service.js
@@ -381,4 +381,40 @@ export class ApiService {
       headers: { 'Content-Type': 'application/json' },
     });
   }
+
+  /**
+   * Get hotspot analysis for a single screenshot
+   * @param {string} screenshotName - Screenshot name to get hotspots for
+   * @param {Object} options - Optional settings
+   * @param {number} [options.windowSize=20] - Number of historical builds to analyze
+   * @returns {Promise<Object>} Hotspot analysis data
+   */
+  async getScreenshotHotspots(screenshotName, options = {}) {
+    let { windowSize = 20 } = options;
+    let queryParams = new URLSearchParams({ windowSize: String(windowSize) });
+    let encodedName = encodeURIComponent(screenshotName);
+    return this.request(
+      `/api/sdk/screenshots/${encodedName}/hotspots?${queryParams}`
+    );
+  }
+
+  /**
+   * Batch get hotspot analysis for multiple screenshots
+   * More efficient than calling getScreenshotHotspots for each screenshot
+   * @param {string[]} screenshotNames - Array of screenshot names
+   * @param {Object} options - Optional settings
+   * @param {number} [options.windowSize=20] - Number of historical builds to analyze
+   * @returns {Promise<Object>} Hotspots keyed by screenshot name
+   */
+  async getBatchHotspots(screenshotNames, options = {}) {
+    let { windowSize = 20 } = options;
+    return this.request('/api/sdk/screenshots/hotspots', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        screenshot_names: screenshotNames,
+        windowSize,
+      }),
+    });
+  }
 }


### PR DESCRIPTION
## Summary

- Download and apply cloud-learned hotspot data during local TDD comparisons to automatically filter out known dynamic content (timestamps, IDs, etc.)
- Add API methods for fetching hotspot data (single and batch)
- Download hotspots alongside baselines during sync
- Calculate diff coverage within hotspot regions
- Auto-pass comparisons where 80%+ of diff is in high-confidence hotspots
- Include hotspot analysis in comparison results for dashboard display

## How it works

1. **Baseline sync**: When downloading baselines from the cloud, we also fetch hotspot data for all screenshots
2. **Comparison**: When a diff is detected, we check if the changed pixels fall within known hotspot regions
3. **Filtering**: If 80%+ of the diff is within high-confidence hotspots, the comparison passes with `reason: 'hotspot-filtered'`

## Example output

```
✅ PASSED Dashboard - differences in known hotspots (0.15% different, 42 pixels, 1 region, 95% in hotspots)
```

## Requires

Companion PR in the cloud product adds the SDK endpoints:
- `GET /api/sdk/screenshots/:screenshotName/hotspots`
- `POST /api/sdk/screenshots/hotspots` (batch)

## Test plan

- [x] All 604 existing tests pass
- [ ] Manual test with actual cloud data