### PR TITLE
✨ Add --fail-on-diff option and improve SDK resilience

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -368,6 +368,7 @@ tddCmd
   .option('--environment <env>', 'Environment name', 'test')
   .option('--threshold <number>', 'Comparison threshold', parseFloat)
   .option('--timeout <ms>', 'Server timeout in milliseconds', '30000')
+  .option('--fail-on-diff', 'Fail tests when visual differences are detected')
   .option('--token <token>', 'API token override')
   .option('--daemon-child', 'Internal: run as daemon child process')
   .action(async options => {
@@ -416,6 +417,7 @@ tddCmd
     '--set-baseline',
     'Accept current screenshots as new baseline (overwrites existing)'
   )
+  .option('--fail-on-diff', 'Fail tests when visual differences are detected')
   .option('--no-open', 'Skip opening report in browser')
   .action(async (command, options) => {
     const globalOptions = program.opts();

--- a/src/commands/tdd-daemon.js
+++ b/src/commands/tdd-daemon.js
@@ -86,6 +86,7 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
           ? ['--threshold', options.threshold.toString()]
           : []),
         ...(options.timeout ? ['--timeout', options.timeout] : []),
+        ...(options.failOnDiff ? ['--fail-on-diff'] : []),
         ...(options.token ? ['--token', options.token] : []),
         ...(globalOptions.json ? ['--json'] : []),
         ...(globalOptions.verbose ? ['--verbose'] : []),
@@ -250,6 +251,7 @@ export async function runDaemonChild(options = {}, globalOptions = {}) {
       pid: process.pid,
       port: port,
       startTime: Date.now(),
+      failOnDiff: options.failOnDiff || false,
     };
     writeFileSync(
       join(vizzlyDir, 'server.json'),

--- a/src/server/handlers/tdd-handler.js
+++ b/src/server/handlers/tdd-handler.js
@@ -470,21 +470,20 @@ export const createTddHandler = (
     // Update comparison in report data file
     updateComparison(newComparison);
 
+    // Visual diffs return 200 with status: 'diff' - they're not errors
+    // The SDK/user can decide whether to fail tests based on this
     if (comparison.status === 'failed') {
       return {
-        statusCode: 422,
+        statusCode: 200,
         body: {
-          error: 'Visual difference detected',
-          details: `Screenshot '${name}' differs from baseline`,
-          comparison: {
-            name: comparison.name,
-            status: comparison.status,
-            baseline: comparison.baseline,
-            current: comparison.current,
-            diff: comparison.diff,
-            diffPercentage: comparison.diffPercentage,
-            threshold: comparison.threshold,
-          },
+          status: 'diff',
+          name: comparison.name,
+          message: `Visual difference detected for '${name}'`,
+          baseline: comparison.baseline,
+          current: comparison.current,
+          diff: comparison.diff,
+          diffPercentage: comparison.diffPercentage,
+          threshold: comparison.threshold,
           tddMode: true,
         },
       };
@@ -494,14 +493,11 @@ export const createTddHandler = (
       return {
         statusCode: 200,
         body: {
-          status: 'success',
-          message: `Baseline updated for ${name}`,
-          comparison: {
-            name: comparison.name,
-            status: comparison.status,
-            baseline: comparison.baseline,
-            current: comparison.current,
-          },
+          status: 'baseline-updated',
+          name: comparison.name,
+          message: `Baseline updated for '${name}'`,
+          baseline: comparison.baseline,
+          current: comparison.current,
           tddMode: true,
         },
       };
@@ -517,15 +513,14 @@ export const createTddHandler = (
       };
     }
 
-    // Debug output handled by tdd.js event handler
+    // Match or new baseline
     return {
       statusCode: 200,
       body: {
-        success: true,
-        comparison: {
-          name: comparison.name,
-          status: comparison.status,
-        },
+        status: comparison.status === 'new' ? 'new' : 'match',
+        name: comparison.name,
+        baseline: comparison.baseline,
+        current: comparison.current,
         tddMode: true,
       },
     };


### PR DESCRIPTION
## Summary

- Visual diffs no longer break tests by default - SDKs can now choose whether to fail on diffs
- Server returns 200 for diffs with `status: 'diff'` instead of 422 error
- Added `--fail-on-diff` CLI flag for `vizzly tdd start` and `vizzly tdd run`

## Changes

**Server:**
- Visual diffs return `200` with `status: 'diff'` instead of `422`
- Consistent response format with `status` field: `'match'`, `'diff'`, `'new'`, or `'baseline-updated'`

**CLI:**
- `--fail-on-diff` flag on `vizzly tdd start` and `vizzly tdd run`
- `failOnDiff` stored in `server.json` for SDK discovery

**Ember SDK:**
- Read `failOnDiff` from server.json, env var, or per-snapshot option
- Gracefully skip snapshots when no server running (like Percy)
- `failOnDiff` option on `vizzlySnapshot()` for per-snapshot control

## Usage

```bash
# Default: diffs logged as warnings, tests pass
vizzly tdd start

# Fail tests on visual diffs
vizzly tdd start --fail-on-diff

# Or via environment variable
VIZZLY_FAIL_ON_DIFF=true npm test

# Or per-snapshot
await vizzlySnapshot('critical-ui', { failOnDiff: true });
```

## Test plan

- [x] Updated `tdd-handler.test.js` for new 200 response format
- [x] Added tests for diff response structure
- [x] Added tests for `getServerInfo()` reading `failOnDiff`
- [x] All CLI tests pass
- [x] All Ember SDK tests pass