### PR TITLE
♻️ Refactor ProjectService into functional decomposition

### DIFF
--- a/src/project/core.js
+++ b/src/project/core.js
@@ -1,0 +1,310 @@
+/**
+ * Project Core - Pure functions for project logic
+ *
+ * No I/O, no side effects - just data transformations.
+ */
+
+import { VizzlyError } from '../errors/vizzly-error.js';
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validate that a directory path is provided
+ * @param {string} directory - Directory path to validate
+ * @returns {{ valid: boolean, error: Error|null }}
+ */
+export function validateDirectory(directory) {
+  if (!directory) {
+    return {
+      valid: false,
+      error: new VizzlyError('Directory path is required', 'INVALID_DIRECTORY'),
+    };
+  }
+  return { valid: true, error: null };
+}
+
+/**
+ * Validate project data for mapping creation
+ * @param {Object} projectData - Project data to validate
+ * @param {string} [projectData.projectSlug] - Project slug
+ * @param {string} [projectData.organizationSlug] - Organization slug
+ * @param {string} [projectData.token] - Project token
+ * @returns {{ valid: boolean, error: Error|null }}
+ */
+export function validateProjectData(projectData) {
+  if (!projectData.projectSlug) {
+    return {
+      valid: false,
+      error: new VizzlyError(
+        'Project slug is required',
+        'INVALID_PROJECT_DATA'
+      ),
+    };
+  }
+
+  if (!projectData.organizationSlug) {
+    return {
+      valid: false,
+      error: new VizzlyError(
+        'Organization slug is required',
+        'INVALID_PROJECT_DATA'
+      ),
+    };
+  }
+
+  if (!projectData.token) {
+    return {
+      valid: false,
+      error: new VizzlyError(
+        'Project token is required',
+        'INVALID_PROJECT_DATA'
+      ),
+    };
+  }
+
+  return { valid: true, error: null };
+}
+
+// ============================================================================
+// Mapping Transformations
+// ============================================================================
+
+/**
+ * Convert mappings object to array with directory paths included
+ * @param {Object} mappings - Object with directory paths as keys
+ * @returns {Array<Object>} Array of mappings with directory property
+ */
+export function mappingsToArray(mappings) {
+  return Object.entries(mappings).map(([directory, data]) => ({
+    directory,
+    ...data,
+  }));
+}
+
+/**
+ * Build a mapping result object
+ * @param {string} directory - Directory path
+ * @param {Object} projectData - Project data
+ * @returns {Object} Mapping result with directory included
+ */
+export function buildMappingResult(directory, projectData) {
+  return {
+    directory,
+    ...projectData,
+  };
+}
+
+// ============================================================================
+// API Request Helpers
+// ============================================================================
+
+/**
+ * Build query params for builds API request
+ * @param {Object} options - Query options
+ * @param {number} [options.limit] - Number of builds to fetch
+ * @param {string} [options.branch] - Filter by branch
+ * @returns {string} Query string (empty string if no params)
+ */
+export function buildBuildsQueryParams(options = {}) {
+  let params = new globalThis.URLSearchParams();
+
+  if (options.limit) {
+    params.append('limit', String(options.limit));
+  }
+
+  if (options.branch) {
+    params.append('branch', options.branch);
+  }
+
+  let query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+/**
+ * Build organization header object
+ * @param {string} organizationSlug - Organization slug
+ * @returns {Object} Headers object with X-Organization header
+ */
+export function buildOrgHeader(organizationSlug) {
+  return { 'X-Organization': organizationSlug };
+}
+
+/**
+ * Build API URL for project endpoint
+ * @param {string} projectSlug - Project slug
+ * @returns {string} API URL path
+ */
+export function buildProjectUrl(projectSlug) {
+  return `/api/project/${projectSlug}`;
+}
+
+/**
+ * Build API URL for builds endpoint
+ * @param {string} projectSlug - Project slug
+ * @param {Object} options - Query options
+ * @returns {string} Full API URL path with query params
+ */
+export function buildBuildsUrl(projectSlug, options = {}) {
+  let queryString = buildBuildsQueryParams(options);
+  return `/api/build/${projectSlug}${queryString}`;
+}
+
+/**
+ * Build API URL for project tokens endpoint
+ * @param {string} organizationSlug - Organization slug
+ * @param {string} projectSlug - Project slug
+ * @param {string} [tokenId] - Optional token ID for specific token operations
+ * @returns {string} API URL path
+ */
+export function buildTokensUrl(organizationSlug, projectSlug, tokenId) {
+  let base = `/api/cli/organizations/${organizationSlug}/projects/${projectSlug}/tokens`;
+  return tokenId ? `${base}/${tokenId}` : base;
+}
+
+// ============================================================================
+// Response Extraction
+// ============================================================================
+
+/**
+ * Extract projects from API response
+ * @param {Object} response - API response
+ * @returns {Array} Array of projects
+ */
+export function extractProjects(response) {
+  return response?.projects || [];
+}
+
+/**
+ * Extract project from API response
+ * @param {Object} response - API response
+ * @returns {Object} Project object
+ */
+export function extractProject(response) {
+  return response?.project || response;
+}
+
+/**
+ * Extract builds from API response
+ * @param {Object} response - API response
+ * @returns {Array} Array of builds
+ */
+export function extractBuilds(response) {
+  return response?.builds || [];
+}
+
+/**
+ * Extract token from API response
+ * @param {Object} response - API response
+ * @returns {Object} Token object
+ */
+export function extractToken(response) {
+  return response?.token;
+}
+
+/**
+ * Extract tokens from API response
+ * @param {Object} response - API response
+ * @returns {Array} Array of tokens
+ */
+export function extractTokens(response) {
+  return response?.tokens || [];
+}
+
+/**
+ * Enrich projects with organization info
+ * @param {Array} projects - Array of projects
+ * @param {Object} org - Organization object
+ * @param {string} org.slug - Organization slug
+ * @param {string} org.name - Organization name
+ * @returns {Array} Projects with organization info added
+ */
+export function enrichProjectsWithOrg(projects, org) {
+  return projects.map(project => ({
+    ...project,
+    organizationSlug: org.slug,
+    organizationName: org.name,
+  }));
+}
+
+/**
+ * Extract organizations from whoami response
+ * @param {Object} whoamiResponse - Whoami API response
+ * @returns {Array} Array of organizations
+ */
+export function extractOrganizations(whoamiResponse) {
+  return whoamiResponse?.organizations || [];
+}
+
+// ============================================================================
+// Error Building
+// ============================================================================
+
+/**
+ * Build error for project fetch failure
+ * @param {Error} originalError - Original error
+ * @returns {VizzlyError} Wrapped error
+ */
+export function buildProjectFetchError(originalError) {
+  return new VizzlyError(
+    `Failed to fetch project: ${originalError.message}`,
+    'PROJECT_FETCH_FAILED',
+    { originalError }
+  );
+}
+
+/**
+ * Build error for no authentication available
+ * @returns {VizzlyError} No auth error
+ */
+export function buildNoAuthError() {
+  return new VizzlyError('No authentication available', 'NO_AUTH_SERVICE');
+}
+
+/**
+ * Build error for no API service available
+ * @returns {VizzlyError} No API service error
+ */
+export function buildNoApiServiceError() {
+  return new VizzlyError('API service not available', 'NO_API_SERVICE');
+}
+
+/**
+ * Build error for token creation failure
+ * @param {Error} originalError - Original error
+ * @returns {VizzlyError} Wrapped error
+ */
+export function buildTokenCreateError(originalError) {
+  return new VizzlyError(
+    `Failed to create project token: ${originalError.message}`,
+    'TOKEN_CREATE_FAILED',
+    { originalError }
+  );
+}
+
+/**
+ * Build error for token fetch failure
+ * @param {Error} originalError - Original error
+ * @returns {VizzlyError} Wrapped error
+ */
+export function buildTokensFetchError(originalError) {
+  return new VizzlyError(
+    `Failed to fetch project tokens: ${originalError.message}`,
+    'TOKENS_FETCH_FAILED',
+    { originalError }
+  );
+}
+
+/**
+ * Build error for token revoke failure
+ * @param {Error} originalError - Original error
+ * @returns {VizzlyError} Wrapped error
+ */
+export function buildTokenRevokeError(originalError) {
+  return new VizzlyError(
+    `Failed to revoke project token: ${originalError.message}`,
+    'TOKEN_REVOKE_FAILED',
+    { originalError }
+  );
+}

--- a/src/project/index.js
+++ b/src/project/index.js
@@ -1,0 +1,54 @@
+/**
+ * Project Module - Public exports
+ *
+ * Provides functional project management primitives:
+ * - core.js: Pure functions for validation, URL building, response extraction
+ * - operations.js: Project operations with dependency injection
+ */
+
+// Core pure functions
+export {
+  buildBuildsQueryParams,
+  buildBuildsUrl,
+  buildMappingResult,
+  buildNoApiServiceError,
+  buildNoAuthError,
+  buildOrgHeader,
+  buildProjectFetchError,
+  buildProjectUrl,
+  buildTokenCreateError,
+  buildTokenRevokeError,
+  buildTokensFetchError,
+  buildTokensUrl,
+  enrichProjectsWithOrg,
+  extractBuilds,
+  extractOrganizations,
+  extractProject,
+  extractProjects,
+  extractToken,
+  extractTokens,
+  mappingsToArray,
+  validateDirectory,
+  validateProjectData,
+} from './core.js';
+
+// Project operations (take dependencies as parameters)
+export {
+  createMapping,
+  createProjectToken,
+  getMapping,
+  getProject,
+  getProjectWithApiToken,
+  getProjectWithOAuth,
+  getRecentBuilds,
+  getRecentBuildsWithApiToken,
+  getRecentBuildsWithOAuth,
+  listMappings,
+  listProjects,
+  listProjectsWithApiToken,
+  listProjectsWithOAuth,
+  listProjectTokens,
+  removeMapping,
+  revokeProjectToken,
+  switchProject,
+} from './operations.js';

--- a/src/project/operations.js
+++ b/src/project/operations.js
@@ -1,0 +1,489 @@
+/**
+ * Project Operations - Project operations with dependency injection
+ *
+ * Each operation takes its dependencies as parameters:
+ * - mappingStore: for reading/writing project mappings
+ * - httpClient: for making API requests (OAuth or API token based)
+ *
+ * This makes them trivially testable without mocking modules.
+ */
+
+import {
+  buildBuildsUrl,
+  buildMappingResult,
+  buildNoApiServiceError,
+  buildNoAuthError,
+  buildOrgHeader,
+  buildProjectFetchError,
+  buildProjectUrl,
+  buildTokenCreateError,
+  buildTokenRevokeError,
+  buildTokensFetchError,
+  buildTokensUrl,
+  enrichProjectsWithOrg,
+  extractBuilds,
+  extractOrganizations,
+  extractProject,
+  extractProjects,
+  extractToken,
+  extractTokens,
+  mappingsToArray,
+  validateDirectory,
+  validateProjectData,
+} from './core.js';
+
+// ============================================================================
+// Mapping Operations
+// ============================================================================
+
+/**
+ * List all project mappings
+ * @param {Object} mappingStore - Store with getMappings method
+ * @returns {Promise<Array>} Array of project mappings with directory included
+ */
+export async function listMappings(mappingStore) {
+  let mappings = await mappingStore.getMappings();
+  return mappingsToArray(mappings);
+}
+
+/**
+ * Get project mapping for a specific directory
+ * @param {Object} mappingStore - Store with getMapping method
+ * @param {string} directory - Directory path
+ * @returns {Promise<Object|null>} Project mapping or null
+ */
+export async function getMapping(mappingStore, directory) {
+  return mappingStore.getMapping(directory);
+}
+
+/**
+ * Create or update project mapping
+ * @param {Object} mappingStore - Store with saveMapping method
+ * @param {string} directory - Directory path
+ * @param {Object} projectData - Project data
+ * @returns {Promise<Object>} Created mapping with directory included
+ */
+export async function createMapping(mappingStore, directory, projectData) {
+  let dirValidation = validateDirectory(directory);
+  if (!dirValidation.valid) {
+    throw dirValidation.error;
+  }
+
+  let dataValidation = validateProjectData(projectData);
+  if (!dataValidation.valid) {
+    throw dataValidation.error;
+  }
+
+  await mappingStore.saveMapping(directory, projectData);
+  return buildMappingResult(directory, projectData);
+}
+
+/**
+ * Remove project mapping
+ * @param {Object} mappingStore - Store with deleteMapping method
+ * @param {string} directory - Directory path
+ * @returns {Promise<void>}
+ */
+export async function removeMapping(mappingStore, directory) {
+  let validation = validateDirectory(directory);
+  if (!validation.valid) {
+    throw validation.error;
+  }
+
+  await mappingStore.deleteMapping(directory);
+}
+
+/**
+ * Switch project for a directory (convenience wrapper for createMapping)
+ * @param {Object} mappingStore - Store with saveMapping method
+ * @param {string} directory - Directory path
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @param {string} token - Project token
+ * @returns {Promise<Object>} Updated mapping
+ */
+export async function switchProject(
+  mappingStore,
+  directory,
+  projectSlug,
+  organizationSlug,
+  token
+) {
+  return createMapping(mappingStore, directory, {
+    projectSlug,
+    organizationSlug,
+    token,
+  });
+}
+
+// ============================================================================
+// API Operations - List Projects
+// ============================================================================
+
+/**
+ * List all projects from API using OAuth authentication
+ * @param {Object} oauthClient - OAuth HTTP client with authenticatedRequest method
+ * @returns {Promise<Array>} Array of projects with organization info
+ */
+export async function listProjectsWithOAuth(oauthClient) {
+  // First get the user's organizations via whoami
+  let whoami = await oauthClient.authenticatedRequest('/api/auth/cli/whoami', {
+    method: 'GET',
+  });
+
+  let organizations = extractOrganizations(whoami);
+  if (organizations.length === 0) {
+    return [];
+  }
+
+  // Fetch projects for each organization
+  let allProjects = [];
+
+  for (let org of organizations) {
+    try {
+      let response = await oauthClient.authenticatedRequest('/api/project', {
+        method: 'GET',
+        headers: buildOrgHeader(org.slug),
+      });
+
+      let projects = extractProjects(response);
+      let enriched = enrichProjectsWithOrg(projects, org);
+      allProjects.push(...enriched);
+    } catch {
+      // Silently skip failed orgs
+    }
+  }
+
+  return allProjects;
+}
+
+/**
+ * List all projects from API using API token authentication
+ * @param {Object} apiClient - API HTTP client with request method
+ * @returns {Promise<Array>} Array of projects
+ */
+export async function listProjectsWithApiToken(apiClient) {
+  let response = await apiClient.request('/api/project', {
+    method: 'GET',
+  });
+  return extractProjects(response);
+}
+
+/**
+ * List all projects, trying OAuth first then falling back to API token
+ * @param {Object} options - Options
+ * @param {Object} [options.oauthClient] - OAuth HTTP client
+ * @param {Object} [options.apiClient] - API token HTTP client
+ * @returns {Promise<Array>} Array of projects
+ */
+export async function listProjects({ oauthClient, apiClient }) {
+  // Try OAuth-based request first
+  if (oauthClient) {
+    try {
+      return await listProjectsWithOAuth(oauthClient);
+    } catch {
+      // Fall back to API token
+    }
+  }
+
+  // Fall back to API token-based request
+  if (apiClient) {
+    try {
+      return await listProjectsWithApiToken(apiClient);
+    } catch {
+      return [];
+    }
+  }
+
+  // No authentication available
+  return [];
+}
+
+// ============================================================================
+// API Operations - Get Project
+// ============================================================================
+
+/**
+ * Get project details using OAuth authentication
+ * @param {Object} oauthClient - OAuth HTTP client
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @returns {Promise<Object>} Project details
+ */
+export async function getProjectWithOAuth(
+  oauthClient,
+  projectSlug,
+  organizationSlug
+) {
+  let response = await oauthClient.authenticatedRequest(
+    buildProjectUrl(projectSlug),
+    {
+      method: 'GET',
+      headers: buildOrgHeader(organizationSlug),
+    }
+  );
+  return extractProject(response);
+}
+
+/**
+ * Get project details using API token authentication
+ * @param {Object} apiClient - API HTTP client
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @returns {Promise<Object>} Project details
+ */
+export async function getProjectWithApiToken(
+  apiClient,
+  projectSlug,
+  organizationSlug
+) {
+  let response = await apiClient.request(buildProjectUrl(projectSlug), {
+    method: 'GET',
+    headers: buildOrgHeader(organizationSlug),
+  });
+  return extractProject(response);
+}
+
+/**
+ * Get project details, trying OAuth first then falling back to API token
+ * @param {Object} options - Options
+ * @param {Object} [options.oauthClient] - OAuth HTTP client
+ * @param {Object} [options.apiClient] - API token HTTP client
+ * @param {string} options.projectSlug - Project slug
+ * @param {string} options.organizationSlug - Organization slug
+ * @returns {Promise<Object>} Project details
+ */
+export async function getProject({
+  oauthClient,
+  apiClient,
+  projectSlug,
+  organizationSlug,
+}) {
+  // Try OAuth-based request first
+  if (oauthClient) {
+    try {
+      return await getProjectWithOAuth(
+        oauthClient,
+        projectSlug,
+        organizationSlug
+      );
+    } catch {
+      // Fall back to API token
+    }
+  }
+
+  // Fall back to API token
+  if (apiClient) {
+    try {
+      return await getProjectWithApiToken(
+        apiClient,
+        projectSlug,
+        organizationSlug
+      );
+    } catch (error) {
+      throw buildProjectFetchError(error);
+    }
+  }
+
+  throw buildNoAuthError();
+}
+
+// ============================================================================
+// API Operations - Recent Builds
+// ============================================================================
+
+/**
+ * Get recent builds for a project using OAuth authentication
+ * @param {Object} oauthClient - OAuth HTTP client
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @param {Object} options - Query options
+ * @returns {Promise<Array>} Array of builds
+ */
+export async function getRecentBuildsWithOAuth(
+  oauthClient,
+  projectSlug,
+  organizationSlug,
+  options = {}
+) {
+  let response = await oauthClient.authenticatedRequest(
+    buildBuildsUrl(projectSlug, options),
+    {
+      method: 'GET',
+      headers: buildOrgHeader(organizationSlug),
+    }
+  );
+  return extractBuilds(response);
+}
+
+/**
+ * Get recent builds for a project using API token authentication
+ * @param {Object} apiClient - API HTTP client
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @param {Object} options - Query options
+ * @returns {Promise<Array>} Array of builds
+ */
+export async function getRecentBuildsWithApiToken(
+  apiClient,
+  projectSlug,
+  organizationSlug,
+  options = {}
+) {
+  let response = await apiClient.request(buildBuildsUrl(projectSlug, options), {
+    method: 'GET',
+    headers: buildOrgHeader(organizationSlug),
+  });
+  return extractBuilds(response);
+}
+
+/**
+ * Get recent builds for a project, trying OAuth first then falling back to API token
+ * @param {Object} options - Options
+ * @param {Object} [options.oauthClient] - OAuth HTTP client
+ * @param {Object} [options.apiClient] - API token HTTP client
+ * @param {string} options.projectSlug - Project slug
+ * @param {string} options.organizationSlug - Organization slug
+ * @param {number} [options.limit] - Number of builds to fetch
+ * @param {string} [options.branch] - Filter by branch
+ * @returns {Promise<Array>} Array of builds
+ */
+export async function getRecentBuilds({
+  oauthClient,
+  apiClient,
+  projectSlug,
+  organizationSlug,
+  limit,
+  branch,
+}) {
+  let queryOptions = { limit, branch };
+
+  // Try OAuth-based request first
+  if (oauthClient) {
+    try {
+      return await getRecentBuildsWithOAuth(
+        oauthClient,
+        projectSlug,
+        organizationSlug,
+        queryOptions
+      );
+    } catch {
+      // Fall back to API token
+    }
+  }
+
+  // Fall back to API token-based request
+  if (apiClient) {
+    try {
+      return await getRecentBuildsWithApiToken(
+        apiClient,
+        projectSlug,
+        organizationSlug,
+        queryOptions
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  // No authentication available
+  return [];
+}
+
+// ============================================================================
+// API Operations - Project Tokens
+// ============================================================================
+
+/**
+ * Create a project token
+ * @param {Object} apiClient - API HTTP client with request method
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @param {Object} tokenData - Token data
+ * @param {string} tokenData.name - Token name
+ * @param {string} [tokenData.description] - Token description
+ * @returns {Promise<Object>} Created token
+ */
+export async function createProjectToken(
+  apiClient,
+  projectSlug,
+  organizationSlug,
+  tokenData
+) {
+  if (!apiClient) {
+    throw buildNoApiServiceError();
+  }
+
+  try {
+    let response = await apiClient.request(
+      buildTokensUrl(organizationSlug, projectSlug),
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(tokenData),
+      }
+    );
+    return extractToken(response);
+  } catch (error) {
+    throw buildTokenCreateError(error);
+  }
+}
+
+/**
+ * List project tokens
+ * @param {Object} apiClient - API HTTP client with request method
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @returns {Promise<Array>} Array of tokens
+ */
+export async function listProjectTokens(
+  apiClient,
+  projectSlug,
+  organizationSlug
+) {
+  if (!apiClient) {
+    throw buildNoApiServiceError();
+  }
+
+  try {
+    let response = await apiClient.request(
+      buildTokensUrl(organizationSlug, projectSlug),
+      {
+        method: 'GET',
+      }
+    );
+    return extractTokens(response);
+  } catch (error) {
+    throw buildTokensFetchError(error);
+  }
+}
+
+/**
+ * Revoke a project token
+ * @param {Object} apiClient - API HTTP client with request method
+ * @param {string} projectSlug - Project slug
+ * @param {string} organizationSlug - Organization slug
+ * @param {string} tokenId - Token ID to revoke
+ * @returns {Promise<void>}
+ */
+export async function revokeProjectToken(
+  apiClient,
+  projectSlug,
+  organizationSlug,
+  tokenId
+) {
+  if (!apiClient) {
+    throw buildNoApiServiceError();
+  }
+
+  try {
+    await apiClient.request(
+      buildTokensUrl(organizationSlug, projectSlug, tokenId),
+      {
+        method: 'DELETE',
+      }
+    );
+  } catch (error) {
+    throw buildTokenRevokeError(error);
+  }
+}

--- a/tests/project/core.spec.js
+++ b/tests/project/core.spec.js
@@ -1,0 +1,340 @@
+import { describe, expect, it } from 'vitest';
+import { VizzlyError } from '../../src/errors/vizzly-error.js';
+import {
+  buildBuildsQueryParams,
+  buildBuildsUrl,
+  buildMappingResult,
+  buildNoApiServiceError,
+  buildNoAuthError,
+  buildOrgHeader,
+  buildProjectFetchError,
+  buildProjectUrl,
+  buildTokenCreateError,
+  buildTokenRevokeError,
+  buildTokensFetchError,
+  buildTokensUrl,
+  enrichProjectsWithOrg,
+  extractBuilds,
+  extractOrganizations,
+  extractProject,
+  extractProjects,
+  extractToken,
+  extractTokens,
+  mappingsToArray,
+  validateDirectory,
+  validateProjectData,
+} from '../../src/project/core.js';
+
+describe('project/core', () => {
+  describe('validateDirectory', () => {
+    it('returns valid for non-empty directory', () => {
+      let result = validateDirectory('/path/to/project');
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it('returns error for empty directory', () => {
+      let result = validateDirectory('');
+      expect(result.valid).toBe(false);
+      expect(result.error).toBeInstanceOf(VizzlyError);
+      expect(result.error.code).toBe('INVALID_DIRECTORY');
+    });
+
+    it('returns error for null directory', () => {
+      let result = validateDirectory(null);
+      expect(result.valid).toBe(false);
+      expect(result.error.message).toContain('Directory path is required');
+    });
+
+    it('returns error for undefined directory', () => {
+      let result = validateDirectory(undefined);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('validateProjectData', () => {
+    it('returns valid for complete project data', () => {
+      let result = validateProjectData({
+        projectSlug: 'my-project',
+        organizationSlug: 'my-org',
+        token: 'vzt_token_123',
+      });
+      expect(result.valid).toBe(true);
+      expect(result.error).toBeNull();
+    });
+
+    it('returns error for missing projectSlug', () => {
+      let result = validateProjectData({
+        organizationSlug: 'my-org',
+        token: 'vzt_token_123',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error.code).toBe('INVALID_PROJECT_DATA');
+      expect(result.error.message).toContain('Project slug is required');
+    });
+
+    it('returns error for missing organizationSlug', () => {
+      let result = validateProjectData({
+        projectSlug: 'my-project',
+        token: 'vzt_token_123',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error.message).toContain('Organization slug is required');
+    });
+
+    it('returns error for missing token', () => {
+      let result = validateProjectData({
+        projectSlug: 'my-project',
+        organizationSlug: 'my-org',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error.message).toContain('Project token is required');
+    });
+  });
+
+  describe('mappingsToArray', () => {
+    it('converts empty object to empty array', () => {
+      expect(mappingsToArray({})).toEqual([]);
+    });
+
+    it('converts mappings object to array with directory property', () => {
+      let mappings = {
+        '/path/to/project1': { projectSlug: 'proj1', token: 'tok1' },
+        '/path/to/project2': { projectSlug: 'proj2', token: 'tok2' },
+      };
+
+      let result = mappingsToArray(mappings);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        directory: '/path/to/project1',
+        projectSlug: 'proj1',
+        token: 'tok1',
+      });
+      expect(result[1]).toEqual({
+        directory: '/path/to/project2',
+        projectSlug: 'proj2',
+        token: 'tok2',
+      });
+    });
+  });
+
+  describe('buildMappingResult', () => {
+    it('builds mapping result with directory included', () => {
+      let result = buildMappingResult('/my/path', {
+        projectSlug: 'proj',
+        token: 'tok',
+      });
+
+      expect(result).toEqual({
+        directory: '/my/path',
+        projectSlug: 'proj',
+        token: 'tok',
+      });
+    });
+  });
+
+  describe('buildBuildsQueryParams', () => {
+    it('returns empty string for no options', () => {
+      expect(buildBuildsQueryParams()).toBe('');
+      expect(buildBuildsQueryParams({})).toBe('');
+    });
+
+    it('builds query string with limit', () => {
+      expect(buildBuildsQueryParams({ limit: 10 })).toBe('?limit=10');
+    });
+
+    it('builds query string with branch', () => {
+      expect(buildBuildsQueryParams({ branch: 'main' })).toBe('?branch=main');
+    });
+
+    it('builds query string with both params', () => {
+      let result = buildBuildsQueryParams({ limit: 5, branch: 'develop' });
+      expect(result).toContain('limit=5');
+      expect(result).toContain('branch=develop');
+      expect(result).toContain('&');
+    });
+  });
+
+  describe('buildOrgHeader', () => {
+    it('builds X-Organization header', () => {
+      expect(buildOrgHeader('my-org')).toEqual({
+        'X-Organization': 'my-org',
+      });
+    });
+  });
+
+  describe('buildProjectUrl', () => {
+    it('builds project API URL', () => {
+      expect(buildProjectUrl('my-project')).toBe('/api/project/my-project');
+    });
+  });
+
+  describe('buildBuildsUrl', () => {
+    it('builds builds API URL without query params', () => {
+      expect(buildBuildsUrl('my-project')).toBe('/api/build/my-project');
+    });
+
+    it('builds builds API URL with query params', () => {
+      expect(buildBuildsUrl('my-project', { limit: 5 })).toBe(
+        '/api/build/my-project?limit=5'
+      );
+    });
+  });
+
+  describe('buildTokensUrl', () => {
+    it('builds tokens API URL without token ID', () => {
+      expect(buildTokensUrl('my-org', 'my-project')).toBe(
+        '/api/cli/organizations/my-org/projects/my-project/tokens'
+      );
+    });
+
+    it('builds tokens API URL with token ID', () => {
+      expect(buildTokensUrl('my-org', 'my-project', 'tok_123')).toBe(
+        '/api/cli/organizations/my-org/projects/my-project/tokens/tok_123'
+      );
+    });
+  });
+
+  describe('extractProjects', () => {
+    it('extracts projects array from response', () => {
+      let response = { projects: [{ id: 1 }, { id: 2 }] };
+      expect(extractProjects(response)).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('returns empty array for missing projects', () => {
+      expect(extractProjects({})).toEqual([]);
+      expect(extractProjects(null)).toEqual([]);
+      expect(extractProjects(undefined)).toEqual([]);
+    });
+  });
+
+  describe('extractProject', () => {
+    it('extracts project from response.project', () => {
+      let response = { project: { id: 1, name: 'Test' } };
+      expect(extractProject(response)).toEqual({ id: 1, name: 'Test' });
+    });
+
+    it('returns response directly if no project field', () => {
+      let response = { id: 1, name: 'Test' };
+      expect(extractProject(response)).toEqual({ id: 1, name: 'Test' });
+    });
+  });
+
+  describe('extractBuilds', () => {
+    it('extracts builds array from response', () => {
+      let response = { builds: [{ id: 'b1' }, { id: 'b2' }] };
+      expect(extractBuilds(response)).toEqual([{ id: 'b1' }, { id: 'b2' }]);
+    });
+
+    it('returns empty array for missing builds', () => {
+      expect(extractBuilds({})).toEqual([]);
+    });
+  });
+
+  describe('extractToken', () => {
+    it('extracts token from response', () => {
+      let response = { token: { id: 't1', value: 'vzt_xxx' } };
+      expect(extractToken(response)).toEqual({ id: 't1', value: 'vzt_xxx' });
+    });
+
+    it('returns undefined for missing token', () => {
+      expect(extractToken({})).toBeUndefined();
+    });
+  });
+
+  describe('extractTokens', () => {
+    it('extracts tokens array from response', () => {
+      let response = { tokens: [{ id: 't1' }, { id: 't2' }] };
+      expect(extractTokens(response)).toEqual([{ id: 't1' }, { id: 't2' }]);
+    });
+
+    it('returns empty array for missing tokens', () => {
+      expect(extractTokens({})).toEqual([]);
+    });
+  });
+
+  describe('enrichProjectsWithOrg', () => {
+    it('adds organization info to each project', () => {
+      let projects = [{ id: 'p1', name: 'Project 1' }];
+      let org = { slug: 'my-org', name: 'My Org' };
+
+      let result = enrichProjectsWithOrg(projects, org);
+
+      expect(result).toEqual([
+        {
+          id: 'p1',
+          name: 'Project 1',
+          organizationSlug: 'my-org',
+          organizationName: 'My Org',
+        },
+      ]);
+    });
+
+    it('handles empty projects array', () => {
+      expect(enrichProjectsWithOrg([], { slug: 'org', name: 'Org' })).toEqual(
+        []
+      );
+    });
+  });
+
+  describe('extractOrganizations', () => {
+    it('extracts organizations from whoami response', () => {
+      let response = { organizations: [{ id: 'o1' }, { id: 'o2' }] };
+      expect(extractOrganizations(response)).toEqual([
+        { id: 'o1' },
+        { id: 'o2' },
+      ]);
+    });
+
+    it('returns empty array for missing organizations', () => {
+      expect(extractOrganizations({})).toEqual([]);
+      expect(extractOrganizations(null)).toEqual([]);
+    });
+  });
+
+  describe('error builders', () => {
+    it('buildProjectFetchError wraps original error', () => {
+      let original = new Error('Network failed');
+      let error = buildProjectFetchError(original);
+
+      expect(error).toBeInstanceOf(VizzlyError);
+      expect(error.code).toBe('PROJECT_FETCH_FAILED');
+      expect(error.message).toContain('Network failed');
+    });
+
+    it('buildNoAuthError creates no auth error', () => {
+      let error = buildNoAuthError();
+      expect(error.code).toBe('NO_AUTH_SERVICE');
+      expect(error.message).toContain('No authentication available');
+    });
+
+    it('buildNoApiServiceError creates no API service error', () => {
+      let error = buildNoApiServiceError();
+      expect(error.code).toBe('NO_API_SERVICE');
+      expect(error.message).toContain('API service not available');
+    });
+
+    it('buildTokenCreateError wraps original error', () => {
+      let original = new Error('Token create failed');
+      let error = buildTokenCreateError(original);
+
+      expect(error.code).toBe('TOKEN_CREATE_FAILED');
+      expect(error.message).toContain('Token create failed');
+    });
+
+    it('buildTokensFetchError wraps original error', () => {
+      let original = new Error('Fetch failed');
+      let error = buildTokensFetchError(original);
+
+      expect(error.code).toBe('TOKENS_FETCH_FAILED');
+    });
+
+    it('buildTokenRevokeError wraps original error', () => {
+      let original = new Error('Revoke failed');
+      let error = buildTokenRevokeError(original);
+
+      expect(error.code).toBe('TOKEN_REVOKE_FAILED');
+    });
+  });
+});

--- a/tests/project/operations.spec.js
+++ b/tests/project/operations.spec.js
@@ -1,0 +1,496 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createMapping,
+  createProjectToken,
+  getMapping,
+  getProject,
+  getRecentBuilds,
+  listMappings,
+  listProjects,
+  listProjectsWithApiToken,
+  listProjectsWithOAuth,
+  listProjectTokens,
+  removeMapping,
+  revokeProjectToken,
+  switchProject,
+} from '../../src/project/operations.js';
+
+// ============================================================================
+// Test Helpers - Simple stubs passed as dependencies
+// ============================================================================
+
+function createMappingStore(data = {}) {
+  let store = { ...data };
+  return {
+    getMappings: async () => store,
+    getMapping: async dir => store[dir] || null,
+    saveMapping: async (dir, projectData) => {
+      store[dir] = projectData;
+    },
+    deleteMapping: async dir => {
+      delete store[dir];
+    },
+    // For test assertions
+    _store: store,
+  };
+}
+
+function createOAuthClient(responses = {}) {
+  return {
+    authenticatedRequest: async (url, _options) => {
+      if (responses.error) {
+        throw responses.error;
+      }
+      return responses[url] || responses.default || {};
+    },
+  };
+}
+
+function createApiClient(responses = {}) {
+  return {
+    request: async (url, _options) => {
+      if (responses.error) {
+        throw responses.error;
+      }
+      return responses[url] || responses.default || {};
+    },
+  };
+}
+
+// ============================================================================
+// Mapping Operations Tests
+// ============================================================================
+
+describe('project/operations - mapping operations', () => {
+  describe('listMappings', () => {
+    it('returns empty array for empty store', async () => {
+      let store = createMappingStore({});
+      let result = await listMappings(store);
+      expect(result).toEqual([]);
+    });
+
+    it('returns mappings with directory property', async () => {
+      let store = createMappingStore({
+        '/path/to/proj1': { projectSlug: 'proj1', token: 'tok1' },
+        '/path/to/proj2': { projectSlug: 'proj2', token: 'tok2' },
+      });
+
+      let result = await listMappings(store);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].directory).toBe('/path/to/proj1');
+      expect(result[0].projectSlug).toBe('proj1');
+    });
+  });
+
+  describe('getMapping', () => {
+    it('returns mapping for existing directory', async () => {
+      let store = createMappingStore({
+        '/my/project': { projectSlug: 'my-proj', token: 'tok' },
+      });
+
+      let result = await getMapping(store, '/my/project');
+
+      expect(result).toEqual({ projectSlug: 'my-proj', token: 'tok' });
+    });
+
+    it('returns null for non-existent directory', async () => {
+      let store = createMappingStore({});
+      let result = await getMapping(store, '/nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createMapping', () => {
+    it('creates mapping and returns result with directory', async () => {
+      let store = createMappingStore({});
+
+      let result = await createMapping(store, '/new/project', {
+        projectSlug: 'new-proj',
+        organizationSlug: 'my-org',
+        token: 'vzt_token',
+      });
+
+      expect(result).toEqual({
+        directory: '/new/project',
+        projectSlug: 'new-proj',
+        organizationSlug: 'my-org',
+        token: 'vzt_token',
+      });
+      expect(store._store['/new/project']).toBeDefined();
+    });
+
+    it('throws for empty directory', async () => {
+      let store = createMappingStore({});
+
+      await expect(
+        createMapping(store, '', {
+          projectSlug: 'p',
+          organizationSlug: 'o',
+          token: 't',
+        })
+      ).rejects.toThrow('Directory path is required');
+    });
+
+    it('throws for missing projectSlug', async () => {
+      let store = createMappingStore({});
+
+      await expect(
+        createMapping(store, '/dir', { organizationSlug: 'o', token: 't' })
+      ).rejects.toThrow('Project slug is required');
+    });
+
+    it('throws for missing organizationSlug', async () => {
+      let store = createMappingStore({});
+
+      await expect(
+        createMapping(store, '/dir', { projectSlug: 'p', token: 't' })
+      ).rejects.toThrow('Organization slug is required');
+    });
+
+    it('throws for missing token', async () => {
+      let store = createMappingStore({});
+
+      await expect(
+        createMapping(store, '/dir', {
+          projectSlug: 'p',
+          organizationSlug: 'o',
+        })
+      ).rejects.toThrow('Project token is required');
+    });
+  });
+
+  describe('removeMapping', () => {
+    it('removes existing mapping', async () => {
+      let store = createMappingStore({
+        '/my/project': { projectSlug: 'proj', token: 'tok' },
+      });
+
+      await removeMapping(store, '/my/project');
+
+      expect(store._store['/my/project']).toBeUndefined();
+    });
+
+    it('throws for empty directory', async () => {
+      let store = createMappingStore({});
+
+      await expect(removeMapping(store, '')).rejects.toThrow(
+        'Directory path is required'
+      );
+    });
+  });
+
+  describe('switchProject', () => {
+    it('creates mapping for directory', async () => {
+      let store = createMappingStore({});
+
+      let result = await switchProject(
+        store,
+        '/my/dir',
+        'my-proj',
+        'my-org',
+        'vzt_token'
+      );
+
+      expect(result.directory).toBe('/my/dir');
+      expect(result.projectSlug).toBe('my-proj');
+      expect(store._store['/my/dir'].token).toBe('vzt_token');
+    });
+  });
+});
+
+// ============================================================================
+// API Operations Tests - List Projects
+// ============================================================================
+
+describe('project/operations - list projects', () => {
+  describe('listProjectsWithOAuth', () => {
+    it('fetches projects for all organizations', async () => {
+      let client = createOAuthClient({
+        '/api/auth/cli/whoami': {
+          organizations: [
+            { slug: 'org1', name: 'Org One' },
+            { slug: 'org2', name: 'Org Two' },
+          ],
+        },
+        '/api/project': {
+          projects: [{ id: 'p1', name: 'Project 1' }],
+        },
+      });
+
+      let result = await listProjectsWithOAuth(client);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].organizationSlug).toBe('org1');
+      expect(result[1].organizationSlug).toBe('org2');
+    });
+
+    it('returns empty array when no organizations', async () => {
+      let client = createOAuthClient({
+        '/api/auth/cli/whoami': { organizations: [] },
+      });
+
+      let result = await listProjectsWithOAuth(client);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('listProjectsWithApiToken', () => {
+    it('fetches projects from API', async () => {
+      let client = createApiClient({
+        '/api/project': {
+          projects: [{ id: 'p1' }, { id: 'p2' }],
+        },
+      });
+
+      let result = await listProjectsWithApiToken(client);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('listProjects', () => {
+    it('uses OAuth client when available', async () => {
+      let oauthClient = createOAuthClient({
+        '/api/auth/cli/whoami': { organizations: [{ slug: 'o', name: 'O' }] },
+        '/api/project': { projects: [{ id: 'p1' }] },
+      });
+
+      let result = await listProjects({ oauthClient });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].organizationSlug).toBe('o');
+    });
+
+    it('falls back to API client when OAuth fails', async () => {
+      let oauthClient = createOAuthClient({ error: new Error('OAuth failed') });
+      let apiClient = createApiClient({
+        '/api/project': { projects: [{ id: 'api-proj' }] },
+      });
+
+      let result = await listProjects({ oauthClient, apiClient });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('api-proj');
+    });
+
+    it('returns empty array when both fail', async () => {
+      let oauthClient = createOAuthClient({ error: new Error('fail') });
+      let apiClient = createApiClient({ error: new Error('fail') });
+
+      let result = await listProjects({ oauthClient, apiClient });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no clients', async () => {
+      let result = await listProjects({});
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+// ============================================================================
+// API Operations Tests - Get Project
+// ============================================================================
+
+describe('project/operations - get project', () => {
+  describe('getProject', () => {
+    it('uses OAuth client when available', async () => {
+      let oauthClient = createOAuthClient({
+        '/api/project/my-proj': { project: { id: 'p1', name: 'My Project' } },
+      });
+
+      let result = await getProject({
+        oauthClient,
+        projectSlug: 'my-proj',
+        organizationSlug: 'my-org',
+      });
+
+      expect(result.id).toBe('p1');
+    });
+
+    it('falls back to API client when OAuth fails', async () => {
+      let oauthClient = createOAuthClient({ error: new Error('fail') });
+      let apiClient = createApiClient({
+        '/api/project/my-proj': { project: { id: 'api-p1' } },
+      });
+
+      let result = await getProject({
+        oauthClient,
+        apiClient,
+        projectSlug: 'my-proj',
+        organizationSlug: 'my-org',
+      });
+
+      expect(result.id).toBe('api-p1');
+    });
+
+    it('throws PROJECT_FETCH_FAILED when API client fails', async () => {
+      let apiClient = createApiClient({ error: new Error('Network error') });
+
+      await expect(
+        getProject({
+          apiClient,
+          projectSlug: 'my-proj',
+          organizationSlug: 'my-org',
+        })
+      ).rejects.toThrow('Failed to fetch project');
+    });
+
+    it('throws NO_AUTH_SERVICE when no clients', async () => {
+      await expect(
+        getProject({
+          projectSlug: 'my-proj',
+          organizationSlug: 'my-org',
+        })
+      ).rejects.toThrow('No authentication available');
+    });
+  });
+});
+
+// ============================================================================
+// API Operations Tests - Recent Builds
+// ============================================================================
+
+describe('project/operations - recent builds', () => {
+  describe('getRecentBuilds', () => {
+    it('uses OAuth client when available', async () => {
+      let oauthClient = createOAuthClient({
+        '/api/build/my-proj': { builds: [{ id: 'b1' }] },
+      });
+
+      let result = await getRecentBuilds({
+        oauthClient,
+        projectSlug: 'my-proj',
+        organizationSlug: 'my-org',
+      });
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('includes query params in URL', async () => {
+      let requestedUrl = null;
+      let oauthClient = {
+        authenticatedRequest: async (url, _opts) => {
+          requestedUrl = url;
+          return { builds: [] };
+        },
+      };
+
+      await getRecentBuilds({
+        oauthClient,
+        projectSlug: 'proj',
+        organizationSlug: 'org',
+        limit: 5,
+        branch: 'main',
+      });
+
+      expect(requestedUrl).toContain('limit=5');
+      expect(requestedUrl).toContain('branch=main');
+    });
+
+    it('returns empty array when both clients fail', async () => {
+      let oauthClient = createOAuthClient({ error: new Error('fail') });
+      let apiClient = createApiClient({ error: new Error('fail') });
+
+      let result = await getRecentBuilds({
+        oauthClient,
+        apiClient,
+        projectSlug: 'proj',
+        organizationSlug: 'org',
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+// ============================================================================
+// API Operations Tests - Project Tokens
+// ============================================================================
+
+describe('project/operations - project tokens', () => {
+  describe('createProjectToken', () => {
+    it('creates token and returns it', async () => {
+      let apiClient = createApiClient({
+        default: { token: { id: 't1', value: 'vzt_new' } },
+      });
+
+      let result = await createProjectToken(apiClient, 'proj', 'org', {
+        name: 'CI Token',
+      });
+
+      expect(result.id).toBe('t1');
+    });
+
+    it('throws NO_API_SERVICE when no client', async () => {
+      await expect(
+        createProjectToken(null, 'proj', 'org', { name: 'Token' })
+      ).rejects.toThrow('API service not available');
+    });
+
+    it('throws TOKEN_CREATE_FAILED on error', async () => {
+      let apiClient = createApiClient({ error: new Error('Failed') });
+
+      await expect(
+        createProjectToken(apiClient, 'proj', 'org', { name: 'Token' })
+      ).rejects.toThrow('Failed to create project token');
+    });
+  });
+
+  describe('listProjectTokens', () => {
+    it('returns tokens array', async () => {
+      let apiClient = createApiClient({
+        default: { tokens: [{ id: 't1' }, { id: 't2' }] },
+      });
+
+      let result = await listProjectTokens(apiClient, 'proj', 'org');
+      expect(result).toHaveLength(2);
+    });
+
+    it('throws NO_API_SERVICE when no client', async () => {
+      await expect(listProjectTokens(null, 'proj', 'org')).rejects.toThrow(
+        'API service not available'
+      );
+    });
+
+    it('throws TOKENS_FETCH_FAILED on error', async () => {
+      let apiClient = createApiClient({ error: new Error('Failed') });
+
+      await expect(listProjectTokens(apiClient, 'proj', 'org')).rejects.toThrow(
+        'Failed to fetch project tokens'
+      );
+    });
+  });
+
+  describe('revokeProjectToken', () => {
+    it('calls delete endpoint', async () => {
+      let deletedUrl = null;
+      let apiClient = {
+        request: async (url, opts) => {
+          if (opts.method === 'DELETE') {
+            deletedUrl = url;
+          }
+          return {};
+        },
+      };
+
+      await revokeProjectToken(apiClient, 'proj', 'org', 'tok_123');
+
+      expect(deletedUrl).toContain('tok_123');
+    });
+
+    it('throws NO_API_SERVICE when no client', async () => {
+      await expect(
+        revokeProjectToken(null, 'proj', 'org', 'tok')
+      ).rejects.toThrow('API service not available');
+    });
+
+    it('throws TOKEN_REVOKE_FAILED on error', async () => {
+      let apiClient = createApiClient({ error: new Error('Failed') });
+
+      await expect(
+        revokeProjectToken(apiClient, 'proj', 'org', 'tok')
+      ).rejects.toThrow('Failed to revoke project token');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Continues the functional decomposition roadmap (issue #128) by refactoring `ProjectService` into pure functions and dependency-injected operations.

- **Extract pure functions to `src/project/core.js`**:
  - Validation functions (`validateDirectory`, `validateProjectData`)
  - Data transformations (`mappingsToArray`, `buildMappingResult`)
  - URL/header builders (`buildBuildsUrl`, `buildProjectUrl`, `buildTokensUrl`, `buildOrgHeader`)
  - Response extractors (`extractProjects`, `extractBuilds`, `extractToken`, etc.)
  - Error builders for consistent error handling

- **Create DI-based operations in `src/project/operations.js`**:
  - Mapping operations (`listMappings`, `getMapping`, `createMapping`, `removeMapping`, `switchProject`)
  - API operations with OAuth/API token fallback pattern
  - All I/O operations take dependencies as parameters for easy testing

- **Update `ProjectService` class** to be a thin wrapper delegating to the new module

- **Add 76 new tests** with zero `vi.mock`:
  - `tests/project/core.spec.js`: 41 pure function tests
  - `tests/project/operations.spec.js`: 35 tests using simple stubs

## Test plan

- [x] All 76 new project module tests pass
- [x] Existing command tests pass (backwards compatibility)
- [x] Full test suite passes (617 tests)
- [x] Build succeeds
- [x] Lint passes

Closes part of #128