### PR TITLE
✨ Add stable plugin API contract with enforcement tests

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -28,6 +28,7 @@ import {
 import { uploadCommand, validateUploadOptions } from './commands/upload.js';
 import { validateWhoamiOptions, whoamiCommand } from './commands/whoami.js';
 import { loadPlugins } from './plugin-loader.js';
+import { createPluginServices } from './plugin-api.js';
 import { createServices } from './services/index.js';
 import { loadConfig } from './utils/config-loader.js';
 import * as output from './utils/output.js';
@@ -78,6 +79,7 @@ output.configure({
 
 const config = await loadConfig(configPath, {});
 const services = createServices(config);
+const pluginServices = createPluginServices(services);
 
 let plugins = [];
 try {
@@ -88,7 +90,7 @@ try {
       // Add timeout protection for plugin registration (5 seconds)
       const registerPromise = plugin.register(program, {
         config,
-        services,
+        services: pluginServices,
         output,
         // Backwards compatibility alias for plugins using old API
         logger: output,

--- a/src/plugin-api.js
+++ b/src/plugin-api.js
@@ -1,0 +1,43 @@
+/**
+ * Plugin API - Stable interface for Vizzly plugins
+ *
+ * This module defines the stable API contract for plugins. Only methods
+ * exposed here are considered part of the public API and are guaranteed
+ * to not break between minor versions.
+ *
+ * Internal services (apiService, uploader, buildManager, etc.) are NOT
+ * exposed to plugins to prevent coupling to implementation details.
+ */
+
+/**
+ * Creates a stable plugin services object from the internal services
+ *
+ * Only exposes:
+ * - testRunner: Build lifecycle management (createBuild, finalizeBuild, events)
+ * - serverManager: Screenshot server control (start, stop)
+ *
+ * @param {Object} services - Internal services from createServices()
+ * @returns {Object} Frozen plugin services object
+ */
+export function createPluginServices(services) {
+  let { testRunner, serverManager } = services;
+
+  return Object.freeze({
+    testRunner: Object.freeze({
+      // EventEmitter methods for build lifecycle events
+      once: testRunner.once.bind(testRunner),
+      on: testRunner.on.bind(testRunner),
+      off: testRunner.off.bind(testRunner),
+
+      // Build lifecycle
+      createBuild: testRunner.createBuild.bind(testRunner),
+      finalizeBuild: testRunner.finalizeBuild.bind(testRunner),
+    }),
+
+    serverManager: Object.freeze({
+      // Server lifecycle
+      start: serverManager.start.bind(serverManager),
+      stop: serverManager.stop.bind(serverManager),
+    }),
+  });
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -352,6 +352,90 @@ export interface Services {
 }
 
 // ============================================================================
+// Plugin API Types (Stable Contract)
+// ============================================================================
+
+/**
+ * Stable TestRunner interface for plugins.
+ * Only these methods are guaranteed to remain stable across minor versions.
+ */
+export interface PluginTestRunner {
+  /** Listen for a single event emission */
+  once(event: string, callback: (...args: unknown[]) => void): void;
+  /** Subscribe to events */
+  on(event: string, callback: (...args: unknown[]) => void): void;
+  /** Unsubscribe from events */
+  off(event: string, callback: (...args: unknown[]) => void): void;
+  /** Create a new build and return the build ID */
+  createBuild(options: BuildOptions, isTddMode: boolean): Promise<string>;
+  /** Finalize a build after all screenshots are captured */
+  finalizeBuild(
+    buildId: string,
+    isTddMode: boolean,
+    success: boolean,
+    executionTime: number
+  ): Promise<void>;
+}
+
+/**
+ * Stable ServerManager interface for plugins.
+ * Only these methods are guaranteed to remain stable across minor versions.
+ */
+export interface PluginServerManager {
+  /** Start the screenshot server */
+  start(buildId: string, tddMode: boolean, setBaseline: boolean): Promise<void>;
+  /** Stop the screenshot server */
+  stop(): Promise<void>;
+}
+
+/**
+ * Stable services interface for plugins.
+ * This is the public API contract - internal services are NOT exposed.
+ */
+export interface PluginServices {
+  testRunner: PluginTestRunner;
+  serverManager: PluginServerManager;
+}
+
+/**
+ * Build options for createBuild()
+ */
+export interface BuildOptions {
+  port?: number;
+  timeout?: number;
+  buildName?: string;
+  branch?: string;
+  commit?: string;
+  message?: string;
+  environment?: string;
+  threshold?: number;
+  eager?: boolean;
+  allowNoToken?: boolean;
+  wait?: boolean;
+  uploadAll?: boolean;
+  pullRequestNumber?: string;
+  parallelId?: string;
+}
+
+/**
+ * Context object passed to plugin register() function.
+ * This is the stable plugin API contract.
+ */
+export interface PluginContext {
+  /** Merged Vizzly configuration */
+  config: VizzlyConfig;
+  /** Stable services for plugins */
+  services: PluginServices;
+  /** Output utilities for logging */
+  output: OutputUtils;
+  /** @deprecated Use output instead. Alias for backwards compatibility. */
+  logger: OutputUtils;
+}
+
+/** Create stable plugin services from internal services */
+export function createPluginServices(services: Services): PluginServices;
+
+// ============================================================================
 // Output Utilities
 // ============================================================================
 

--- a/tests/contracts/plugin-api.contract.spec.js
+++ b/tests/contracts/plugin-api.contract.spec.js
@@ -1,0 +1,182 @@
+/**
+ * Plugin API Contract Tests
+ *
+ * These tests enforce the stable plugin API contract. If any of these tests
+ * fail, it means a breaking change was introduced to the plugin API.
+ *
+ * DO NOT modify these tests without updating the plugin API version.
+ */
+
+import { EventEmitter } from 'node:events';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createPluginServices } from '../../src/plugin-api.js';
+
+describe('Plugin API Contract', () => {
+  let mockServices;
+  let pluginServices;
+
+  beforeEach(() => {
+    // Create mock internal services that match the real implementation
+    let mockTestRunner = new EventEmitter();
+    mockTestRunner.createBuild = vi.fn().mockResolvedValue('build-123');
+    mockTestRunner.finalizeBuild = vi.fn().mockResolvedValue(undefined);
+
+    let mockServerManager = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockServices = {
+      testRunner: mockTestRunner,
+      serverManager: mockServerManager,
+      // Internal services that should NOT be exposed
+      apiService: { request: vi.fn() },
+      authService: { getToken: vi.fn() },
+      configService: { get: vi.fn() },
+      projectService: { getProject: vi.fn() },
+      uploader: { upload: vi.fn() },
+      buildManager: { create: vi.fn() },
+      tddService: { compare: vi.fn() },
+    };
+
+    pluginServices = createPluginServices(mockServices);
+  });
+
+  describe('Structure', () => {
+    it('exposes testRunner', () => {
+      expect(pluginServices.testRunner).toBeDefined();
+    });
+
+    it('exposes serverManager', () => {
+      expect(pluginServices.serverManager).toBeDefined();
+    });
+
+    it('does NOT expose internal services', () => {
+      expect(pluginServices.apiService).toBeUndefined();
+      expect(pluginServices.authService).toBeUndefined();
+      expect(pluginServices.configService).toBeUndefined();
+      expect(pluginServices.projectService).toBeUndefined();
+      expect(pluginServices.uploader).toBeUndefined();
+      expect(pluginServices.buildManager).toBeUndefined();
+      expect(pluginServices.tddService).toBeUndefined();
+    });
+
+    it('is frozen (immutable)', () => {
+      expect(Object.isFrozen(pluginServices)).toBe(true);
+    });
+
+    it('has frozen testRunner', () => {
+      expect(Object.isFrozen(pluginServices.testRunner)).toBe(true);
+    });
+
+    it('has frozen serverManager', () => {
+      expect(Object.isFrozen(pluginServices.serverManager)).toBe(true);
+    });
+  });
+
+  describe('testRunner contract', () => {
+    it('exposes once() method', () => {
+      expect(typeof pluginServices.testRunner.once).toBe('function');
+    });
+
+    it('exposes on() method', () => {
+      expect(typeof pluginServices.testRunner.on).toBe('function');
+    });
+
+    it('exposes off() method', () => {
+      expect(typeof pluginServices.testRunner.off).toBe('function');
+    });
+
+    it('exposes createBuild() method', () => {
+      expect(typeof pluginServices.testRunner.createBuild).toBe('function');
+    });
+
+    it('exposes finalizeBuild() method', () => {
+      expect(typeof pluginServices.testRunner.finalizeBuild).toBe('function');
+    });
+
+    it('once() works with build-created event', () => {
+      let callback = vi.fn();
+      pluginServices.testRunner.once('build-created', callback);
+
+      mockServices.testRunner.emit('build-created', {
+        url: 'https://example.com',
+      });
+
+      expect(callback).toHaveBeenCalledWith({ url: 'https://example.com' });
+    });
+
+    it('createBuild() returns a promise with buildId', async () => {
+      let options = { buildName: 'Test Build' };
+      let result = await pluginServices.testRunner.createBuild(options, false);
+
+      expect(result).toBe('build-123');
+      expect(mockServices.testRunner.createBuild).toHaveBeenCalledWith(
+        options,
+        false
+      );
+    });
+
+    it('finalizeBuild() accepts correct parameters', async () => {
+      await pluginServices.testRunner.finalizeBuild(
+        'build-123',
+        false,
+        true,
+        1000
+      );
+
+      expect(mockServices.testRunner.finalizeBuild).toHaveBeenCalledWith(
+        'build-123',
+        false,
+        true,
+        1000
+      );
+    });
+  });
+
+  describe('serverManager contract', () => {
+    it('exposes start() method', () => {
+      expect(typeof pluginServices.serverManager.start).toBe('function');
+    });
+
+    it('exposes stop() method', () => {
+      expect(typeof pluginServices.serverManager.stop).toBe('function');
+    });
+
+    it('start() accepts correct parameters', async () => {
+      await pluginServices.serverManager.start('build-123', false, false);
+
+      expect(mockServices.serverManager.start).toHaveBeenCalledWith(
+        'build-123',
+        false,
+        false
+      );
+    });
+
+    it('stop() works correctly', async () => {
+      await pluginServices.serverManager.stop();
+
+      expect(mockServices.serverManager.stop).toHaveBeenCalled();
+    });
+  });
+
+  describe('Immutability', () => {
+    it('prevents adding new properties to pluginServices', () => {
+      expect(() => {
+        pluginServices.newProp = 'value';
+      }).toThrow();
+    });
+
+    it('prevents adding new properties to testRunner', () => {
+      expect(() => {
+        pluginServices.testRunner.newMethod = () => {};
+      }).toThrow();
+    });
+
+    it('prevents adding new properties to serverManager', () => {
+      expect(() => {
+        pluginServices.serverManager.newMethod = () => {};
+      }).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Introduces a minimal stable API surface for plugins to prevent breaking changes like the `services.get()` issue we just fixed.

- Add `src/plugin-api.js` with `createPluginServices()` factory that wraps only stable services
- Add contract tests in `tests/contracts/plugin-api.contract.spec.js` that will fail if API shape changes
- Add TypeScript types: `PluginServices`, `PluginContext`, `PluginTestRunner`, `PluginServerManager`
- Update docs/plugins.md with stable API documentation (removed references to internal services)
- Update example plugin to demonstrate stable API usage

### Stable API Surface

Only these services/methods are now exposed to plugins:

```typescript
interface PluginServices {
  testRunner: {
    once(event, callback): void
    on(event, callback): void
    off(event, callback): void
    createBuild(options, isTddMode): Promise<string>
    finalizeBuild(buildId, isTddMode, success, time): Promise<void>
  }
  serverManager: {
    start(buildId, tddMode, setBaseline): Promise<void>
    stop(): Promise<void>
  }
}
```

Internal services (`apiService`, `uploader`, `buildManager`, etc.) are no longer accessible to plugins.

### Breaking Change Protection

1. **Object.freeze()** - The services object is frozen, preventing accidental modifications
2. **Contract tests** - 21 tests verify the exact API shape; any change will fail CI
3. **TypeScript types** - Strong typing for the plugin context

## Test plan

- [x] All 739 tests pass (including 21 new contract tests)
- [x] Build succeeds
- [ ] Manual: Load a plugin and verify it receives correct services