### PR TITLE
🐛 Fix plugin registration error with frozen output module

### DIFF
--- a/clients/static-site/src/plugin.js
+++ b/clients/static-site/src/plugin.js
@@ -45,10 +45,6 @@ export default {
    * @param {Object} context.services - Service container
    */
   register(program, { config, logger, services }) {
-    // Override logger level to 'info' for static-site command
-    // The CLI logger defaults to 'warn' but static-site needs 'info' for progress
-    logger.level = 'info';
-
     program
       .command('static-site <path>')
       .description(

--- a/clients/storybook/src/plugin.js
+++ b/clients/storybook/src/plugin.js
@@ -41,10 +41,6 @@ export default {
    * @param {Object} context.services - Service container
    */
   register(program, { config, logger, services }) {
-    // Override logger level to 'info' for storybook command
-    // The CLI logger defaults to 'warn' but storybook needs 'info' for progress
-    logger.level = 'info';
-
     program
       .command('storybook <path>')
       .description('Capture screenshots from static Storybook build')


### PR DESCRIPTION
## Summary
- Removes dead code that tried to set `logger.level` on the output module
- ES modules are frozen objects, causing "Cannot add property level, object is not extensible" error
- The output module uses `config.verbose` internally via `configure()`, not a `level` property

## Test plan
- [x] Verified `npx vizzly static-site --help` works without warnings
- [x] Verified `npx vizzly tdd start` works without plugin registration errors