### PR TITLE
✨ Require --public-link flag for private project previews

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -583,6 +583,10 @@ program
   .option('--open', 'Open preview URL in browser after upload')
   .option('--dry-run', 'Show what would be uploaded without uploading')
   .option(
+    '--public-link',
+    'Acknowledge that preview URL grants access to anyone with the link (required for private projects)'
+  )
+  .option(
     '-x, --exclude <pattern>',
     'Exclude files/dirs (repeatable, e.g. -x "*.log" -x "temp/")',
     (val, prev) => (prev ? [...prev, val] : [val])


### PR DESCRIPTION
## Summary

- Adds `--public-link` flag to the `vizzly preview` command
- Private projects now fail preview upload without this flag
- Clear error message explains the access model (anyone with link can view)

## Why

Preview URLs for private projects grant access to anyone with the link until expiration. This change ensures users explicitly acknowledge this access model before uploading.

## Test plan

- [ ] Run `vizzly preview ./dist` on a private project → should fail with clear error
- [ ] Run `vizzly preview ./dist --public-link` on a private project → should work
- [ ] Run `vizzly preview ./dist` on a public project → should work (no flag needed)