### PR TITLE
✨ Add VIZZLY_HOME env var for config directory override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ The React-based reporter works in two modes:
 
 ## Environment Variables
 
+- `VIZZLY_HOME` - Override config directory (default: ~/.vizzly). Useful for development/testing
 - `VIZZLY_TOKEN` - API authentication token
 - `VIZZLY_API_URL` - API base URL (default: https://app.vizzly.dev)
 - `VIZZLY_LOG_LEVEL` - Logging level (debug|info|warn|error)
@@ -225,10 +226,37 @@ Remember to update both local (TDD) and cloud comparison logic to keep behavior 
 5. Add tests in plugin's own package or in `tests/integration/`
 6. See `docs/plugins.md` and `examples/custom-plugin/` for complete guide
 
-## Git Commits & Writing
+## Local Development Setup
+
+When developing the CLI, use `VIZZLY_HOME` to isolate dev state from production:
+
+```bash
+# Set up isolated dev environment
+export VIZZLY_HOME="$HOME/.vizzly.dev"
+export VIZZLY_API_URL="http://localhost:3000"
+
+# Now login, link projects, etc. - all stored in ~/.vizzly.dev
+vizzly login
+vizzly project link
+```
+
+This keeps your production auth/projects in `~/.vizzly` untouched while you work on the CLI.
+
+Recommended: Add a `.envrc` file (with direnv) to auto-set these when entering the repo.
+
+## Git Commits & Pull Requests
 
 **NEVER add AI attribution to commits, PRs, or any writing:**
 - ❌ "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
 - ❌ "Co-Authored-By: Claude <noreply@anthropic.com>"
 
-Use gitmoji for commit messages. Keep commits clear and concise.
+**Commits:**
+- Use gitmoji prefix (✨ feat, 🐛 fix, 📝 docs, ♻️ refactor, 🧪 test, etc.)
+- Keep messages clear and concise
+
+**Pull Requests:**
+- Title must include gitmoji prefix matching the primary change type
+- Description must explain the *why* (motivation/problem being solved)
+- Description must cover all changes in the diff, not just highlights
+- Use a "Summary" section with bullet points for each change
+- Include a "Test plan" section with verification steps

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -668,35 +668,62 @@ Configuration loaded via cosmiconfig in this order:
 
 ### Environment Variables
 
-**Authentication:**
-- `VIZZLY_TOKEN` - API authentication token (project token or access token)
-  - For local development: Use `vizzly login` instead of manually managing tokens
-  - For CI/CD: Use project tokens from environment variables
-  - Token priority: CLI flag → env var → project mapping → user access token
+All Vizzly CLI behavior can be configured via environment variables. This is the complete reference.
 
-**Core Configuration:**
-- `VIZZLY_API_URL` - API base URL override (default: `https://app.vizzly.dev`)
+#### Configuration
 
-**Parallel Builds:**
-- `VIZZLY_PARALLEL_ID` - Unique identifier for parallel test execution
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `VIZZLY_HOME` | Override config directory (auth, project mappings) | `~/.vizzly` |
+| `VIZZLY_TOKEN` | API authentication token (project token `vzt_...`) | - |
+| `VIZZLY_API_URL` | API base URL | `https://app.vizzly.dev` |
+| `VIZZLY_LOG_LEVEL` | Logging verbosity: `debug`, `info`, `warn`, `error` | `info` |
 
-**Git Information Override (CI/CD Enhancement):**
-- `VIZZLY_COMMIT_SHA` - Override detected commit SHA
-- `VIZZLY_COMMIT_MESSAGE` - Override detected commit message
-- `VIZZLY_BRANCH` - Override detected branch name
-- `VIZZLY_PR_NUMBER` - Override detected pull request number
+**Token Priority:** CLI flag → env var → project mapping → user access token
 
-**Runtime (Set by CLI):**
-- `VIZZLY_SERVER_URL` - Screenshot server URL (set by CLI)
-- `VIZZLY_ENABLED` - Enable/disable client (set by CLI)
-- `VIZZLY_BUILD_ID` - Current build ID (set by CLI)
-- `VIZZLY_TDD_MODE` - TDD mode active (set by CLI)
+#### Build & Execution
 
-**Priority Order for Git Information:**
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `VIZZLY_PARALLEL_ID` | Unique identifier for parallel test shards | - |
+| `VIZZLY_BUILD_ID` | Build identifier for grouping screenshots | Auto-generated |
+
+#### Git Information Overrides
+
+Use these in CI/CD to override auto-detected git metadata:
+
+| Variable | Description |
+|----------|-------------|
+| `VIZZLY_COMMIT_SHA` | Commit SHA |
+| `VIZZLY_COMMIT_MESSAGE` | Commit message |
+| `VIZZLY_BRANCH` | Branch name |
+| `VIZZLY_PR_NUMBER` | Pull request number |
+| `VIZZLY_PR_BASE_REF` | PR base branch name |
+| `VIZZLY_PR_BASE_SHA` | PR base commit SHA |
+| `VIZZLY_PR_HEAD_REF` | PR head branch name |
+| `VIZZLY_PR_HEAD_SHA` | PR head commit SHA |
+
+**Priority Order:**
 1. CLI arguments (`--commit`, `--branch`, `--message`)
 2. `VIZZLY_*` environment variables
-3. CI-specific environment variables (e.g., `GITHUB_SHA`, `CI_COMMIT_SHA`)
+3. CI-specific variables (e.g., `GITHUB_SHA`, `CI_COMMIT_SHA`)
 4. Git command detection
+
+#### Runtime (Set by CLI)
+
+These are set automatically when running `vizzly run` or `vizzly tdd`:
+
+| Variable | Description |
+|----------|-------------|
+| `VIZZLY_ENABLED` | `true` when Vizzly capture is active |
+| `VIZZLY_SERVER_URL` | Local screenshot server URL |
+| `VIZZLY_TDD` | `true` when TDD mode is active |
+
+#### Advanced
+
+| Variable | Description |
+|----------|-------------|
+| `VIZZLY_USER_AGENT` | Custom User-Agent string for API requests |
 
 ## Error Handling
 

--- a/src/utils/environment-config.js
+++ b/src/utils/environment-config.js
@@ -4,6 +4,16 @@
  */
 
 /**
+ * Get the Vizzly home directory from environment
+ * Used to override the default ~/.vizzly directory for storing auth, project mappings, etc.
+ * Useful for development (separate dev/prod configs) or testing (isolated test configs)
+ * @returns {string|undefined} Custom home directory path
+ */
+export function getVizzlyHome() {
+  return process.env.VIZZLY_HOME;
+}
+
+/**
  * Get API token from environment
  * @returns {string|undefined} API token
  */
@@ -89,6 +99,7 @@ export function setVizzlyEnabled(enabled) {
  */
 export function getAllEnvironmentConfig() {
   return {
+    home: getVizzlyHome(),
     apiToken: getApiToken(),
     apiUrl: getApiUrl(),
     logLevel: getLogLevel(),

--- a/src/utils/global-config.js
+++ b/src/utils/global-config.js
@@ -11,9 +11,12 @@ import * as output from './output.js';
 
 /**
  * Get the path to the global Vizzly directory
- * @returns {string} Path to ~/.vizzly
+ * @returns {string} Path to VIZZLY_HOME or ~/.vizzly
  */
 export function getGlobalConfigDir() {
+  if (process.env.VIZZLY_HOME) {
+    return process.env.VIZZLY_HOME;
+  }
   return join(homedir(), '.vizzly');
 }
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,24 @@
+/**
+ * Global test setup
+ * Runs before all tests to ensure isolation from user's real config
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Create isolated test directory for VIZZLY_HOME
+// This prevents tests from touching the user's real ~/.vizzly config
+let testVizzlyHome = join(tmpdir(), `vizzly-test-${process.pid}-${Date.now()}`);
+
+mkdirSync(testVizzlyHome, { recursive: true });
+process.env.VIZZLY_HOME = testVizzlyHome;
+
+// Clean up on exit
+process.on('exit', () => {
+  try {
+    rmSync(testVizzlyHome, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+});

--- a/tests/unit/environment-config.spec.js
+++ b/tests/unit/environment-config.spec.js
@@ -73,6 +73,7 @@ describe('Environment Config - Parallel Build Support', () => {
       const config = getAllEnvironmentConfig();
 
       expect(config).toEqual({
+        home: process.env.VIZZLY_HOME,
         apiToken: 'token-123',
         apiUrl: 'https://custom.api.com',
         logLevel: 'debug',

--- a/tests/unit/global-config.spec.js
+++ b/tests/unit/global-config.spec.js
@@ -1,8 +1,12 @@
 /**
  * Tests for global config utilities
+ *
+ * Note: VIZZLY_HOME is set globally by tests/setup.js to isolate from user config
  */
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   clearAuthTokens,
@@ -33,18 +37,28 @@ describe('Global Config Utilities', () => {
   });
 
   describe('getGlobalConfigDir', () => {
-    it('should return path to ~/.vizzly directory', () => {
-      const configDir = getGlobalConfigDir();
-      expect(configDir).toContain('.vizzly');
-      expect(configDir).toBeTruthy();
+    it('should use VIZZLY_HOME when set', () => {
+      let configDir = getGlobalConfigDir();
+      expect(configDir).toBe(process.env.VIZZLY_HOME);
+    });
+
+    it('should fall back to ~/.vizzly when VIZZLY_HOME is not set', () => {
+      let originalHome = process.env.VIZZLY_HOME;
+      delete process.env.VIZZLY_HOME;
+
+      try {
+        let configDir = getGlobalConfigDir();
+        expect(configDir).toBe(join(homedir(), '.vizzly'));
+      } finally {
+        process.env.VIZZLY_HOME = originalHome;
+      }
     });
   });
 
   describe('getGlobalConfigPath', () => {
-    it('should return path to ~/.vizzly/config.json', () => {
-      const configPath = getGlobalConfigPath();
-      expect(configPath).toContain('.vizzly');
-      expect(configPath).toContain('config.json');
+    it('should return path to config.json within VIZZLY_HOME', () => {
+      let configPath = getGlobalConfigPath();
+      expect(configPath).toBe(join(process.env.VIZZLY_HOME, 'config.json'));
     });
   });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 8000,
+    setupFiles: ['./tests/setup.js'],
     include: ['tests/**/*.spec.js', 'tests/**/*.spec.jsx'],
     exclude: ['tests/reporter/**'],
     coverage: {


### PR DESCRIPTION
## Why

When developing the CLI, there's constant friction from:
1. **Tests wiping out real config** - Running `npm test` clears `~/.vizzly/config.json`, losing auth tokens and project mappings
2. **No dev/prod separation** - Can't maintain separate state for local dev API vs production, requiring constant re-login and re-linking projects

## Summary

- **`src/utils/global-config.js`**: `getGlobalConfigDir()` now checks `VIZZLY_HOME` env var before falling back to `~/.vizzly`
- **`src/utils/environment-config.js`**: Added `getVizzlyHome()` getter and included `home` in `getAllEnvironmentConfig()`
- **`tests/setup.js`** (new): Global test setup that sets `VIZZLY_HOME` to an isolated temp directory, cleaned up on exit
- **`vitest.config.js`**: Added `setupFiles` to run global setup before all tests
- **`tests/unit/global-config.spec.js`**: Simplified to use global setup, added tests for `VIZZLY_HOME` behavior
- **`tests/unit/environment-config.spec.js`**: Updated to include new `home` field in config assertion
- **`CLAUDE.md`**: Documented `VIZZLY_HOME` env var, added "Local Development Setup" section, and updated PR guidelines
- **`docs/api-reference.md`**: Comprehensive rewrite of Environment Variables section with all 18 env vars in organized tables

## Usage

```bash
# Set up isolated dev environment
export VIZZLY_HOME="$HOME/.vizzly.dev"
export VIZZLY_API_URL="http://localhost:3000"

# Now login, link projects, etc. - all stored in ~/.vizzly.dev
vizzly login
vizzly project link
```

Production config in `~/.vizzly` stays untouched.

## Test plan

- [x] All 679 tests pass
- [x] Tests use isolated temp directory via global setup (verified no writes to `~/.vizzly`)
- [x] `getGlobalConfigDir()` returns `VIZZLY_HOME` when set
- [x] `getGlobalConfigDir()` falls back to `~/.vizzly` when `VIZZLY_HOME` is not set
- [x] `getAllEnvironmentConfig()` includes `home` field