### PR TITLE
🐛 Flatten nested properties in screenshot upload payload

### DIFF
--- a/src/api/core.js
+++ b/src/api/core.js
@@ -194,6 +194,8 @@ export function buildScreenshotCheckObject(sha256, name, metadata = {}) {
     browser: meta.browser || 'chrome',
     viewport_width: meta.viewport?.width || meta.viewport_width || 1920,
     viewport_height: meta.viewport?.height || meta.viewport_height || 1080,
+    url: meta.url || meta.properties?.url || null,
+    metadata: meta,
   };
 }
 

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -207,7 +207,7 @@ function createSimpleClient(serverUrl) {
             name,
             image,
             type,
-            properties: options,
+            properties: { ...options, ...options.properties },
             fullPage: options.fullPage || false,
           },
           DEFAULT_TIMEOUT_MS

--- a/tests/api/core.test.js
+++ b/tests/api/core.test.js
@@ -425,6 +425,8 @@ describe('api/core', () => {
         browser: 'chrome',
         viewport_width: 1920,
         viewport_height: 1080,
+        url: null,
+        metadata: {},
       });
     });
 


### PR DESCRIPTION
## Summary

- When SDK clients pass `{ properties: { url, viewport } }` as options to `vizzlyScreenshot()`, the client sent `properties: { properties: { url } }` — double-nesting the data
- The server reads `properties.url` (top-level) and got `undefined`, so `screenshots.url` was never populated for static site uploads
- This broke preview linking in the full-screen review UI since `canLinkToPreview()` needs a valid URL from `comparison.current_url`
- Fix: spread `options.properties` into the top level so `url`, `viewport`, etc. are directly accessible

## Context

Server-side fallback already deployed (`properties.properties?.url`) but this fixes the source of the nesting bug.

## Test plan

- [x] SDK client tests pass (32/32)
- [ ] Re-run static-site CI build and verify `screenshots.url` is populated
- [ ] Verify preview links appear in full-screen review UI