### PR TITLE
🐛 Fix acceptBaseline saving to wrong path with double .png extension

### DIFF
--- a/src/tdd/tdd-service.js
+++ b/src/tdd/tdd-service.js
@@ -1397,8 +1397,8 @@ export class TddService {
       mkdirSync(this.baselinePath, { recursive: true });
     }
 
-    // Update the baseline
-    let baselineImagePath = safePath(this.baselinePath, `${filename}.png`);
+    // Update the baseline (filename already includes .png extension)
+    let baselineImagePath = safePath(this.baselinePath, filename);
 
     writeFileSync(baselineImagePath, imageBuffer);
 


### PR DESCRIPTION
## Summary

- Fix bug where `acceptBaseline` was appending `.png` to filenames that already included the extension
- Baselines were being saved as `name_hash.png.png` instead of `name_hash.png`
- This caused accepted baselines to never be found on subsequent test runs, so users had to re-approve the same screenshot every time

## Test plan

- [x] Added regression test that verifies baseline is saved to correct path
- [x] All existing tests pass