### PR TITLE
🐛 Fix JWT tokens incorrectly used as API keys

### DIFF
--- a/src/services/api-service.js
+++ b/src/services/api-service.js
@@ -35,7 +35,7 @@ export class ApiService {
 
     if (!this.token && !options.allowNoToken) {
       throw new VizzlyError(
-        'No API token provided. Set VIZZLY_TOKEN environment variable or run "vizzly login".'
+        'No API token provided. Set VIZZLY_TOKEN environment variable or link a project in the TDD dashboard.'
       );
     }
   }
@@ -118,13 +118,13 @@ export class ApiService {
         }
 
         throw new AuthError(
-          'Invalid or expired API token. Please run "vizzly login" to authenticate.'
+          'Invalid or expired API token. Link a project via "vizzly project:select" or set VIZZLY_TOKEN.'
         );
       }
 
       if (response.status === 401) {
         throw new AuthError(
-          'Invalid or expired API token. Please run "vizzly login" to authenticate.'
+          'Invalid or expired API token. Link a project via "vizzly project:select" or set VIZZLY_TOKEN.'
         );
       }
 

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -2,7 +2,7 @@ import { cosmiconfigSync } from 'cosmiconfig';
 import { resolve } from 'path';
 import { getApiToken, getApiUrl, getParallelId } from './environment-config.js';
 import { validateVizzlyConfigWithDefaults } from './config-schema.js';
-import { getAccessToken, getProjectMapping } from './global-config.js';
+import { getProjectMapping } from './global-config.js';
 import * as output from './output.js';
 
 let DEFAULT_CONFIG = {
@@ -99,14 +99,6 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
         project: projectMapping.projectSlug,
         org: projectMapping.organizationSlug,
       });
-    }
-  }
-
-  // 3.5. Check global config for user access token (if no CLI flag)
-  if (!config.apiKey && !cliOverrides.token) {
-    let globalToken = await getAccessToken();
-    if (globalToken) {
-      config.apiKey = globalToken;
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove fallback that used JWT access tokens as SDK API keys
- Update error messages to guide users to link a project via `vizzly project:select`
- Update tests to reflect new behavior

## Problem
After running `vizzly login`, commands like `vizzly doctor` would fail with "Invalid API token format" because the JWT was being sent to SDK endpoints that expect `vzt_*` format tokens.

## Root Cause
`config-loader.js` had a fallback (lines 106-111) that used the user's JWT access token as `apiKey` when no project token was configured. SDK endpoints reject JWTs since they expect project tokens.

## Token Types
| Token | Format | Purpose |
|-------|--------|---------|
| User JWT | `eyJ...` | User auth: login, list orgs/projects |
| Project Token | `vzt_*` | SDK operations: upload screenshots |

## The Fix
Remove the JWT fallback. Users must either:
1. Set `VIZZLY_TOKEN` environment variable
2. Link a project via `vizzly project:select` (stores `vzt_*` token)

Fixes #95