### PR TITLE
🐛 Pass comparison.threshold to cloud when creating builds

### DIFF
--- a/src/services/test-runner.js
+++ b/src/services/test-runner.js
@@ -191,7 +191,7 @@ export class TestRunner extends EventEmitter {
       // API mode: create build via API
       const apiService = await this.createApiService();
       if (apiService) {
-        const buildResult = await apiService.createBuild({
+        let buildPayload = {
           name: options.buildName || `Test Run ${new Date().toISOString()}`,
           branch: options.branch || 'main',
           environment: options.environment || 'test',
@@ -199,12 +199,18 @@ export class TestRunner extends EventEmitter {
           commit_message: options.message,
           github_pull_request_number: options.pullRequestNumber,
           parallel_id: options.parallelId,
-          metadata: {
+        };
+
+        // Only include metadata if we have meaningful config to send
+        if (this.config.comparison?.threshold != null) {
+          buildPayload.metadata = {
             comparison: {
-              threshold: this.config.comparison?.threshold,
+              threshold: this.config.comparison.threshold,
             },
-          },
-        });
+          };
+        }
+
+        const buildResult = await apiService.createBuild(buildPayload);
         output.debug('build', `created ${buildResult.id}`);
 
         // Emit build created event

--- a/tests/integration/run-command.spec.js
+++ b/tests/integration/run-command.spec.js
@@ -243,7 +243,7 @@ describe('Run Command Threshold Passthrough', () => {
     });
   });
 
-  it('should pass undefined threshold when not configured', async () => {
+  it('should omit metadata when threshold is not configured', async () => {
     let capturedRequestBody = null;
 
     global.fetch.mockImplementation(async (url, options) => {
@@ -297,12 +297,8 @@ describe('Run Command Threshold Passthrough', () => {
       tdd: false,
     });
 
-    // Metadata should still be sent, but threshold will be undefined
+    // Metadata should not be included when threshold is not configured
     expect(capturedRequestBody).not.toBeNull();
-    expect(capturedRequestBody.build.metadata).toEqual({
-      comparison: {
-        threshold: undefined,
-      },
-    });
+    expect(capturedRequestBody.build.metadata).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Sends `comparison.threshold` from `vizzly.config.js` to the cloud API when creating builds
- Cloud comparisons now use the same threshold as local TDD mode

## Context

The threshold config wasn't being passed through, so cloud builds were falling back to project defaults or 0.1. This caused inconsistent behavior where TDD mode would catch differences but cloud wouldn't (or vice versa).

Fixes #103
Related: #102