### PR TITLE
🐛 Fix double-nested properties in client screenshot payload

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -199,6 +199,13 @@ function createSimpleClient(serverUrl) {
         let image = isFilePath ? imageBuffer : imageBuffer.toString('base64');
         let type = isFilePath ? 'file-path' : 'base64';
 
+        let {
+          fullPage,
+          threshold,
+          properties: userProperties,
+          ...rest
+        } = options;
+
         let httpStart = Date.now();
         const { status, json } = await httpPost(
           `${serverUrl}/screenshot`,
@@ -207,8 +214,8 @@ function createSimpleClient(serverUrl) {
             name,
             image,
             type,
-            properties: options,
-            fullPage: options.fullPage || false,
+            properties: { ...rest, ...userProperties },
+            fullPage: fullPage || false,
           },
           DEFAULT_TIMEOUT_MS
         );

--- a/tests/sdk/client.test.js
+++ b/tests/sdk/client.test.js
@@ -377,6 +377,36 @@ describe('client/index httpPost integration tests', () => {
     assert.deepStrictEqual(req.body.properties, { browser: 'chrome' });
   });
 
+  it('flattens nested properties into top-level properties', async () => {
+    await vizzlyScreenshot('test', Buffer.from('data'), {
+      properties: { url: 'http://localhost:3000/page' },
+    });
+
+    assert.strictEqual(requests.length, 1);
+    assert.deepStrictEqual(requests[0].body.properties, {
+      url: 'http://localhost:3000/page',
+    });
+  });
+
+  it('excludes SDK options from properties', async () => {
+    await vizzlyScreenshot('test', Buffer.from('data'), {
+      fullPage: true,
+      threshold: 0.1,
+      properties: { url: 'http://localhost:3000' },
+      browser: 'firefox',
+    });
+
+    assert.strictEqual(requests.length, 1);
+    let { properties, fullPage } = requests[0].body;
+    assert.strictEqual(fullPage, true);
+    assert.deepStrictEqual(properties, {
+      browser: 'firefox',
+      url: 'http://localhost:3000',
+    });
+    assert.strictEqual(properties.fullPage, undefined);
+    assert.strictEqual(properties.threshold, undefined);
+  });
+
   it('sends Connection: close header to disable keep-alive', async () => {
     await vizzlyScreenshot('test', Buffer.from('data'));
 


### PR DESCRIPTION
## Summary

- The client SDK was sending the entire `options` object as `properties`, causing double-nesting when SDKs passed `{ properties: { url } }` — the server received `properties: { properties: { url } }` making `url` unreachable
- Now destructures SDK-internal options (`fullPage`, `threshold`) out and flattens `options.properties` into the top-level properties object
- Adds tests verifying properties flattening and that SDK options don't leak into properties
- Closes #221 — this fixes the root cause instead of patching around it server-side

## Context

After the URL capture change (#220), Storybook and Static Site SDKs passed `{ properties: { url: page.url() } }` to `vizzlyScreenshot()`. The client blindly forwarded the whole options object as `properties`, double-nesting the data. A server-side fallback (`properties.properties?.url`) was deployed as a stopgap — this fix makes that fallback unnecessary.

## Test plan

- [x] `npm test` — 1894 pass, 0 fail
- [x] `npm run lint` — clean
- [x] New test: verifies `{ properties: { url } }` flattens to `{ url }` in the payload
- [x] New test: verifies `fullPage` and `threshold` are excluded from properties
- [x] Existing integration tests still pass (no breaking changes)