### PR TITLE
✨ Log screenshot events for menubar display

### DIFF
--- a/src/server/handlers/tdd-handler.js
+++ b/src/server/handlers/tdd-handler.js
@@ -482,9 +482,11 @@ export const createTddHandler = (
     updateComparison(newComparison);
 
     // Log screenshot event for menubar
+    // Normalize status to match HTTP response ('failed' -> 'diff')
+    let logStatus = comparison.status === 'failed' ? 'diff' : comparison.status;
     output.info(`Screenshot: ${sanitizedName}`, {
       screenshot: sanitizedName,
-      status: comparison.status,
+      status: logStatus,
       diffPercentage: comparison.diffPercentage || 0,
     });
 
@@ -579,7 +581,12 @@ export const createTddHandler = (
 
       updateComparison(updatedComparison);
 
-      output.info(`Baseline accepted for comparison ${comparisonId}`);
+      // Log screenshot event for menubar
+      output.info(`Screenshot: ${comparison.name}`, {
+        screenshot: comparison.name,
+        status: 'accepted',
+        diffPercentage: 0,
+      });
       return result;
     } catch (error) {
       output.error(`Failed to accept baseline for ${comparisonId}:`, error);
@@ -609,7 +616,12 @@ export const createTddHandler = (
 
       updateComparison(updatedComparison);
 
-      output.info(`Changes rejected for comparison ${comparisonId}`);
+      // Log screenshot event for menubar
+      output.info(`Screenshot: ${comparison.name}`, {
+        screenshot: comparison.name,
+        status: 'rejected',
+        diffPercentage: comparison.diffPercentage || 0,
+      });
       return { success: true, id: comparisonId };
     } catch (error) {
       output.error(`Failed to reject baseline for ${comparisonId}:`, error);


### PR DESCRIPTION
## Summary

Each screenshot comparison now logs to `server.log` with:
- screenshot name  
- status (passed/failed/new/etc)
- diffPercentage

This enables the menubar app to show individual screenshot results in the log viewer.

## Test plan

- [ ] Start TDD server, run tests, verify `server.log` contains screenshot entries
- [ ] Verify menubar log viewer displays screenshot events with status icons