### PR TITLE
✨ Improve preview command with smart exclusions and dry-run

### DIFF
--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -333,18 +333,15 @@ export async function finalizeParallelBuild(client, parallelId) {
  * @returns {Promise<Object>} Upload result with preview URL
  */
 export async function uploadPreviewZip(client, buildId, zipBuffer) {
-  // Create form data with the ZIP file
-  let FormData = (await import('form-data')).default;
+  // Use native FormData (Node 18+) with Blob for proper fetch compatibility
   let formData = new FormData();
-  formData.append('file', zipBuffer, {
-    filename: 'preview.zip',
-    contentType: 'application/zip',
-  });
+  let blob = new Blob([zipBuffer], { type: 'application/zip' });
+  formData.append('file', blob, 'preview.zip');
 
   return client.request(`/api/sdk/builds/${buildId}/preview/upload-zip`, {
     method: 'POST',
     body: formData,
-    headers: formData.getHeaders(),
+    // Let fetch set the Content-Type with boundary automatically
   });
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -572,13 +572,37 @@ program
 program
   .command('preview')
   .description('Upload static files as a preview for a build')
-  .argument('<path>', 'Path to static files (dist/, build/, out/)')
+  .argument('[path]', 'Path to static files (dist/, build/, out/)')
   .option('-b, --build <id>', 'Build ID to attach preview to')
   .option('-p, --parallel-id <id>', 'Look up build by parallel ID')
   .option('--base <path>', 'Override auto-detected base path')
   .option('--open', 'Open preview URL in browser after upload')
+  .option('--dry-run', 'Show what would be uploaded without uploading')
+  .option(
+    '-x, --exclude <pattern>',
+    'Exclude files/dirs (repeatable, e.g. -x "*.log" -x "temp/")',
+    (val, prev) => (prev ? [...prev, val] : [val])
+  )
+  .option(
+    '-i, --include <pattern>',
+    'Override default exclusions (repeatable, e.g. -i package.json -i tests/)',
+    (val, prev) => (prev ? [...prev, val] : [val])
+  )
   .action(async (path, options) => {
     const globalOptions = program.opts();
+
+    // Show helpful error if path is missing
+    if (!path) {
+      output.error('Path to static files is required');
+      output.blank();
+      output.print('  Upload your build output directory:');
+      output.blank();
+      output.print('    vizzly preview ./dist');
+      output.print('    vizzly preview ./build');
+      output.print('    vizzly preview ./out');
+      output.blank();
+      process.exit(1);
+    }
 
     // Validate options
     const validationErrors = validatePreviewOptions(path, options);

--- a/tests/api/endpoints.test.js
+++ b/tests/api/endpoints.test.js
@@ -525,10 +525,8 @@ describe('api/endpoints', () => {
       await uploadPreviewZip(client, 'build-123', zipBuffer);
 
       let call = client.getLastCall();
-      // Should have form-data headers
-      assert.ok(
-        call.options.headers['content-type']?.includes('multipart/form-data')
-      );
+      // Should send body as native FormData (fetch sets Content-Type automatically)
+      assert.ok(call.options.body instanceof FormData);
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix form-data upload by using native `FormData`/`Blob` for fetch compatibility (the `form-data` npm package doesn't stream correctly with Node's native fetch)
- Add smart default exclusions for non-static files: `node_modules`, `tests/`, `__tests__/`, `coverage/`, `*.config.js`, `package.json`, `*.md`, etc.
- Add `--dry-run` flag to preview what would be uploaded without actually uploading
- Add `--exclude/-x` flag to add custom exclusion patterns (repeatable, use trailing `/` for directories)
- Add `--include/-i` flag to override default exclusions (e.g., `--include package.json`)
- Show helpful error message with examples when path argument is missing
- Skip API token validation for dry-run mode

## Test plan

- [ ] Run `vizzly preview ./dist --dry-run` to verify file listing works
- [ ] Run `vizzly preview ./dist --dry-run --verbose` to see exclusion lists
- [ ] Run `vizzly preview ./dist --dry-run --exclude "*.css"` to test custom exclusions
- [ ] Run `vizzly preview ./dist --dry-run --include package.json` to test including excluded files
- [ ] Run `vizzly preview` (no path) to verify helpful error message
- [ ] Run actual upload to verify form-data fix works