### PR TITLE
⬆️ Upgrade honeydiff to 0.6.0 for noise filtering

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -662,7 +662,8 @@ Configuration loaded via cosmiconfig in this order:
 
   // Comparison Configuration
   comparison: {
-    threshold: number         // CIEDE2000 Delta E (default: 2.0)
+    threshold: number,        // CIEDE2000 Delta E (default: 2.0)
+    minClusterSize: number    // Min cluster size for noise filtering (default: 2)
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
-        "@vizzly-testing/honeydiff": "^0.5.0",
+        "@vizzly-testing/honeydiff": "^0.6.0",
         "commander": "^14.0.0",
         "cosmiconfig": "^9.0.0",
         "dotenv": "^17.2.1",
@@ -205,7 +205,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3485,7 +3484,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3662,9 +3660,9 @@
       }
     },
     "node_modules/@vizzly-testing/honeydiff": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@vizzly-testing/honeydiff/-/honeydiff-0.5.0.tgz",
-      "integrity": "sha512-Pw/CdhvtLm/uH0M/1rZukwlc5z41CWusXDUCDYBznxyBCWGayPFAY1vifQ3EaKCeWL31OF/pUsAr1lFBtEmnGg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@vizzly-testing/honeydiff/-/honeydiff-0.6.0.tgz",
+      "integrity": "sha512-KQQp+nFYoRI+A3SQD8tKhyhhigQe/lpgV2XDvW82XGyOqojb1AeMKOQcXx+m+cX5OsOduMrzCGYGvy6ABpSk2w==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"
@@ -4039,7 +4037,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6615,7 +6612,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6777,7 +6773,6 @@
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7637,7 +7632,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7767,7 +7761,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7905,7 +7898,6 @@
       "integrity": "sha512-ITcnkFeR3+fI8P1wMgItjGrR10170d8auB4EpMLPqmx6uxElH3a/hHGQabSHKdqd4FXWO1nFIp9rRn7JQ34ACQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7999,7 +7991,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8013,7 +8004,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -8176,7 +8166,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@vizzly-testing/honeydiff": "^0.5.0",
+    "@vizzly-testing/honeydiff": "^0.6.0",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",
     "dotenv": "^17.2.1",

--- a/src/services/tdd-service.js
+++ b/src/services/tdd-service.js
@@ -143,6 +143,7 @@ export class TddService {
     this.baselineData = null;
     this.comparisons = [];
     this.threshold = config.comparison?.threshold || 2.0;
+    this.minClusterSize = config.comparison?.minClusterSize ?? 2; // Filter single-pixel noise by default
     this.signatureProperties = []; // Custom properties from project's baseline_signature_properties
 
     // Check if we're in baseline update mode
@@ -1238,6 +1239,7 @@ export class TddService {
         diffPath: diffImagePath,
         overwrite: true,
         includeClusters: true, // Enable spatial clustering analysis
+        minClusterSize: this.minClusterSize, // Filter single-pixel noise (default: 2)
       });
 
       if (!result.isDifferent) {

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -20,7 +20,8 @@ export { VizzlyConfig } from './index';
  *     port: 47392
  *   },
  *   comparison: {
- *     threshold: 2.0  // CIEDE2000 Delta E (0=exact, 1=JND, 2=recommended)
+ *     threshold: 2.0,      // CIEDE2000 Delta E (0=exact, 1=JND, 2=recommended)
+ *     minClusterSize: 2    // Filter single-pixel noise (1=exact, 2=default, 3+=permissive)
  *   }
  * });
  */

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -29,7 +29,17 @@ export interface UploadConfig {
 }
 
 export interface ComparisonConfig {
+  /** CIEDE2000 Delta E threshold (0=exact, 1=JND, 2=recommended default) */
   threshold?: number;
+  /**
+   * Minimum cluster size to count as a real difference.
+   * Filters out scattered single-pixel noise from rendering variance.
+   * - 1 = Exact matching (any different pixel counts)
+   * - 2 = Default (filters single isolated pixels as noise)
+   * - 3+ = More permissive (only larger clusters detected)
+   * @default 2
+   */
+  minClusterSize?: number;
 }
 
 export interface TddConfig {


### PR DESCRIPTION
## Summary

- Upgrades `@vizzly-testing/honeydiff` from 0.5.0 to 0.6.0
- Enables automatic noise filtering via new `minClusterSize` default (2)
- Single isolated pixel differences are now filtered as rendering noise
- Addresses run-to-run variance causing flaky visual tests

## What's new in honeydiff 0.6.0

The new version introduces `minClusterSize` which filters out scattered single-pixel differences that are typically caused by:
- Font rendering variance between runs
- Sub-pixel antialiasing differences
- Minor color quantization

With the default `minClusterSize: 2`, only clustered pixel differences (2+ connected pixels) are counted as real changes. This reduces false positives while still catching actual visual regressions.

## Test plan

- [x] `npm install` completes successfully
- [x] Run TDD mode and verify noise filtering works
- [x] Confirm real visual changes are still detected

Closes #102