### PR TITLE
✨ Make finalize command resilient to missing builds

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -236,6 +236,10 @@ program
   .option('--json', 'Machine-readable output')
   .option('--color', 'Force colored output (even in non-TTY)')
   .option('--no-color', 'Disable colored output')
+  .option(
+    '--strict',
+    'Fail on any error (default: be resilient, warn on non-critical issues)'
+  )
   .configureHelp({ formatHelp });
 
 // Load plugins before defining commands


### PR DESCRIPTION
## Summary

- Add global `--strict` flag for all CLI commands to opt into hard failures
- Handle 404 errors gracefully in `finalize` command (warn + exit 0 by default)
- Show helpful debugging hints when builds are missing (in verbose mode)
- Add tests for new resilient behavior

## Why

The `finalize` command was breaking CI pipelines when no parallel build existed (e.g., tests were skipped, no screenshots uploaded, or mismatched parallel-id). This is a poor UX for CI workflows where Vizzly tests might be conditionally skipped.

## Behavior

**Default (resilient):**
```bash
vizzly finalize abc123
# No build found for parallel ID: abc123 - finalize skipped.
# Exit code: 0
```

**Strict mode:**
```bash
vizzly finalize abc123 --strict
# Error: No build found for parallel ID: abc123
# Exit code: 1
```

## Test plan

- [x] Run `node --test tests/commands/finalize.test.js` - all 17 tests pass
- [x] Run full test suite - all 1860 tests pass
- [ ] Manual test: `vizzly finalize nonexistent-id` exits 0 with warning
- [ ] Manual test: `vizzly finalize nonexistent-id --strict` exits 1 with error

Closes VIZ-108