### PR TITLE
🐛 Fix comparisons command returning empty results

### DIFF
--- a/src/commands/builds.js
+++ b/src/commands/builds.js
@@ -60,7 +60,7 @@ export async function buildsCommand(
     if (options.build) {
       output.startSpinner('Fetching build...');
       let include = options.comparisons ? 'comparisons' : undefined;
-      let response = await getBuild(client, options.build, { include });
+      let response = await getBuild(client, options.build, include);
       output.stopSpinner();
 
       let build = response.build || response;

--- a/src/commands/comparisons.js
+++ b/src/commands/comparisons.js
@@ -78,9 +78,7 @@ export async function comparisonsCommand(
     // Get comparisons for a specific build
     if (options.build) {
       output.startSpinner('Fetching comparisons for build...');
-      let response = await getBuild(client, options.build, {
-        include: 'comparisons',
-      });
+      let response = await getBuild(client, options.build, 'comparisons');
       output.stopSpinner();
 
       let build = response.build || response;

--- a/tests/commands/builds.test.js
+++ b/tests/commands/builds.test.js
@@ -144,6 +144,50 @@ describe('commands/builds', () => {
       assert.strictEqual(dataCall.args[0].id, 'build-1');
     });
 
+    it('passes include as a string to getBuild when --comparisons is set', async () => {
+      let output = createMockOutput();
+      let capturedInclude = null;
+
+      await buildsCommand(
+        { build: 'build-1', comparisons: true },
+        { json: true },
+        {
+          loadConfig: async () => ({ apiKey: 'test-token' }),
+          createApiClient: () => ({}),
+          getBuild: async (_client, _buildId, include) => {
+            capturedInclude = include;
+            return { build: { id: 'build-1', status: 'completed' } };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedInclude, 'comparisons');
+    });
+
+    it('passes undefined include to getBuild when --comparisons is not set', async () => {
+      let output = createMockOutput();
+      let capturedInclude = 'NOT_CALLED';
+
+      await buildsCommand(
+        { build: 'build-1' },
+        { json: true },
+        {
+          loadConfig: async () => ({ apiKey: 'test-token' }),
+          createApiClient: () => ({}),
+          getBuild: async (_client, _buildId, include) => {
+            capturedInclude = include;
+            return { build: { id: 'build-1', status: 'completed' } };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedInclude, undefined);
+    });
+
     it('passes filters to API', async () => {
       let output = createMockOutput();
       let capturedFilters = null;

--- a/tests/commands/comparisons.test.js
+++ b/tests/commands/comparisons.test.js
@@ -137,6 +137,28 @@ describe('commands/comparisons', () => {
       assert.strictEqual(dataCall.args[0].summary.failed, 1);
     });
 
+    it('passes include as a string to getBuild, not an object', async () => {
+      let output = createMockOutput();
+      let capturedInclude = null;
+
+      await comparisonsCommand(
+        { build: 'build-1' },
+        { json: true },
+        {
+          loadConfig: async () => ({ apiKey: 'test-token' }),
+          createApiClient: () => ({}),
+          getBuild: async (_client, _buildId, include) => {
+            capturedInclude = include;
+            return { build: { id: 'build-1', comparisons: [] } };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedInclude, 'comparisons');
+    });
+
     it('searches comparisons by name', async () => {
       let output = createMockOutput();
       let capturedName = null;


### PR DESCRIPTION
## Summary

- `getBuild()` expects the `include` parameter as a string (e.g. `'comparisons'`), but both `comparisons.js` and `builds.js` were passing an object (`{ include: 'comparisons' }`)
- This caused the query string to contain `include=[object Object]`, which the API didn't recognize — so comparisons were silently omitted from the response
- Added tests that capture the actual arguments passed to `getBuild` to prevent this regression

## Test plan

- [ ] `npm test` passes (21 tests across both files, all green)
- [ ] `vizzly comparisons --build <id>` now returns comparison data instead of empty results
- [ ] `vizzly builds --build <id> --comparisons` also correctly includes comparisons