### PR TITLE
🐛 Fix services.get() calls to use direct property access

### DIFF
--- a/clients/static-site/src/index.js
+++ b/clients/static-site/src/index.js
@@ -210,8 +210,8 @@ export async function run(buildPath, options = {}, context = {}) {
     if (!isTdd && hasToken && services) {
       // Run mode: Initialize test runner for build management
       try {
-        testRunner = await services.get('testRunner');
-        serverManager = await services.get('serverManager');
+        testRunner = services.testRunner;
+        serverManager = services.serverManager;
         startTime = Date.now();
 
         // Listen for build-created event to get the URL

--- a/clients/storybook/src/index.js
+++ b/clients/storybook/src/index.js
@@ -207,8 +207,8 @@ export async function run(storybookPath, options = {}, context = {}) {
     if (!isTdd && hasToken && services) {
       // Run mode: Initialize test runner for build management
       try {
-        testRunner = await services.get('testRunner');
-        serverManager = await services.get('serverManager');
+        testRunner = services.testRunner;
+        serverManager = services.serverManager;
         startTime = Date.now();
 
         // Listen for build-created event to get the URL

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -104,8 +104,8 @@ export default {
       .action(async (arg, options) => {
         output.info(`Running my-command with ${arg}`);
 
-        // Access shared services if needed
-        let apiService = await services.get('apiService');
+        // Access shared services directly
+        let apiService = services.apiService;
 
         // Your command logic here
       });
@@ -152,7 +152,7 @@ register(program, { config, output, services }) {
   program
     .command('upload-screenshots <dir>')
     .action(async (dir) => {
-      let uploader = await services.get('uploader');
+      let uploader = services.uploader;
       await uploader.uploadScreenshots(screenshots);
     });
 }
@@ -290,8 +290,8 @@ Use async/await for asynchronous operations:
 
 ```javascript
 .action(async (options) => {
-  let service = await services.get('apiService');
-  let result = await service.doSomething();
+  let apiService = services.apiService;
+  let result = await apiService.doSomething();
   output.info(`Result: ${result}`);
 });
 ```
@@ -397,7 +397,7 @@ export default {
         output.info(`Captured ${screenshots.length} screenshots`);
 
         // Upload using Vizzly's uploader service
-        let uploader = await services.get('uploader');
+        let uploader = services.uploader;
         await uploader.uploadScreenshots(screenshots);
 
         output.success('Upload complete!');

--- a/examples/custom-plugin/plugin.js
+++ b/examples/custom-plugin/plugin.js
@@ -55,8 +55,8 @@ export default {
         try {
           logger.info('Checking API connection...');
 
-          // Access the API service from the container
-          let apiService = await services.get('apiService');
+          // Access the API service directly
+          let apiService = services.apiService;
 
           logger.info(`API URL: ${config.apiUrl || 'https://app.vizzly.dev'}`);
           logger.info(`API Token: ${config.apiKey ? '***' + config.apiKey.slice(-4) : 'Not set'}`);


### PR DESCRIPTION
## Summary

- Fix `services.get('testRunner')` → `services.testRunner` in static-site client
- Fix `services.get('serverManager')` → `services.serverManager` in static-site client  
- Fix same issue in storybook client
- Update plugin docs and example to use correct API

The service factory (`createServices()`) returns a plain object with services as direct properties, not a DI container with a `.get()` method. This was causing "services.get is not a function" errors when using static-site or storybook plugins in cloud mode.

## Test plan

- [x] All 718 tests pass
- [ ] Manual test: `npx vizzly static-site ./dist` with `VIZZLY_TOKEN` set