### PR TITLE
🔊 Improve menubar app integration with logging and notifications

### DIFF
--- a/src/tdd/server-registry.js
+++ b/src/tdd/server-registry.js
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
@@ -173,13 +174,20 @@ export class ServerRegistry {
   /**
    * Notify the menubar app that the registry changed
    *
-   * NOTE: The menubar app primarily uses FSEvents file watching on servers.json.
-   * This method is a placeholder for future notification mechanisms (e.g., XPC).
-   * For now, file watching provides reliable, immediate updates.
+   * Uses macOS notifyutil for instant Darwin notification delivery.
+   * The menubar app listens for this in addition to file watching.
    */
   notifyMenubar() {
-    // File watching on servers.json is the primary notification mechanism.
-    // This method exists for future enhancements (XPC, etc.) but is currently a no-op.
+    if (process.platform !== 'darwin') return;
+
+    try {
+      execSync('notifyutil -p dev.vizzly.serverChanged', {
+        stdio: 'ignore',
+        timeout: 500,
+      });
+    } catch {
+      // Non-fatal - menubar will still see changes via file watching
+    }
   }
 
   /**

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -183,6 +183,7 @@ export function getColors() {
  */
 export function success(message, data = {}) {
   stopSpinner();
+  writeLog('info', message, { status: 'success', ...data });
   if (config.silent) return;
 
   if (config.json) {
@@ -217,6 +218,7 @@ export function result(message) {
  * Show an info message
  */
 export function info(message, data = {}) {
+  writeLog('info', message, data);
   if (!shouldLog('info')) return;
 
   if (config.json) {
@@ -231,6 +233,7 @@ export function info(message, data = {}) {
  */
 export function warn(message, data = {}) {
   stopSpinner();
+  writeLog('warn', message, data);
   if (!shouldLog('warn')) return;
 
   if (config.json) {


### PR DESCRIPTION
## Summary

- Add `writeLog()` calls to `info()`, `warn()`, `success()` output functions so TDD server operations are logged to `server.log` for menubar display
- Implement `notifyMenubar()` using macOS `notifyutil` for instant Darwin notifications (safely no-ops on non-darwin platforms)

## Platform Safety

The `notifyMenubar()` function checks `process.platform !== 'darwin'` and returns early on non-macOS systems, so this is safe for Windows/Linux.

## Test plan

- [ ] Start TDD server on macOS, verify `server.log` contains more than just session_start
- [ ] Verify menubar receives instant updates when server starts/stops
- [ ] Verify CLI works normally on Linux/Windows (no crashes from notification code)