### PR TITLE
✨ Add Playwright options support to Ember SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,17 +503,13 @@ jobs:
     needs: [lint, changes-ember]
     if: needs.changes-ember.outputs.ember == 'true'
 
-    strategy:
-      matrix:
-        node-version: [22, 24]
-
     steps:
     - uses: actions/checkout@v4
 
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 22
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 22
 
     - name: Install CLI dependencies
       run: npm ci
@@ -559,7 +555,6 @@ jobs:
         CI: true
 
     - name: Run Ember E2E visual tests
-      if: matrix.node-version == 22
       working-directory: ./clients/ember
       run: |
         cd test-app

--- a/clients/ember/package-lock.json
+++ b/clients/ember/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vizzly-testing/ember",
-  "version": "0.0.1-beta.1",
+  "version": "0.0.1-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vizzly-testing/ember",
-      "version": "0.0.1-beta.1",
+      "version": "0.0.1-beta.2",
       "license": "MIT",
       "dependencies": {
         "playwright-core": "^1.49.0"

--- a/clients/ember/package.json
+++ b/clients/ember/package.json
@@ -37,7 +37,7 @@
   },
   "main": "./src/index.js",
   "bin": {
-    "vizzly-browser": "bin/vizzly-browser.js"
+    "vizzly-testem-launcher": "bin/vizzly-testem-launcher.js"
   },
   "files": [
     "bin",

--- a/clients/ember/test-app/testem.cjs
+++ b/clients/ember/test-app/testem.cjs
@@ -12,5 +12,11 @@ if (typeof module !== 'undefined') {
     launch_in_ci: ['Chrome'],
     launch_in_dev: ['Chrome'],
     browser_start_timeout: 120,
+    browser_args: {
+      Chrome: {
+        ci: ['--headless', '--disable-gpu'],
+        dev: [], // headed for local debugging
+      },
+    },
   });
 }

--- a/clients/ember/tests/integration/e2e.test.js
+++ b/clients/ember/tests/integration/e2e.test.js
@@ -115,7 +115,7 @@ describe('e2e with TDD server', { skip: !process.env.RUN_E2E }, () => {
     let testUrl = `http://127.0.0.1:${testServerPort}/`;
     browserInstance = await launchBrowser('chromium', testUrl, {
       snapshotUrl,
-      headless: true,
+      playwrightOptions: { headless: true },
     });
 
     setPage(browserInstance.page);
@@ -181,7 +181,7 @@ describe('e2e without TDD server', () => {
     let testUrl = `http://127.0.0.1:${testServerPort}/`;
     browserInstance = await launchBrowser('chromium', testUrl, {
       snapshotUrl,
-      headless: true,
+      playwrightOptions: { headless: true },
     });
 
     setPage(browserInstance.page);

--- a/clients/ember/tests/integration/launcher.test.js
+++ b/clients/ember/tests/integration/launcher.test.js
@@ -116,7 +116,7 @@ describe('launcher integration', () => {
     let testUrl = `http://127.0.0.1:${testServerPort}/`;
     browserInstance = await launchBrowser('chromium', testUrl, {
       snapshotUrl,
-      headless: true,
+      playwrightOptions: { headless: true },
     });
 
     // Set page reference for screenshot capture
@@ -171,7 +171,7 @@ describe('launcher integration', () => {
     let testUrl = `http://127.0.0.1:${testServerPort}/`;
     browserInstance = await launchBrowser('chromium', testUrl, {
       snapshotUrl,
-      headless: true,
+      playwrightOptions: { headless: true },
     });
 
     // Verify the URL was injected
@@ -190,7 +190,7 @@ describe('launcher integration', () => {
       let testUrl = `http://127.0.0.1:${testServerPort}/`;
       browserInstance = await launchBrowser('chromium', testUrl, {
         snapshotUrl,
-        headless: true,
+        playwrightOptions: { headless: true },
       });
     }
 


### PR DESCRIPTION
## Summary

- Rename `vizzly-browser` → `vizzly-testem-launcher` (clearer about its role)
- Add `playwrightOptions` parameter to `configure()` for direct Playwright control
- Default to headless mode (`headless: true`)
- Support all Playwright `browserType.launch()` options
- Simplify CI to Node 22 only

## Usage

```js
// Basic - headless by default
module.exports = configure({
  launch_in_ci: ['Chrome'],
});

// Headed for local debugging
module.exports = configure({
  launch_in_ci: ['Chrome'],
}, {
  headless: false,
  slowMo: 100,
});

// CI vs local
const isCI = process.env.CI;
module.exports = configure({
  launch_in_ci: ['Chrome'],
}, {
  headless: isCI,
});
```

## Playwright Options

The second argument accepts [Playwright browserType.launch() options](https://playwright.dev/docs/api/class-browsertype#browser-type-launch) directly:

| Option | Type | Default | Description |
|--------|------|---------|-------------|
| `headless` | boolean | `true` | Run browser in headless mode |
| `slowMo` | number | - | Slow down operations by specified ms |
| `timeout` | number | - | Browser launch timeout |
| `proxy` | object | - | Proxy settings |
| `args` | string[] | - | Additional browser arguments |

## Test plan

- [x] Unit tests pass (38 tests)
- [x] Integration tests pass (5 tests)
- [x] Lint passes
- [ ] CI passes