### PR TITLE
✨ Add explicit project targeting for build commands

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -115,7 +115,7 @@ export function createApiClient(options = {}) {
    * Check if refresh token is available
    */
   async function hasRefreshToken() {
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokens(baseUrl);
     return !!auth?.refreshToken;
   }
 
@@ -124,7 +124,7 @@ export function createApiClient(options = {}) {
    * @returns {Promise<string|null>} New token or null if refresh failed
    */
   async function attemptTokenRefresh() {
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokens(baseUrl);
     if (!auth?.refreshToken) return null;
 
     try {
@@ -143,12 +143,15 @@ export function createApiClient(options = {}) {
       let data = await response.json();
 
       // Save new tokens
-      await saveAuthTokens({
-        accessToken: data.accessToken,
-        refreshToken: data.refreshToken,
-        expiresAt: data.expiresAt,
-        user: auth.user,
-      });
+      await saveAuthTokens(
+        {
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+          expiresAt: data.expiresAt,
+          user: auth.user,
+        },
+        baseUrl
+      );
 
       return data.accessToken;
     } catch {

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -69,6 +69,15 @@ export function buildRequestHeaders({
 // Payload Construction
 // ============================================================================
 
+function cleanString(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  let trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
 /**
  * Build payload for screenshot upload
  * @param {string} name - Screenshot name
@@ -94,6 +103,43 @@ export function buildScreenshotPayload(
   }
 
   return payload;
+}
+
+/**
+ * Build payload for explicit project targeting
+ * @param {Object|null|undefined} target - Target options
+ * @returns {Object|null} Normalized target payload
+ */
+export function buildTargetPayload(target) {
+  if (!target || typeof target !== 'object' || Array.isArray(target)) {
+    return null;
+  }
+
+  let projectId = cleanString(
+    target.projectId || target.project_id || target.id
+  );
+  let organizationSlug = cleanString(
+    target.organizationSlug ||
+      target.organization_slug ||
+      target.organization?.slug ||
+      target.organization
+  );
+  let projectSlug = cleanString(
+    target.projectSlug ||
+      target.project_slug ||
+      target.project?.slug ||
+      target.project
+  );
+
+  if (projectId) {
+    return { projectId };
+  }
+
+  if (organizationSlug && projectSlug) {
+    return { organizationSlug, projectSlug };
+  }
+
+  return null;
 }
 
 /**

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -14,6 +14,7 @@ import {
   buildScreenshotCheckObject,
   buildScreenshotPayload,
   buildShaCheckPayload,
+  buildTargetPayload,
   computeSha256,
   findScreenshotBySha,
   shaExists,
@@ -58,10 +59,17 @@ export async function getBuilds(client, filters = {}) {
  */
 export async function createBuild(client, metadata) {
   let payload = buildBuildPayload(metadata);
+  let target = buildTargetPayload(metadata?.target);
+  let body = { build: payload };
+
+  if (target) {
+    body.target = target;
+  }
+
   return client.request('/api/sdk/builds', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ build: payload }),
+    body: JSON.stringify(body),
   });
 }
 
@@ -314,13 +322,22 @@ export async function getTokenContext(client) {
  * Finalize a parallel build
  * @param {Object} client - API client
  * @param {string} parallelId - Parallel ID to finalize
+ * @param {Object} [options] - Optional target metadata
  * @returns {Promise<Object>} Finalization result
  */
-export async function finalizeParallelBuild(client, parallelId) {
-  return client.request(`/api/sdk/parallel/${parallelId}/finalize`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  });
+export async function finalizeParallelBuild(client, parallelId, options = {}) {
+  let target = buildTargetPayload(options.target);
+  let requestOptions = { method: 'POST' };
+
+  if (target) {
+    requestOptions.headers = { 'Content-Type': 'application/json' };
+    requestOptions.body = JSON.stringify({ target });
+  }
+
+  return client.request(
+    `/api/sdk/parallel/${parallelId}/finalize`,
+    requestOptions
+  );
 }
 
 // ============================================================================

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -45,10 +45,10 @@ export {
  * Create a token store adapter from global-config functions
  * Used by auth operations that need tokenStore parameter
  */
-export function createTokenStore() {
+export function createTokenStore(apiUrl) {
   return {
-    getTokens: getAuthTokens,
-    saveTokens: saveAuthTokens,
-    clearTokens: clearAuthTokens,
+    getTokens: () => getAuthTokens(apiUrl),
+    saveTokens: tokens => saveAuthTokens(tokens, apiUrl),
+    clearTokens: () => clearAuthTokens(apiUrl),
   };
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -263,6 +263,7 @@ program
   .description('Vizzly CLI for visual regression testing')
   .version(getPackageVersion())
   .option('-c, --config <path>', 'Config file path')
+  .option('--api-url <url>', 'API URL override')
   .option('--token <token>', 'Vizzly API token')
   .option('-v, --verbose', 'Verbose output (shorthand for --log-level debug)')
   .option(
@@ -389,6 +390,9 @@ program
   .option('--commit <sha>', 'Git commit SHA')
   .option('--message <msg>', 'Commit message')
   .option('--environment <env>', 'Environment name', 'test')
+  .option('--org <slug>', 'Target organization slug')
+  .option('--project <slug>', 'Target project slug')
+  .option('--project-id <id>', 'Target project ID')
   .option('--threshold <number>', 'Comparison threshold', parseFloat)
   .option('--token <token>', 'API token override')
   .option('--wait', 'Wait for build completion')
@@ -565,6 +569,9 @@ program
   .option('--commit <sha>', 'Git commit SHA')
   .option('--message <msg>', 'Commit message')
   .option('--environment <env>', 'Environment name', 'test')
+  .option('--org <slug>', 'Target organization slug')
+  .option('--project <slug>', 'Target project slug')
+  .option('--project-id <id>', 'Target project ID')
   .option('--token <token>', 'API token override')
   .option('--wait', 'Wait for build completion')
   .option('--timeout <ms>', 'Server timeout in milliseconds', '30000')
@@ -997,6 +1004,9 @@ program
   .command('finalize')
   .description('Finalize a parallel build after all shards complete')
   .argument('<parallel-id>', 'Parallel ID to finalize')
+  .option('--org <slug>', 'Target organization slug')
+  .option('--project <slug>', 'Target project slug')
+  .option('--project-id <id>', 'Target project ID')
   .action(async (parallelId, options) => {
     const globalOptions = program.opts();
 
@@ -1019,6 +1029,9 @@ program
   .argument('[path]', 'Path to static files (dist/, build/, out/)')
   .option('-b, --build <id>', 'Build ID to attach preview to')
   .option('-p, --parallel-id <id>', 'Look up build by parallel ID')
+  .option('--org <slug>', 'Target organization slug')
+  .option('--project <slug>', 'Target project slug')
+  .option('--project-id <id>', 'Target project ID')
   .option('--base <path>', 'Override auto-detected base path')
   .option('--open', 'Open preview URL in browser after upload')
   .option('--dry-run', 'Show what would be uploaded without uploading')
@@ -1088,7 +1101,6 @@ program
 program
   .command('login')
   .description('Authenticate with your Vizzly account')
-  .option('--api-url <url>', 'API URL override')
   .action(async options => {
     const globalOptions = program.opts();
 
@@ -1108,7 +1120,6 @@ program
 program
   .command('logout')
   .description('Clear stored authentication tokens')
-  .option('--api-url <url>', 'API URL override')
   .action(async options => {
     const globalOptions = program.opts();
 
@@ -1128,7 +1139,6 @@ program
 program
   .command('whoami')
   .description('Show current authentication status and user information')
-  .option('--api-url <url>', 'API URL override')
   .action(async options => {
     const globalOptions = program.opts();
 

--- a/src/commands/config-cmd.js
+++ b/src/commands/config-cmd.js
@@ -40,6 +40,7 @@ export async function configCommand(
 
     // Build the config object to display
     let displayConfig = {
+      target: config.target || {},
       server: config.server || { port: 47392, timeout: 30000 },
       build: config.build || {},
       upload: config.upload || {},
@@ -109,6 +110,7 @@ export async function configCommand(
     displaySection(output, 'TDD', displayConfig.tdd);
 
     if (globalOptions.verbose) {
+      displaySection(output, 'Target', displayConfig.target);
       displaySection(output, 'Build', displayConfig.build);
       displaySection(output, 'Upload', displayConfig.upload);
 

--- a/src/commands/finalize.js
+++ b/src/commands/finalize.js
@@ -9,6 +9,10 @@ import {
 } from '../api/index.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import * as defaultOutput from '../utils/output.js';
+import {
+  resolveProjectTarget as defaultResolveProjectTarget,
+  validateTargetOptions,
+} from '../utils/project-target.js';
 import { writeSession as defaultWriteSession } from '../utils/session.js';
 
 let MISSING_BUILD_HINTS = [
@@ -34,6 +38,7 @@ export async function finalizeCommand(
     loadConfig = defaultLoadConfig,
     createApiClient = defaultCreateApiClient,
     finalizeParallelBuild = defaultFinalizeParallelBuild,
+    resolveProjectTarget = defaultResolveProjectTarget,
     output = defaultOutput,
     writeSession = defaultWriteSession,
     exit = code => process.exit(code),
@@ -59,6 +64,21 @@ export async function finalizeCommand(
       return { success: false, reason: 'no-api-key' };
     }
 
+    let resolvedTarget = await resolveProjectTarget({
+      command: 'finalize',
+      options,
+      config,
+      requireTarget: true,
+    });
+    if (resolvedTarget.target) {
+      config.target = resolvedTarget.target;
+    }
+    output.debug('target', {
+      command: 'finalize',
+      source: resolvedTarget.source,
+      target: resolvedTarget.target,
+    });
+
     if (globalOptions.verbose) {
       output.info('Configuration loaded');
       output.debug('Config details', {
@@ -74,7 +94,9 @@ export async function finalizeCommand(
       token: config.apiKey,
       command: 'finalize',
     });
-    let result = await finalizeParallelBuild(client, parallelId);
+    let result = await finalizeParallelBuild(client, parallelId, {
+      target: config.target,
+    });
     output.stopSpinner();
 
     // Write session for subsequent commands (like preview)
@@ -166,6 +188,8 @@ export function validateFinalizeOptions(parallelId, _options) {
   if (!parallelId || parallelId.trim() === '') {
     errors.push('Parallel ID is required');
   }
+
+  errors.push(...validateTargetOptions(_options));
 
   return errors;
 }

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -31,11 +31,13 @@ export async function loginCommand(options = {}, globalOptions = {}) {
   try {
     output.header('login');
 
+    let apiUrl = globalOptions.apiUrl || options.apiUrl || getApiUrl();
+
     // Create auth client and token store
     let client = createAuthClient({
-      baseUrl: options.apiUrl || getApiUrl(),
+      baseUrl: apiUrl,
     });
-    let tokenStore = createTokenStore();
+    let tokenStore = createTokenStore(apiUrl);
 
     // Initiate device flow
     output.startSpinner('Connecting to Vizzly...');

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -17,54 +17,69 @@ import * as output from '../utils/output.js';
  * @param {Object} options - Command options
  * @param {Object} globalOptions - Global CLI options
  */
-export async function logoutCommand(options = {}, globalOptions = {}) {
-  output.configure({
+export async function logoutCommand(
+  options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    createAuthClient: createAuthClientImpl = createAuthClient,
+    createTokenStore: createTokenStoreImpl = createTokenStore,
+    getAuthTokens: getAuthTokensImpl = getAuthTokens,
+    logout: logoutImpl = logout,
+    output: outputImpl = output,
+    exit = code => process.exit(code),
+  } = deps;
+
+  outputImpl.configure({
     json: globalOptions.json,
     verbose: globalOptions.verbose,
     color: !globalOptions.noColor,
   });
 
   try {
+    let apiUrl = globalOptions.apiUrl || options.apiUrl || getApiUrl();
+
     // Check if user is logged in
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokensImpl(apiUrl);
 
     if (!auth || !auth.accessToken) {
       if (globalOptions.json) {
-        output.data({ loggedOut: false, reason: 'not_logged_in' });
+        outputImpl.data({ loggedOut: false, reason: 'not_logged_in' });
       } else {
-        output.header('logout');
-        output.print('  Not logged in');
+        outputImpl.header('logout');
+        outputImpl.print('  Not logged in');
       }
-      output.cleanup();
+      outputImpl.cleanup();
       return;
     }
 
     // Logout
-    output.startSpinner('Logging out...');
+    outputImpl.startSpinner('Logging out...');
 
-    let client = createAuthClient({
-      baseUrl: options.apiUrl || getApiUrl(),
+    let client = createAuthClientImpl({
+      baseUrl: apiUrl,
     });
-    let tokenStore = createTokenStore();
+    let tokenStore = createTokenStoreImpl(apiUrl);
 
-    await logout(client, tokenStore);
+    await logoutImpl(client, tokenStore);
 
-    output.stopSpinner();
+    outputImpl.stopSpinner();
 
     if (globalOptions.json) {
-      output.data({ loggedOut: true });
+      outputImpl.data({ loggedOut: true });
     } else {
-      output.header('logout');
-      output.complete('Logged out');
-      output.blank();
-      output.hint('Run "vizzly login" to authenticate again');
+      outputImpl.header('logout');
+      outputImpl.complete('Logged out');
+      outputImpl.blank();
+      outputImpl.hint('Run "vizzly login" to authenticate again');
     }
 
-    output.cleanup();
+    outputImpl.cleanup();
   } catch (error) {
-    output.stopSpinner();
-    output.error('Logout failed', error);
-    process.exit(1);
+    outputImpl.stopSpinner();
+    outputImpl.error('Logout failed', error);
+    exit(1);
   }
 }
 

--- a/src/commands/orgs.js
+++ b/src/commands/orgs.js
@@ -39,7 +39,8 @@ export async function orgsCommand(
 
     // Prefer user auth token for listing orgs (project tokens are org-scoped).
     // Falls back to config.apiKey which may be: VIZZLY_TOKEN, --token flag, or project token.
-    let token = (await getAccessToken()) || config.apiKey;
+    let token =
+      (await getAccessToken(config.apiUrl || getApiUrl())) || config.apiKey;
 
     if (!token) {
       output.error(

--- a/src/commands/preview.js
+++ b/src/commands/preview.js
@@ -15,12 +15,17 @@ import { promisify } from 'node:util';
 import {
   createApiClient as defaultCreateApiClient,
   getBuild as defaultGetBuild,
+  getBuilds as defaultGetBuilds,
   uploadPreviewZip as defaultUploadPreviewZip,
 } from '../api/index.js';
 import { openBrowser as defaultOpenBrowser } from '../utils/browser.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import { detectBranch as defaultDetectBranch } from '../utils/git.js';
 import * as defaultOutput from '../utils/output.js';
+import {
+  resolveProjectTarget as defaultResolveProjectTarget,
+  validateTargetOptions,
+} from '../utils/project-target.js';
 import {
   formatSessionAge as defaultFormatSessionAge,
   readSession as defaultReadSession,
@@ -321,6 +326,50 @@ function formatBytes(bytes) {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
+function buildParallelLookupFilters(parallelId, target = null) {
+  let filters = {
+    limit: 20,
+    parallelId,
+  };
+
+  if (target?.projectId) {
+    filters.projectId = target.projectId;
+    return filters;
+  }
+
+  if (target?.organizationSlug) {
+    filters.organization = target.organizationSlug;
+  }
+
+  if (target?.projectSlug) {
+    filters.project = target.projectSlug;
+  }
+
+  return filters;
+}
+
+function extractBuildList(response) {
+  if (Array.isArray(response)) {
+    return response;
+  }
+
+  return response?.builds || [];
+}
+
+function findBuildByParallelId(builds, parallelId) {
+  let matches = builds.filter(build => build.parallel_id === parallelId);
+
+  if (matches.length === 1) {
+    return { build: matches[0], ambiguous: false };
+  }
+
+  if (matches.length > 1) {
+    return { build: null, ambiguous: true };
+  }
+
+  return { build: null, ambiguous: false };
+}
+
 /**
  * Preview command implementation
  * @param {string} path - Path to static files
@@ -338,10 +387,12 @@ export async function previewCommand(
     loadConfig = defaultLoadConfig,
     createApiClient = defaultCreateApiClient,
     getBuild = defaultGetBuild,
+    getBuilds = defaultGetBuilds,
     uploadPreviewZip = defaultUploadPreviewZip,
     readSession = defaultReadSession,
     formatSessionAge = defaultFormatSessionAge,
     detectBranch = defaultDetectBranch,
+    resolveProjectTarget = defaultResolveProjectTarget,
     openBrowser = defaultOpenBrowser,
     output = defaultOutput,
     exit = code => process.exit(code),
@@ -357,6 +408,11 @@ export async function previewCommand(
     // Load configuration
     let allOptions = { ...globalOptions, ...options };
     let config = await loadConfig(globalOptions.config, allOptions);
+    let requiresParallelTarget =
+      !options.dryRun &&
+      Boolean(config.apiKey) &&
+      !options.build &&
+      Boolean(options.parallelId);
 
     // Validate API token (skip for dry-run)
     if (!options.dryRun && !config.apiKey) {
@@ -365,6 +421,23 @@ export async function previewCommand(
       );
       exit(1);
       return { success: false, reason: 'no-api-key' };
+    }
+
+    if (!options.dryRun && config.apiKey) {
+      let resolvedTarget = await resolveProjectTarget({
+        command: 'preview',
+        options,
+        config,
+        requireTarget: requiresParallelTarget,
+      });
+      if (resolvedTarget?.target) {
+        config.target = resolvedTarget.target;
+      }
+      output.debug('target', {
+        command: 'preview',
+        source: resolvedTarget?.source,
+        target: resolvedTarget?.target,
+      });
     }
 
     // Validate path exists and is a directory
@@ -384,20 +457,68 @@ export async function previewCommand(
     // Resolve build ID
     let buildId = options.build;
     let buildSource = 'flag';
+    let currentBranch = null;
+    let session = null;
 
     if (!buildId && options.parallelId) {
-      // TODO: Look up build by parallel ID
-      output.error(
-        'Parallel ID lookup not yet implemented. Use --build to specify build ID directly.'
-      );
-      exit(1);
-      return { success: false, reason: 'parallel-id-not-implemented' };
+      currentBranch = await detectBranch();
+      session = readSession({ currentBranch });
+
+      if (
+        session?.buildId &&
+        !session.expired &&
+        session.parallelId === options.parallelId
+      ) {
+        buildId = session.buildId;
+        buildSource = `${session.source}:parallel-id`;
+      } else if (!options.dryRun) {
+        let client = createApiClient({
+          baseUrl: config.apiUrl,
+          token: config.apiKey,
+          command: 'preview',
+        });
+        let response = await getBuilds(
+          client,
+          buildParallelLookupFilters(options.parallelId, config.target)
+        );
+        let lookupResult = findBuildByParallelId(
+          extractBuildList(response),
+          options.parallelId
+        );
+
+        if (lookupResult.ambiguous) {
+          output.error(
+            `Multiple builds found for parallel ID: ${options.parallelId}`
+          );
+          output.hint(
+            'Pass a more specific target project or use --build to choose a build directly.'
+          );
+          exit(1);
+          return { success: false, reason: 'parallel-id-ambiguous' };
+        }
+
+        if (lookupResult.build) {
+          buildId = lookupResult.build.id;
+          buildSource = 'parallel-id';
+        } else {
+          output.error(`No build found for parallel ID: ${options.parallelId}`);
+          output.hint(
+            'Run visual tests first, or pass --build to attach a preview to a known build.'
+          );
+          exit(1);
+          return { success: false, reason: 'no-build-for-parallel-id' };
+        }
+      }
     }
 
     if (!buildId) {
       // Try to read from session
-      let currentBranch = await detectBranch();
-      let session = readSession({ currentBranch });
+      if (!currentBranch) {
+        currentBranch = await detectBranch();
+      }
+      if (!session) {
+        session = readSession({ currentBranch });
+      }
 
       if (session?.buildId && !session.expired) {
         if (session.branchMismatch) {
@@ -753,12 +874,14 @@ export async function previewCommand(
  * @param {string} path - Path to static files
  * @param {Object} options - Command options
  */
-export function validatePreviewOptions(path, _options) {
+export function validatePreviewOptions(path, options) {
   let errors = [];
 
   if (!path || path.trim() === '') {
     errors.push('Path to static files is required');
   }
+
+  errors.push(...validateTargetOptions(options));
 
   return errors;
 }

--- a/src/commands/projects.js
+++ b/src/commands/projects.js
@@ -39,7 +39,8 @@ export async function projectsCommand(
 
     // Prefer user auth token for listing projects (project tokens are org-scoped).
     // Falls back to config.apiKey which may be: VIZZLY_TOKEN, --token flag, or project token.
-    let token = (await getAccessToken()) || config.apiKey;
+    let token =
+      (await getAccessToken(config.apiUrl || getApiUrl())) || config.apiKey;
 
     if (!token) {
       output.error(

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -28,6 +28,10 @@ import {
   generateBuildNameWithGit as defaultGenerateBuildNameWithGit,
 } from '../utils/git.js';
 import * as defaultOutput from '../utils/output.js';
+import {
+  resolveProjectTarget as defaultResolveProjectTarget,
+  validateTargetOptions,
+} from '../utils/project-target.js';
 import { writeSession as defaultWriteSession } from '../utils/session.js';
 
 /**
@@ -60,6 +64,7 @@ export async function runCommand(
     detectCommitMessage = defaultDetectCommitMessage,
     detectPullRequestNumber = defaultDetectPullRequestNumber,
     generateBuildNameWithGit = defaultGenerateBuildNameWithGit,
+    resolveProjectTarget = defaultResolveProjectTarget,
     spawn = defaultSpawn,
     output = defaultOutput,
     writeSession = defaultWriteSession,
@@ -173,6 +178,22 @@ export async function runCommand(
       return { success: false, reason: 'no-api-key' };
     }
 
+    if (config.apiKey) {
+      let resolvedTarget = await resolveProjectTarget({
+        command: 'run',
+        options,
+        config,
+      });
+      if (resolvedTarget.target) {
+        config.target = resolvedTarget.target;
+      }
+      output.debug('target', {
+        command: 'run',
+        source: resolvedTarget.source,
+        target: resolvedTarget.target,
+      });
+    }
+
     // Collect git metadata and build info
     let branch = await detectBranch(options.branch);
     let commit = await detectCommit(options.commit);
@@ -245,6 +266,7 @@ export async function runCommand(
       uploadAll: options.uploadAll || false,
       pullRequestNumber,
       parallelId: config.parallelId,
+      target: config.target,
     };
 
     // Start test run
@@ -599,6 +621,8 @@ export function validateRunOptions(testCommand, options) {
       errors.push('Upload timeout must be a positive integer (milliseconds)');
     }
   }
+
+  errors.push(...validateTargetOptions(options));
 
   return errors;
 }

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -13,6 +13,10 @@ import {
   generateBuildNameWithGit as defaultGenerateBuildNameWithGit,
 } from '../utils/git.js';
 import * as defaultOutput from '../utils/output.js';
+import {
+  resolveProjectTarget as defaultResolveProjectTarget,
+  validateTargetOptions,
+} from '../utils/project-target.js';
 import { writeSession as defaultWriteSession } from '../utils/session.js';
 
 /**
@@ -78,6 +82,7 @@ export async function uploadCommand(
     detectCommitMessage = defaultDetectCommitMessage,
     detectPullRequestNumber = defaultDetectPullRequestNumber,
     generateBuildNameWithGit = defaultGenerateBuildNameWithGit,
+    resolveProjectTarget = defaultResolveProjectTarget,
     output = defaultOutput,
     writeSession = defaultWriteSession,
     exit = code => process.exit(code),
@@ -109,6 +114,20 @@ export async function uploadCommand(
       exit(1);
       return { success: false, reason: 'no-api-key' };
     }
+
+    let resolvedTarget = await resolveProjectTarget({
+      command: 'upload',
+      options,
+      config,
+    });
+    if (resolvedTarget.target) {
+      config.target = resolvedTarget.target;
+    }
+    output.debug('target', {
+      command: 'upload',
+      source: resolvedTarget.source,
+      target: resolvedTarget.target,
+    });
 
     // Collect git metadata if not provided
     const branch = await detectBranch(options.branch);
@@ -145,6 +164,7 @@ export async function uploadCommand(
       metadata: options.metadata ? JSON.parse(options.metadata) : {},
       pullRequestNumber,
       parallelId: config.parallelId,
+      target: config.target,
       onProgress: progressData => {
         const {
           message: progressMessage,
@@ -443,6 +463,8 @@ export function validateUploadOptions(screenshotsPath, options) {
       errors.push('Upload timeout must be a positive integer (milliseconds)');
     }
   }
+
+  errors.push(...validateTargetOptions(options));
 
   return errors;
 }

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -17,56 +17,71 @@ import * as output from '../utils/output.js';
  * @param {Object} options - Command options
  * @param {Object} globalOptions - Global CLI options
  */
-export async function whoamiCommand(options = {}, globalOptions = {}) {
-  output.configure({
+export async function whoamiCommand(
+  options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    createAuthClient: createAuthClientImpl = createAuthClient,
+    createTokenStore: createTokenStoreImpl = createTokenStore,
+    getAuthTokens: getAuthTokensImpl = getAuthTokens,
+    whoami: whoamiImpl = whoami,
+    output: outputImpl = output,
+    exit = code => process.exit(code),
+  } = deps;
+
+  outputImpl.configure({
     json: globalOptions.json,
     verbose: globalOptions.verbose,
     color: !globalOptions.noColor,
   });
 
   try {
+    let apiUrl = globalOptions.apiUrl || options.apiUrl || getApiUrl();
+
     // Check if user is logged in
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokensImpl(apiUrl);
 
     if (!auth || !auth.accessToken) {
       if (globalOptions.json) {
-        output.data({ authenticated: false });
+        outputImpl.data({ authenticated: false });
       } else {
-        output.header('whoami');
-        output.print('  Not logged in');
-        output.blank();
-        output.hint('Run "vizzly login" to authenticate');
+        outputImpl.header('whoami');
+        outputImpl.print('  Not logged in');
+        outputImpl.blank();
+        outputImpl.hint('Run "vizzly login" to authenticate');
       }
-      output.cleanup();
+      outputImpl.cleanup();
       return;
     }
 
     // Get current user info
-    output.startSpinner('Fetching user information...');
+    outputImpl.startSpinner('Fetching user information...');
 
-    let client = createAuthClient({
-      baseUrl: options.apiUrl || getApiUrl(),
+    let client = createAuthClientImpl({
+      baseUrl: apiUrl,
     });
-    let tokenStore = createTokenStore();
+    let tokenStore = createTokenStoreImpl(apiUrl);
 
-    let response = await whoami(client, tokenStore);
+    let response = await whoamiImpl(client, tokenStore);
 
-    output.stopSpinner();
+    outputImpl.stopSpinner();
 
     // Output in JSON mode
     if (globalOptions.json) {
-      output.data({
+      outputImpl.data({
         authenticated: true,
         user: response.user,
         organizations: response.organizations || [],
         tokenExpiresAt: auth.expiresAt,
       });
-      output.cleanup();
+      outputImpl.cleanup();
       return;
     }
 
     // Human-readable output
-    output.header('whoami');
+    outputImpl.header('whoami');
 
     // Show user info using keyValue
     if (response.user) {
@@ -83,25 +98,25 @@ export async function whoamiCommand(options = {}, globalOptions = {}) {
         userInfo['User ID'] = response.user.id;
       }
 
-      output.keyValue(userInfo);
+      outputImpl.keyValue(userInfo);
     }
 
     // Show organizations as a list
     if (response.organizations && response.organizations.length > 0) {
-      output.blank();
-      output.labelValue('Organizations', '');
+      outputImpl.blank();
+      outputImpl.labelValue('Organizations', '');
       let orgItems = response.organizations.map(org => {
         let parts = [org.name];
         if (org.slug) parts.push(`@${org.slug}`);
         if (org.role) parts.push(`[${org.role}]`);
         return parts.join(' ');
       });
-      output.list(orgItems);
+      outputImpl.list(orgItems);
 
       if (globalOptions.verbose) {
         for (let org of response.organizations) {
           if (org.id) {
-            output.hint(`  ${org.name} ID: ${org.id}`);
+            outputImpl.hint(`  ${org.name} ID: ${org.id}`);
           }
         }
       }
@@ -109,7 +124,7 @@ export async function whoamiCommand(options = {}, globalOptions = {}) {
 
     // Show token expiry info
     if (auth.expiresAt) {
-      output.blank();
+      outputImpl.blank();
       let expiresAt = new Date(auth.expiresAt);
       let now = new Date();
       let msUntilExpiry = expiresAt.getTime() - now.getTime();
@@ -118,51 +133,51 @@ export async function whoamiCommand(options = {}, globalOptions = {}) {
       let minutesUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60));
 
       if (msUntilExpiry <= 0) {
-        output.warn('Token has expired');
-        output.hint('Run "vizzly login" to refresh your authentication');
+        outputImpl.warn('Token has expired');
+        outputImpl.hint('Run "vizzly login" to refresh your authentication');
       } else if (daysUntilExpiry > 0) {
-        output.hint(
+        outputImpl.hint(
           `Token expires in ${daysUntilExpiry} day${daysUntilExpiry !== 1 ? 's' : ''} (${expiresAt.toLocaleDateString()})`
         );
       } else if (hoursUntilExpiry > 0) {
-        output.hint(
+        outputImpl.hint(
           `Token expires in ${hoursUntilExpiry} hour${hoursUntilExpiry !== 1 ? 's' : ''}`
         );
       } else if (minutesUntilExpiry > 0) {
-        output.hint(
+        outputImpl.hint(
           `Token expires in ${minutesUntilExpiry} minute${minutesUntilExpiry !== 1 ? 's' : ''}`
         );
       } else {
-        output.warn('Token expires in less than a minute');
-        output.hint('Run "vizzly login" to refresh your authentication');
+        outputImpl.warn('Token expires in less than a minute');
+        outputImpl.hint('Run "vizzly login" to refresh your authentication');
       }
 
       if (globalOptions.verbose) {
-        output.hint(`Token expires at: ${expiresAt.toISOString()}`);
+        outputImpl.hint(`Token expires at: ${expiresAt.toISOString()}`);
       }
     }
 
-    output.cleanup();
+    outputImpl.cleanup();
   } catch (error) {
-    output.stopSpinner();
+    outputImpl.stopSpinner();
 
     // Handle authentication errors with helpful messages
     if (error.name === 'AuthError') {
       if (globalOptions.json) {
-        output.data({
+        outputImpl.data({
           authenticated: false,
           error: error.message,
         });
       } else {
-        output.error('Authentication token is invalid or expired', error);
-        output.blank();
-        output.hint('Run "vizzly login" to authenticate again');
+        outputImpl.error('Authentication token is invalid or expired', error);
+        outputImpl.blank();
+        outputImpl.hint('Run "vizzly login" to authenticate again');
       }
-      output.cleanup();
-      process.exit(1);
+      outputImpl.cleanup();
+      exit(1);
     } else {
-      output.error('Failed to get user information', error);
-      process.exit(1);
+      outputImpl.error('Failed to get user information', error);
+      exit(1);
     }
   }
 }

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -45,9 +45,9 @@ export function createAuthService(options = {}) {
   // Create token store adapter for global config
   // Allow injection for testing
   let tokenStore = options.tokenStore || {
-    getTokens: getAuthTokens,
-    saveTokens: saveAuthTokens,
-    clearTokens: clearAuthTokens,
+    getTokens: () => getAuthTokens(apiUrl),
+    saveTokens: tokens => saveAuthTokens(tokens, apiUrl),
+    clearTokens: () => clearAuthTokens(apiUrl),
   };
 
   return {

--- a/src/services/project-service.js
+++ b/src/services/project-service.js
@@ -31,7 +31,7 @@ export function createProjectService(options = {}) {
   let httpClient = options.httpClient || createAuthClient({ baseUrl: apiUrl });
 
   // Allow injection of getAuthTokens for testing
-  let tokenGetter = options.getAuthTokens || getAuthTokens;
+  let tokenGetter = options.getAuthTokens || (() => getAuthTokens(apiUrl));
 
   /**
    * Create an OAuth client with current access token

--- a/src/test-runner/core.js
+++ b/src/test-runner/core.js
@@ -78,6 +78,10 @@ export function buildApiBuildPayload(options, comparisonConfig = null) {
     };
   }
 
+  if (options.target) {
+    payload.target = options.target;
+  }
+
   return payload;
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -46,9 +46,16 @@ export interface TddConfig {
   openReport?: boolean;
 }
 
+export interface TargetConfig {
+  organizationSlug?: string;
+  projectSlug?: string;
+  projectId?: string;
+}
+
 export interface VizzlyConfig {
   apiKey?: string;
   apiUrl?: string;
+  target?: TargetConfig;
   server?: ServerConfig;
   build?: BuildConfig;
   upload?: UploadConfig;
@@ -150,6 +157,7 @@ export interface UploadOptions {
   threshold?: number;
   pullRequestNumber?: string;
   parallelId?: string;
+  target?: TargetConfig;
   onProgress?: (progress: UploadProgress) => void;
 }
 
@@ -419,6 +427,7 @@ export interface BuildOptions {
   uploadAll?: boolean;
   pullRequestNumber?: string;
   parallelId?: string;
+  target?: TargetConfig;
 }
 
 /**

--- a/src/uploader/core.js
+++ b/src/uploader/core.js
@@ -107,7 +107,7 @@ export function extractBrowserFromFilename(filename) {
  * @returns {Object} Build info payload
  */
 export function buildBuildInfo(options, defaultBranch = 'main') {
-  return {
+  let buildInfo = {
     name: options.buildName || `Upload ${new Date().toISOString()}`,
     branch: options.branch || defaultBranch || 'main',
     commit_sha: options.commit,
@@ -117,6 +117,12 @@ export function buildBuildInfo(options, defaultBranch = 'main') {
     github_pull_request_number: options.pullRequestNumber,
     parallel_id: options.parallelId,
   };
+
+  if (options.target) {
+    buildInfo.target = options.target;
+  }
+
+  return buildInfo;
 }
 
 // ============================================================================

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path';
 import { cosmiconfigSync } from 'cosmiconfig';
+import { DEFAULT_API_URL } from '../api/client.js';
 import { validateVizzlyConfigWithDefaults } from './config-schema.js';
 import {
   getApiToken,
@@ -13,7 +14,7 @@ import * as output from './output.js';
 const DEFAULT_CONFIG = {
   // API Configuration
   apiKey: undefined, // Will be set from env, global config, or CLI overrides
-  apiUrl: getApiUrl(),
+  apiUrl: DEFAULT_API_URL,
 
   // Server Configuration (for run command)
   server: {
@@ -86,7 +87,7 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
     config.apiKey = envApiKey;
     output.debug('config', 'using token from environment');
   }
-  if (envApiUrl !== 'https://app.vizzly.dev') config.apiUrl = envApiUrl;
+  if (process.env.VIZZLY_API_URL !== undefined) config.apiUrl = envApiUrl;
   if (envBuildName) {
     config.build.name = envBuildName;
     output.debug('config', 'using build name from environment');
@@ -104,7 +105,7 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
   // This enables interactive commands (builds, comparisons, approve, etc.)
   // to work without a project token when the user is logged in
   if (!config.apiKey) {
-    let userToken = await getAccessToken();
+    let userToken = await getAccessToken(config.apiUrl);
     if (userToken) {
       config.apiKey = userToken;
       output.debug('config', 'using token from user login');
@@ -122,6 +123,7 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
 function applyCLIOverrides(config, cliOverrides = {}) {
   // Global overrides
   if (cliOverrides.token) config.apiKey = cliOverrides.token;
+  if (cliOverrides.apiUrl) config.apiUrl = cliOverrides.apiUrl;
 
   // Build-related overrides
   if (cliOverrides.buildName) config.build.name = cliOverrides.buildName;

--- a/src/utils/config-schema.js
+++ b/src/utils/config-schema.js
@@ -52,6 +52,29 @@ const tddSchema = z.object({
   openReport: z.boolean().default(false),
 });
 
+const targetSchema = z
+  .object({
+    organizationSlug: z.string().trim().min(1).optional(),
+    projectSlug: z.string().trim().min(1).optional(),
+    projectId: z.string().trim().min(1).optional(),
+  })
+  .superRefine((target, ctx) => {
+    if (target.projectId) {
+      return;
+    }
+
+    let hasOrganizationSlug = Boolean(target.organizationSlug);
+    let hasProjectSlug = Boolean(target.projectSlug);
+
+    if (hasOrganizationSlug !== hasProjectSlug) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'target.organizationSlug and target.projectSlug must be provided together unless target.projectId is set',
+      });
+    }
+  });
+
 /**
  * Core Vizzly configuration schema
  * Allows plugin-specific keys with passthrough for extensibility
@@ -61,6 +84,7 @@ export const vizzlyConfigSchema = z
     // Core Vizzly config
     apiKey: z.string().optional(),
     apiUrl: z.string().url().optional(),
+    target: targetSchema.optional(),
     server: serverSchema.default({ port: 47392, timeout: 30000 }),
     build: buildSchema.default({
       name: 'Build {timestamp}',

--- a/src/utils/global-config.js
+++ b/src/utils/global-config.js
@@ -4,10 +4,18 @@
  */
 
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  readFile,
+  rename,
+  writeFile,
+} from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as output from './output.js';
+
+let DEFAULT_AUTH_API_URL = 'https://app.vizzly.dev';
 
 /**
  * Get the path to the global Vizzly directory
@@ -74,21 +82,24 @@ export async function loadGlobalConfig() {
 export async function saveGlobalConfig(config) {
   await ensureGlobalConfigDir();
 
-  const configPath = getGlobalConfigPath();
-  const content = JSON.stringify(config, null, 2);
+  let configPath = getGlobalConfigPath();
+  let content = JSON.stringify(config, null, 2);
+  let tempPath = `${configPath}.${process.pid}.${Date.now()}.tmp`;
 
-  // Write file with secure permissions (owner read/write only)
-  await writeFile(configPath, content, { mode: 0o600 });
+  // Write atomically so concurrent readers never observe a truncated file.
+  await writeFile(tempPath, content, { mode: 0o600 });
 
   // Ensure permissions are set correctly (in case umask interfered)
   try {
-    await chmod(configPath, 0o600);
+    await chmod(tempPath, 0o600);
   } catch (error) {
     // On Windows, chmod may not work as expected, but that's okay
     if (process.platform !== 'win32') {
       throw error;
     }
   }
+
+  await rename(tempPath, configPath);
 }
 
 /**
@@ -97,6 +108,47 @@ export async function saveGlobalConfig(config) {
  */
 export async function clearGlobalConfig() {
   await saveGlobalConfig({});
+}
+
+export function normalizeApiUrl(apiUrl = DEFAULT_AUTH_API_URL) {
+  let parsedUrl = new URL(apiUrl || DEFAULT_AUTH_API_URL);
+  let pathname = parsedUrl.pathname.replace(/\/+$/, '');
+
+  if (pathname === '/') {
+    pathname = '';
+  }
+
+  return `${parsedUrl.origin}${pathname}`;
+}
+
+function migrateLegacyAuthConfig(config) {
+  let migratedConfig = { ...config };
+  let defaultApiUrl = normalizeApiUrl(DEFAULT_AUTH_API_URL);
+
+  if (migratedConfig.auth?.accessToken) {
+    migratedConfig.authByApiUrl = {
+      ...(migratedConfig.authByApiUrl || {}),
+    };
+
+    if (!migratedConfig.authByApiUrl[defaultApiUrl]) {
+      migratedConfig.authByApiUrl[defaultApiUrl] = migratedConfig.auth;
+    }
+  }
+
+  delete migratedConfig.auth;
+
+  return migratedConfig;
+}
+
+async function loadMigratedGlobalConfig(persist = false) {
+  let config = await loadGlobalConfig();
+  let migratedConfig = migrateLegacyAuthConfig(config);
+
+  if (persist && JSON.stringify(migratedConfig) !== JSON.stringify(config)) {
+    await saveGlobalConfig(migratedConfig);
+  }
+
+  return migratedConfig;
 }
 
 /**
@@ -128,31 +180,39 @@ export async function getUserPath() {
 
 /**
  * Get authentication tokens from global config
+ * @param {string} [apiUrl] - API URL scope (defaults to cloud)
  * @returns {Promise<Object|null>} Token object with accessToken, refreshToken, expiresAt, user, or null if not found
  */
-export async function getAuthTokens() {
-  const config = await loadGlobalConfig();
+export async function getAuthTokens(apiUrl = DEFAULT_AUTH_API_URL) {
+  let config = await loadMigratedGlobalConfig(true);
+  let normalizedApiUrl = normalizeApiUrl(apiUrl);
+  let auth = config.authByApiUrl?.[normalizedApiUrl];
 
-  if (!config.auth || !config.auth.accessToken) {
+  if (!auth || !auth.accessToken) {
     return null;
   }
 
-  return config.auth;
+  return auth;
 }
 
 /**
  * Save authentication tokens to global config
  * @param {Object} auth - Auth object with accessToken, refreshToken, expiresAt, user
+ * @param {string} [apiUrl] - API URL scope (defaults to cloud)
  * @returns {Promise<void>}
  */
-export async function saveAuthTokens(auth) {
-  const config = await loadGlobalConfig();
+export async function saveAuthTokens(auth, apiUrl = DEFAULT_AUTH_API_URL) {
+  let config = await loadMigratedGlobalConfig();
+  let normalizedApiUrl = normalizeApiUrl(apiUrl);
 
-  config.auth = {
-    accessToken: auth.accessToken,
-    refreshToken: auth.refreshToken,
-    expiresAt: auth.expiresAt,
-    user: auth.user,
+  config.authByApiUrl = {
+    ...(config.authByApiUrl || {}),
+    [normalizedApiUrl]: {
+      accessToken: auth.accessToken,
+      refreshToken: auth.refreshToken,
+      expiresAt: auth.expiresAt,
+      user: auth.user,
+    },
   };
 
   await saveGlobalConfig(config);
@@ -160,20 +220,31 @@ export async function saveAuthTokens(auth) {
 
 /**
  * Clear authentication tokens from global config
+ * @param {string} [apiUrl] - API URL scope (defaults to cloud)
  * @returns {Promise<void>}
  */
-export async function clearAuthTokens() {
-  const config = await loadGlobalConfig();
-  delete config.auth;
+export async function clearAuthTokens(apiUrl = DEFAULT_AUTH_API_URL) {
+  let config = await loadMigratedGlobalConfig();
+  let normalizedApiUrl = normalizeApiUrl(apiUrl);
+
+  if (config.authByApiUrl) {
+    delete config.authByApiUrl[normalizedApiUrl];
+
+    if (Object.keys(config.authByApiUrl).length === 0) {
+      delete config.authByApiUrl;
+    }
+  }
+
   await saveGlobalConfig(config);
 }
 
 /**
  * Check if authentication tokens exist and are not expired
+ * @param {string} [apiUrl] - API URL scope (defaults to cloud)
  * @returns {Promise<boolean>} True if valid tokens exist
  */
-export async function hasValidTokens() {
-  const auth = await getAuthTokens();
+export async function hasValidTokens(apiUrl = DEFAULT_AUTH_API_URL) {
+  let auth = await getAuthTokens(apiUrl);
 
   if (!auth || !auth.accessToken) {
     return false;
@@ -196,12 +267,13 @@ export async function hasValidTokens() {
 
 /**
  * Get the access token from global config if valid and not expired
+ * @param {string} [apiUrl] - API URL scope (defaults to cloud)
  * @returns {Promise<string|null>} Access token or null
  */
-export async function getAccessToken() {
-  let valid = await hasValidTokens();
+export async function getAccessToken(apiUrl = DEFAULT_AUTH_API_URL) {
+  let valid = await hasValidTokens(apiUrl);
   if (!valid) return null;
 
-  let auth = await getAuthTokens();
+  let auth = await getAuthTokens(apiUrl);
   return auth?.accessToken || null;
 }

--- a/src/utils/project-target.js
+++ b/src/utils/project-target.js
@@ -1,0 +1,146 @@
+import { ValidationError } from '../errors/vizzly-error.js';
+
+export let MISSING_TARGET_MESSAGE =
+  'This command needs a target project. Pass --org and --project, use --project-id, or add target to vizzly.config.js.';
+
+function cleanString(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  let trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+function extractExplicitTarget(options = {}) {
+  let projectId = cleanString(options.projectId);
+  let organizationSlug = cleanString(options.org);
+  let projectSlug = cleanString(options.project);
+
+  if (projectId) {
+    return { projectId };
+  }
+
+  if (organizationSlug && projectSlug) {
+    return { organizationSlug, projectSlug };
+  }
+
+  return null;
+}
+
+export function isProjectToken(apiKey) {
+  return typeof apiKey === 'string' && apiKey.startsWith('vzt_');
+}
+
+export function validateTargetOptions(options = {}) {
+  let errors = [];
+  let projectId = cleanString(options.projectId);
+  let organizationSlug = cleanString(options.org);
+  let projectSlug = cleanString(options.project);
+
+  if (projectId) {
+    return errors;
+  }
+
+  if (projectSlug && !organizationSlug) {
+    errors.push(
+      '--project requires --org. Pass both --org and --project, or use --project-id.'
+    );
+  }
+
+  if (organizationSlug && !projectSlug) {
+    errors.push(
+      '--org requires --project. Pass both --org and --project, or use --project-id.'
+    );
+  }
+
+  return errors;
+}
+
+export function normalizeTarget(target = {}) {
+  if (!target || typeof target !== 'object') {
+    return null;
+  }
+
+  let projectId = cleanString(target.projectId || target.id);
+  let organizationSlug = cleanString(
+    target.organizationSlug || target.organization?.slug || target.organization
+  );
+  let projectSlug = cleanString(
+    target.projectSlug || target.project?.slug || target.project
+  );
+
+  if (projectId) {
+    return { projectId };
+  }
+
+  if (organizationSlug && projectSlug) {
+    return { organizationSlug, projectSlug };
+  }
+
+  return null;
+}
+
+export function resolveTargetFromSources({
+  options = {},
+  configTarget = null,
+  tokenContext = null,
+} = {}) {
+  let explicitTarget = extractExplicitTarget(options);
+  if (explicitTarget) {
+    return {
+      source: explicitTarget.projectId ? 'flag:project-id' : 'flag:slug',
+      target: explicitTarget,
+    };
+  }
+
+  let normalizedConfigTarget = normalizeTarget(configTarget);
+  if (normalizedConfigTarget) {
+    return { source: 'config', target: normalizedConfigTarget };
+  }
+
+  let normalizedTokenTarget = normalizeTarget(tokenContext);
+  if (normalizedTokenTarget) {
+    return { source: 'token-context', target: normalizedTokenTarget };
+  }
+
+  return null;
+}
+
+export async function resolveProjectTarget({
+  command = 'command',
+  options = {},
+  config = {},
+  requireTarget = true,
+} = {}) {
+  let validationErrors = validateTargetOptions(options);
+  if (validationErrors.length > 0) {
+    throw new ValidationError('Invalid target options', validationErrors, {
+      command,
+    });
+  }
+
+  let resolvedTarget = resolveTargetFromSources({
+    options,
+    configTarget: config.target,
+  });
+
+  if (resolvedTarget) {
+    return resolvedTarget;
+  }
+
+  if (isProjectToken(config.apiKey)) {
+    return {
+      source: 'project-token',
+      target: null,
+    };
+  }
+
+  if (!requireTarget) {
+    return null;
+  }
+
+  throw new ValidationError(MISSING_TARGET_MESSAGE, [], {
+    command,
+  });
+}

--- a/tests/api/core.test.js
+++ b/tests/api/core.test.js
@@ -16,6 +16,7 @@ import {
   buildScreenshotCheckObject,
   buildScreenshotPayload,
   buildShaCheckPayload,
+  buildTargetPayload,
   buildUserAgent,
   computeSha256,
   extractErrorBody,
@@ -381,6 +382,32 @@ describe('api/core', () => {
       });
 
       assert.deepStrictEqual(result.metadata, { ci: 'github' });
+    });
+  });
+
+  describe('buildTargetPayload', () => {
+    it('builds a project id target', () => {
+      let result = buildTargetPayload({ projectId: 'proj_123' });
+
+      assert.deepStrictEqual(result, { projectId: 'proj_123' });
+    });
+
+    it('normalizes slug targets from nested objects', () => {
+      let result = buildTargetPayload({
+        organization: { slug: 'acme' },
+        project: { slug: 'marketing-site' },
+      });
+
+      assert.deepStrictEqual(result, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
+    });
+
+    it('returns null for partial targets', () => {
+      let result = buildTargetPayload({ organizationSlug: 'acme' });
+
+      assert.strictEqual(result, null);
     });
   });
 

--- a/tests/api/endpoints.test.js
+++ b/tests/api/endpoints.test.js
@@ -120,6 +120,27 @@ describe('api/endpoints', () => {
       let body = JSON.parse(call.options.body);
       assert.strictEqual(body.build.name, 'Test Build');
       assert.strictEqual(body.build.branch, 'main');
+      assert.strictEqual(body.target, undefined);
+    });
+
+    it('includes explicit target metadata when provided', async () => {
+      let client = createMockClient({ id: 'new-build' });
+
+      await createBuild(client, {
+        name: 'Test Build',
+        branch: 'main',
+        environment: 'test',
+        target: {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        },
+      });
+
+      let body = JSON.parse(client.getLastCall().options.body);
+      assert.deepStrictEqual(body.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
     });
   });
 
@@ -495,6 +516,24 @@ describe('api/endpoints', () => {
         '/api/sdk/parallel/parallel-123/finalize'
       );
       assert.strictEqual(call.options.method, 'POST');
+      assert.strictEqual(call.options.body, undefined);
+    });
+
+    it('includes explicit target metadata when provided', async () => {
+      let client = createMockClient({ success: true });
+
+      await finalizeParallelBuild(client, 'parallel-123', {
+        target: {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        },
+      });
+
+      let body = JSON.parse(client.getLastCall().options.body);
+      assert.deepStrictEqual(body.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
     });
   });
 

--- a/tests/commands/finalize.test.js
+++ b/tests/commands/finalize.test.js
@@ -32,6 +32,18 @@ function createMockOutput() {
   };
 }
 
+function createMockConfig(overrides = {}) {
+  return {
+    apiKey: 'test-token',
+    apiUrl: 'https://api.test',
+    target: {
+      organizationSlug: 'acme',
+      projectSlug: 'marketing-site',
+    },
+    ...overrides,
+  };
+}
+
 describe('commands/finalize', () => {
   describe('validateFinalizeOptions', () => {
     it('returns no errors for valid parallel ID', () => {
@@ -57,6 +69,22 @@ describe('commands/finalize', () => {
     it('returns error for undefined parallel ID', () => {
       let errors = validateFinalizeOptions(undefined, {});
       assert.deepStrictEqual(errors, ['Parallel ID is required']);
+    });
+
+    it('returns error for --project without --org', () => {
+      let errors = validateFinalizeOptions('parallel-123', {
+        project: 'web-app',
+      });
+      assert.deepStrictEqual(errors, [
+        '--project requires --org. Pass both --org and --project, or use --project-id.',
+      ]);
+    });
+
+    it('returns error for --org without --project', () => {
+      let errors = validateFinalizeOptions('parallel-123', { org: 'acme' });
+      assert.deepStrictEqual(errors, [
+        '--org requires --project. Pass both --org and --project, or use --project-id.',
+      ]);
     });
   });
 
@@ -87,26 +115,55 @@ describe('commands/finalize', () => {
       assert.ok(output.calls.some(c => c.method === 'error'));
     });
 
-    it('calls finalizeParallelBuild with correct params', async () => {
+    it('returns error when target cannot be resolved for user auth', async () => {
       let output = createMockOutput();
-      let capturedClient = null;
-      let capturedParallelId = null;
+      let exitCode = null;
 
       let result = await finalizeCommand(
         'parallel-123',
         {},
         {},
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () =>
+            createMockConfig({ apiKey: 'user-token', target: undefined }),
+          output,
+          exit: code => {
+            exitCode = code;
+          },
+        }
+      );
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(exitCode, 1);
+      assert.ok(
+        output.calls.some(
+          c =>
+            c.method === 'error' &&
+            c.args[0] === 'Failed to finalize parallel build' &&
+            c.args[1]?.message?.includes('This command needs a target project')
+        )
+      );
+    });
+
+    it('calls finalizeParallelBuild with correct params', async () => {
+      let output = createMockOutput();
+      let capturedClient = null;
+      let capturedParallelId = null;
+      let capturedOptions = null;
+
+      let result = await finalizeCommand(
+        'parallel-123',
+        {},
+        {},
+        {
+          loadConfig: async () => createMockConfig({ apiKey: 'user-token' }),
           createApiClient: opts => {
             capturedClient = opts;
             return { request: async () => ({}) };
           },
-          finalizeParallelBuild: async (_client, parallelId) => {
+          finalizeParallelBuild: async (_client, parallelId, options) => {
             capturedParallelId = parallelId;
+            capturedOptions = options;
             return {
               build: {
                 id: 'build-456',
@@ -122,8 +179,48 @@ describe('commands/finalize', () => {
 
       assert.strictEqual(result.success, true);
       assert.strictEqual(capturedParallelId, 'parallel-123');
-      assert.strictEqual(capturedClient.token, 'test-token');
+      assert.strictEqual(capturedClient.token, 'user-token');
       assert.strictEqual(capturedClient.command, 'finalize');
+      assert.deepStrictEqual(capturedOptions, {
+        target: {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        },
+      });
+    });
+
+    it('keeps project token finalize working without an explicit target', async () => {
+      let output = createMockOutput();
+      let capturedOptions = null;
+
+      let result = await finalizeCommand(
+        'parallel-123',
+        {},
+        {},
+        {
+          loadConfig: async () =>
+            createMockConfig({
+              apiKey: 'vzt_project-token',
+              target: undefined,
+            }),
+          createApiClient: () => ({ request: async () => ({}) }),
+          finalizeParallelBuild: async (_client, _parallelId, options) => {
+            capturedOptions = options;
+            return {
+              build: {
+                id: 'build-456',
+                status: 'completed',
+                parallel_id: 'parallel-123',
+              },
+            };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(result.success, true);
+      assert.deepStrictEqual(capturedOptions, { target: undefined });
     });
 
     it('outputs JSON when json flag is set', async () => {
@@ -134,10 +231,7 @@ describe('commands/finalize', () => {
         {},
         { json: true },
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => ({
             build: {
@@ -164,10 +258,7 @@ describe('commands/finalize', () => {
         {},
         { json: false },
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => ({
             build: {
@@ -195,10 +286,7 @@ describe('commands/finalize', () => {
         {},
         { verbose: true },
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => ({
             build: {
@@ -224,10 +312,7 @@ describe('commands/finalize', () => {
         {},
         {},
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => {
             throw new Error('API error');
@@ -254,10 +339,7 @@ describe('commands/finalize', () => {
         {},
         {},
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => ({
             build: {
@@ -287,7 +369,7 @@ describe('commands/finalize', () => {
           loadConfig: async (configPath, options) => {
             capturedConfigPath = configPath;
             capturedOptions = options;
-            return { apiKey: 'test-token', apiUrl: 'https://api.test' };
+            return createMockConfig();
           },
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => ({
@@ -315,10 +397,7 @@ describe('commands/finalize', () => {
         {},
         {},
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => {
             throw apiError;
@@ -353,10 +432,7 @@ describe('commands/finalize', () => {
         {},
         { strict: true },
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => {
             throw apiError;
@@ -388,10 +464,7 @@ describe('commands/finalize', () => {
         {},
         {},
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => {
             throw apiError;
@@ -426,10 +499,7 @@ describe('commands/finalize', () => {
         {},
         { strict: true },
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => {
             throw apiError;
@@ -462,10 +532,7 @@ describe('commands/finalize', () => {
         {},
         { verbose: true },
         {
-          loadConfig: async () => ({
-            apiKey: 'test-token',
-            apiUrl: 'https://api.test',
-          }),
+          loadConfig: async () => createMockConfig(),
           createApiClient: () => ({ request: async () => ({}) }),
           finalizeParallelBuild: async () => {
             throw apiError;

--- a/tests/commands/logout.test.js
+++ b/tests/commands/logout.test.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { logoutCommand } from '../../src/commands/logout.js';
+
+function createMockOutput() {
+  let calls = [];
+
+  return {
+    calls,
+    configure: opts => calls.push({ method: 'configure', args: [opts] }),
+    data: data => calls.push({ method: 'data', args: [data] }),
+    header: value => calls.push({ method: 'header', args: [value] }),
+    print: value => calls.push({ method: 'print', args: [value] }),
+    startSpinner: value =>
+      calls.push({ method: 'startSpinner', args: [value] }),
+    stopSpinner: () => calls.push({ method: 'stopSpinner', args: [] }),
+    complete: value => calls.push({ method: 'complete', args: [value] }),
+    blank: () => calls.push({ method: 'blank', args: [] }),
+    hint: value => calls.push({ method: 'hint', args: [value] }),
+    error: (value, error) =>
+      calls.push({ method: 'error', args: [value, error] }),
+    cleanup: () => calls.push({ method: 'cleanup', args: [] }),
+  };
+}
+
+describe('commands/logout', () => {
+  it('reports not logged in for the targeted apiUrl', async () => {
+    let output = createMockOutput();
+    let capturedApiUrl = null;
+
+    await logoutCommand(
+      {},
+      { json: true, apiUrl: 'http://localhost:3000' },
+      {
+        getAuthTokens: async apiUrl => {
+          capturedApiUrl = apiUrl;
+          return null;
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedApiUrl, 'http://localhost:3000');
+    assert.deepStrictEqual(
+      output.calls.find(call => call.method === 'data')?.args[0],
+      { loggedOut: false, reason: 'not_logged_in' }
+    );
+  });
+
+  it('logs out using the targeted apiUrl scope', async () => {
+    let output = createMockOutput();
+    let capturedBaseUrl = null;
+    let capturedTokenStoreApiUrl = null;
+    let logoutCalled = false;
+
+    await logoutCommand(
+      {},
+      { apiUrl: 'http://localhost:3000' },
+      {
+        getAuthTokens: async apiUrl => ({
+          accessToken: `token-for-${apiUrl}`,
+          refreshToken: 'refresh-token',
+        }),
+        createAuthClient: ({ baseUrl }) => {
+          capturedBaseUrl = baseUrl;
+          return { baseUrl };
+        },
+        createTokenStore: apiUrl => {
+          capturedTokenStoreApiUrl = apiUrl;
+          return { apiUrl };
+        },
+        logout: async (client, tokenStore) => {
+          logoutCalled = true;
+          assert.deepStrictEqual(client, { baseUrl: 'http://localhost:3000' });
+          assert.deepStrictEqual(tokenStore, {
+            apiUrl: 'http://localhost:3000',
+          });
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(logoutCalled, true);
+    assert.strictEqual(capturedBaseUrl, 'http://localhost:3000');
+    assert.strictEqual(capturedTokenStoreApiUrl, 'http://localhost:3000');
+    assert.ok(output.calls.some(call => call.method === 'complete'));
+  });
+});

--- a/tests/commands/orgs.test.js
+++ b/tests/commands/orgs.test.js
@@ -127,6 +127,36 @@ describe('commands/orgs', () => {
       assert.strictEqual(capturedToken, 'env-token');
     });
 
+    it('uses the targeted apiUrl when resolving user auth', async () => {
+      let output = createMockOutput();
+      let capturedApiUrl = null;
+      let capturedBaseUrl = null;
+
+      await orgsCommand(
+        {},
+        { json: true, apiUrl: 'http://localhost:3000' },
+        {
+          loadConfig: async (_configPath, overrides) => ({
+            apiUrl: overrides.apiUrl,
+          }),
+          getAccessToken: async apiUrl => {
+            capturedApiUrl = apiUrl;
+            return 'local-user-token';
+          },
+          createApiClient: ({ baseUrl, token }) => {
+            capturedBaseUrl = baseUrl;
+            assert.strictEqual(token, 'local-user-token');
+            return { request: async () => ({ organizations: mockOrgs }) };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedApiUrl, 'http://localhost:3000');
+      assert.strictEqual(capturedBaseUrl, 'http://localhost:3000');
+    });
+
     it('returns all orgs in JSON output', async () => {
       let output = createMockOutput();
 

--- a/tests/commands/preview.test.js
+++ b/tests/commands/preview.test.js
@@ -75,6 +75,24 @@ describe('validatePreviewOptions', () => {
     let errors = validatePreviewOptions('   ', {});
     assert.ok(errors.includes('Path to static files is required'));
   });
+
+  it('fails with --project but no --org', () => {
+    let errors = validatePreviewOptions('./dist', { project: 'web-app' });
+    assert.ok(
+      errors.includes(
+        '--project requires --org. Pass both --org and --project, or use --project-id.'
+      )
+    );
+  });
+
+  it('fails with --org but no --project', () => {
+    let errors = validatePreviewOptions('./dist', { org: 'acme' });
+    assert.ok(
+      errors.includes(
+        '--org requires --project. Pass both --org and --project, or use --project-id.'
+      )
+    );
+  });
 });
 
 describe('previewCommand', () => {
@@ -180,6 +198,132 @@ describe('previewCommand', () => {
         c => c.method === 'error' && c.args[0].includes('No build found')
       ),
       'Should show no build found error'
+    );
+  });
+
+  it('uses build ID from matching session parallel ID', async () => {
+    let output = createMockOutput();
+    let capturedBuildId = null;
+
+    await previewCommand(
+      distDir,
+      { parallelId: 'parallel-123' },
+      {},
+      {
+        loadConfig: async () => ({
+          apiKey: 'user-token',
+          apiUrl: 'https://api.test',
+          target: {
+            organizationSlug: 'acme',
+            projectSlug: 'marketing-site',
+          },
+        }),
+        readSession: () => ({
+          buildId: 'session-build-123',
+          parallelId: 'parallel-123',
+          source: 'session_file',
+          expired: false,
+        }),
+        detectBranch: async () => 'main',
+        createApiClient: () => ({}),
+        getBuild: async () => ({ project: { isPublic: true } }),
+        uploadPreviewZip: async (_client, buildId) => {
+          capturedBuildId = buildId;
+          return {
+            previewUrl: 'https://preview.test',
+            uploaded: 3,
+            totalBytes: 1000,
+            newBytes: 800,
+          };
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedBuildId, 'session-build-123');
+  });
+
+  it('looks up build by parallel ID with target filters', async () => {
+    let output = createMockOutput();
+    let capturedFilters = null;
+    let capturedBuildId = null;
+
+    await previewCommand(
+      distDir,
+      { parallelId: 'parallel-789' },
+      {},
+      {
+        loadConfig: async () => ({
+          apiKey: 'user-token',
+          apiUrl: 'https://api.test',
+          target: {
+            organizationSlug: 'acme',
+            projectSlug: 'marketing-site',
+          },
+        }),
+        readSession: () => null,
+        detectBranch: async () => 'main',
+        createApiClient: () => ({}),
+        getBuilds: async (_client, filters) => {
+          capturedFilters = filters;
+          return {
+            builds: [{ id: 'build-789', parallel_id: 'parallel-789' }],
+          };
+        },
+        getBuild: async () => ({ project: { isPublic: true } }),
+        uploadPreviewZip: async (_client, buildId) => {
+          capturedBuildId = buildId;
+          return {
+            previewUrl: 'https://preview.test',
+            uploaded: 3,
+            totalBytes: 1000,
+            newBytes: 800,
+          };
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.deepStrictEqual(capturedFilters, {
+      limit: 20,
+      parallelId: 'parallel-789',
+      organization: 'acme',
+      project: 'marketing-site',
+    });
+    assert.strictEqual(capturedBuildId, 'build-789');
+  });
+
+  it('requires a target for user-auth parallel ID lookup', async () => {
+    let output = createMockOutput();
+    let exitCode = null;
+
+    let result = await previewCommand(
+      distDir,
+      { parallelId: 'parallel-123' },
+      {},
+      {
+        loadConfig: async () => ({
+          apiKey: 'user-token',
+          apiUrl: 'https://api.test',
+        }),
+        output,
+        exit: code => {
+          exitCode = code;
+        },
+      }
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(exitCode, 1);
+    assert.ok(
+      output.calls.some(
+        c =>
+          c.method === 'error' &&
+          c.args[0] === 'Preview upload failed' &&
+          c.args[1]?.message?.includes('This command needs a target project')
+      )
     );
   });
 

--- a/tests/commands/projects.test.js
+++ b/tests/commands/projects.test.js
@@ -144,6 +144,41 @@ describe('commands/projects', () => {
       assert.strictEqual(capturedToken, 'env-token');
     });
 
+    it('uses the targeted apiUrl when resolving user auth', async () => {
+      let output = createMockOutput();
+      let capturedApiUrl = null;
+      let capturedBaseUrl = null;
+
+      await projectsCommand(
+        {},
+        { json: true, apiUrl: 'http://localhost:3000' },
+        {
+          loadConfig: async (_configPath, overrides) => ({
+            apiUrl: overrides.apiUrl,
+          }),
+          getAccessToken: async apiUrl => {
+            capturedApiUrl = apiUrl;
+            return 'local-user-token';
+          },
+          createApiClient: ({ baseUrl, token }) => {
+            capturedBaseUrl = baseUrl;
+            assert.strictEqual(token, 'local-user-token');
+            return {
+              request: async () => ({
+                projects: mockProjects,
+                pagination: { total: 2, hasMore: false },
+              }),
+            };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedApiUrl, 'http://localhost:3000');
+      assert.strictEqual(capturedBaseUrl, 'http://localhost:3000');
+    });
+
     it('returns all projects in JSON output', async () => {
       let output = createMockOutput();
 

--- a/tests/commands/run.test.js
+++ b/tests/commands/run.test.js
@@ -48,6 +48,10 @@ function createMockConfig(overrides = {}) {
   return {
     apiKey: 'test-token',
     apiUrl: 'https://api.test',
+    target: {
+      organizationSlug: 'acme',
+      projectSlug: 'marketing-site',
+    },
     server: { port: 47392, timeout: 30000 },
     build: { environment: 'test' },
     comparison: { threshold: 0.1 },
@@ -80,6 +84,38 @@ describe('commands/run', () => {
       assert.strictEqual(result.reason, 'no-api-key');
       assert.strictEqual(exitCode, 1);
       assert.ok(output.calls.some(c => c.method === 'error'));
+    });
+
+    it('returns error when build target cannot be resolved', async () => {
+      let output = createMockOutput();
+      let exitCode = null;
+
+      let result = await runCommand(
+        'npm test',
+        {},
+        {},
+        {
+          loadConfig: async () =>
+            createMockConfig({ apiKey: 'user-token', target: undefined }),
+          output,
+          exit: code => {
+            exitCode = code;
+          },
+          processOn: () => {},
+          processRemoveListener: () => {},
+        }
+      );
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(exitCode, 1);
+      assert.ok(
+        output.calls.some(
+          c =>
+            c.method === 'error' &&
+            c.args[0] === 'Test run failed' &&
+            c.args[1]?.message?.includes('This command needs a target project')
+        )
+      );
     });
 
     it('allows running without token when allowNoToken is set', async () => {
@@ -476,6 +512,82 @@ describe('commands/run', () => {
         'minClusterSize should be passed from config to runOptions'
       );
       assert.strictEqual(capturedRunOptions.threshold, 2.0);
+    });
+
+    it('passes resolved target to the run flow for user auth', async () => {
+      let output = createMockOutput();
+      let capturedRunOptions = null;
+
+      await runCommand(
+        'npm test',
+        {},
+        {},
+        {
+          loadConfig: async () => createMockConfig({ apiKey: 'user-token' }),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          createUploader: () => ({}),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { buildId: null, screenshotsCaptured: 0 };
+          },
+          detectBranch: async () => 'main',
+          detectCommit: async () => 'abc123',
+          detectCommitMessage: async () => 'test',
+          detectPullRequestNumber: () => null,
+          generateBuildNameWithGit: async () => 'test-build',
+          output,
+          exit: () => {},
+          processOn: () => {},
+          processRemoveListener: () => {},
+        }
+      );
+
+      assert.deepStrictEqual(capturedRunOptions.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
+    });
+
+    it('keeps project token runs working without an explicit target', async () => {
+      let output = createMockOutput();
+      let capturedRunOptions = null;
+
+      let result = await runCommand(
+        'npm test',
+        {},
+        {},
+        {
+          loadConfig: async () =>
+            createMockConfig({
+              apiKey: 'vzt_project-token',
+              target: undefined,
+            }),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          createUploader: () => ({}),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { buildId: 'build-123', screenshotsCaptured: 1 };
+          },
+          detectBranch: async () => 'main',
+          detectCommit: async () => 'abc123',
+          detectCommitMessage: async () => 'test',
+          detectPullRequestNumber: () => null,
+          generateBuildNameWithGit: async () => 'test-build',
+          output,
+          exit: () => {},
+          processOn: () => {},
+          processRemoveListener: () => {},
+        }
+      );
+
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(capturedRunOptions.target, undefined);
     });
 
     it('uses provided git metadata options', async () => {
@@ -1302,6 +1414,26 @@ describe('commands/run', () => {
         assert.ok(
           errors.includes(
             'Upload timeout must be a positive integer (milliseconds)'
+          )
+        );
+      });
+    });
+
+    describe('target validation', () => {
+      it('should fail with --project but no --org', () => {
+        let errors = validateRunOptions('npm test', { project: 'web-app' });
+        assert.ok(
+          errors.includes(
+            '--project requires --org. Pass both --org and --project, or use --project-id.'
+          )
+        );
+      });
+
+      it('should fail with --org but no --project', () => {
+        let errors = validateRunOptions('npm test', { org: 'acme' });
+        assert.ok(
+          errors.includes(
+            '--org requires --project. Pass both --org and --project, or use --project-id.'
           )
         );
       });

--- a/tests/commands/targeting.integration.test.js
+++ b/tests/commands/targeting.integration.test.js
@@ -1,0 +1,358 @@
+import assert from 'node:assert';
+import { once } from 'node:events';
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { createCLIRunner, parseJSONOutput } from '../helpers/cli-runner.js';
+
+let __filename = fileURLToPath(import.meta.url);
+let __dirname = dirname(__filename);
+let FIXTURE_SCREENSHOT = join(
+  __dirname,
+  '../reporter/fixtures/images/screenshots/homepage-desktop.png'
+);
+
+let cleanupTasks = [];
+
+afterEach(async () => {
+  for (let task of cleanupTasks.reverse()) {
+    await task();
+  }
+  cleanupTasks = [];
+});
+
+function createJsonResponse(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+async function readRequestBody(req) {
+  let chunks = [];
+
+  for await (let chunk of req) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks);
+}
+
+function createSdkStubServer() {
+  let state = {
+    buildRequests: [],
+    shaRequests: [],
+    uploadRequests: [],
+    statusRequests: [],
+    finalizeRequests: [],
+    nextBuildId: 1,
+    lastBuildId: null,
+  };
+
+  let server = createServer(async (req, res) => {
+    let baseUrl = `http://${req.headers.host}`;
+    let url = new URL(req.url, baseUrl);
+    let bodyBuffer = await readRequestBody(req);
+    let bodyText = bodyBuffer.toString('utf8');
+
+    if (req.method === 'POST' && url.pathname === '/api/sdk/builds') {
+      let body = JSON.parse(bodyText || '{}');
+      let buildId = `build-${state.nextBuildId++}`;
+      state.lastBuildId = buildId;
+      state.buildRequests.push({
+        headers: req.headers,
+        body,
+        buildId,
+      });
+
+      createJsonResponse(res, 201, {
+        id: buildId,
+        status: 'processing',
+        projectSlug: 'web-app',
+        organizationSlug: 'acme',
+        url: `${baseUrl}/acme/web-app/builds/${buildId}`,
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/sdk/check-shas') {
+      state.shaRequests.push({
+        headers: req.headers,
+        body: JSON.parse(bodyText || '{}'),
+      });
+
+      createJsonResponse(res, 200, {
+        existing: [],
+        missing: [],
+        screenshots: [],
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/sdk/upload') {
+      state.uploadRequests.push({
+        headers: req.headers,
+        bodyText: bodyBuffer.toString('latin1'),
+      });
+
+      createJsonResponse(res, 201, {
+        build: {
+          id: state.lastBuildId,
+          url: `${baseUrl}/acme/web-app/builds/${state.lastBuildId}`,
+        },
+        count: 1,
+      });
+      return;
+    }
+
+    if (
+      req.method === 'PUT' &&
+      /^\/api\/sdk\/builds\/[^/]+\/status$/.test(url.pathname)
+    ) {
+      let buildId = url.pathname.split('/')[4];
+      state.statusRequests.push({
+        headers: req.headers,
+        body: JSON.parse(bodyText || '{}'),
+        buildId,
+      });
+
+      createJsonResponse(res, 200, {
+        message: 'Build status updated successfully',
+        build: {
+          id: buildId,
+          status: 'completed',
+        },
+      });
+      return;
+    }
+
+    if (
+      req.method === 'POST' &&
+      /^\/api\/sdk\/parallel\/[^/]+\/finalize$/.test(url.pathname)
+    ) {
+      let parallelId = url.pathname.split('/')[4];
+      state.finalizeRequests.push({
+        headers: req.headers,
+        body: bodyText ? JSON.parse(bodyText) : null,
+        parallelId,
+      });
+
+      createJsonResponse(res, 200, {
+        message: 'Parallel build finalized successfully',
+        build: {
+          id: 'build-finalize-1',
+          status: 'completed',
+          parallel_id: parallelId,
+        },
+      });
+      return;
+    }
+
+    createJsonResponse(res, 404, {
+      error: `Unhandled route: ${req.method} ${url.pathname}`,
+    });
+  });
+
+  return {
+    state,
+    async start() {
+      server.listen(0, '127.0.0.1');
+      await once(server, 'listening');
+      let address = server.address();
+      return `http://127.0.0.1:${address.port}`;
+    },
+    async close() {
+      await new Promise((resolve, reject) => {
+        server.close(error => {
+          if (error) {
+            reject(error);
+            return;
+          }
+
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function createTempCliWorkspace() {
+  let rootDir = await mkdtemp(join(tmpdir(), 'vizzly-cli-targeting-'));
+  let homeDir = join(rootDir, 'home');
+  let projectDir = join(rootDir, 'project');
+  let screenshotsDir = join(projectDir, 'screenshots');
+
+  await mkdir(homeDir, { recursive: true });
+  await mkdir(projectDir, { recursive: true });
+  await mkdir(screenshotsDir, { recursive: true });
+  await copyFile(
+    FIXTURE_SCREENSHOT,
+    join(screenshotsDir, 'homepage-desktop.png')
+  );
+
+  cleanupTasks.push(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  return { rootDir, homeDir, projectDir, screenshotsDir };
+}
+
+async function writeLoggedInUserAuth(homeDir, apiUrl) {
+  let expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+  await writeFile(
+    join(homeDir, 'config.json'),
+    JSON.stringify(
+      {
+        authByApiUrl: {
+          [apiUrl]: {
+            accessToken: 'user-access-token',
+            refreshToken: 'refresh-token',
+            expiresAt,
+            user: {
+              id: 'user-1',
+              email: 'user@example.com',
+            },
+          },
+        },
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function writeRepoTargetConfig(projectDir, apiUrl) {
+  await writeFile(
+    join(projectDir, 'vizzly.config.js'),
+    `export default {
+  apiUrl: '${apiUrl}',
+  target: {
+    organizationSlug: 'acme',
+    projectSlug: 'web-app'
+  },
+  upload: {
+    batchSize: 1
+  }
+};
+`
+  );
+}
+
+function getDataMessage(output) {
+  let messages = parseJSONOutput(output);
+  return messages.find(message => message.status === 'data')?.data || null;
+}
+
+describe('commands/targeting integration', () => {
+  it('uses repo target config and local user auth for upload', async () => {
+    let server = createSdkStubServer();
+    cleanupTasks.push(() => server.close());
+
+    let apiUrl = await server.start();
+    let { homeDir, projectDir, screenshotsDir } =
+      await createTempCliWorkspace();
+    await writeLoggedInUserAuth(homeDir, apiUrl);
+    await writeRepoTargetConfig(projectDir, apiUrl);
+
+    let cli = createCLIRunner(projectDir, {
+      VIZZLY_HOME: homeDir,
+      VIZZLY_API_URL: apiUrl,
+      VIZZLY_SERVER_URL: apiUrl,
+    });
+
+    let result = await cli.runSuccess(['upload', screenshotsDir, '--json']);
+    let data = getDataMessage(result.stdout);
+
+    assert.ok(data);
+    assert.strictEqual(data.buildId, 'build-1');
+    assert.strictEqual(data.url, `${apiUrl}/acme/web-app/builds/build-1`);
+
+    assert.strictEqual(server.state.buildRequests.length, 1);
+    assert.strictEqual(
+      server.state.buildRequests[0].headers.authorization,
+      'Bearer user-access-token'
+    );
+    assert.deepStrictEqual(server.state.buildRequests[0].body.target, {
+      organizationSlug: 'acme',
+      projectSlug: 'web-app',
+    });
+
+    assert.strictEqual(server.state.shaRequests.length, 1);
+    assert.strictEqual(server.state.shaRequests[0].body.buildId, 'build-1');
+
+    assert.strictEqual(server.state.uploadRequests.length, 1);
+    assert.ok(
+      server.state.uploadRequests[0].bodyText.includes('name="build_id"')
+    );
+    assert.ok(server.state.uploadRequests[0].bodyText.includes('build-1'));
+
+    assert.strictEqual(server.state.statusRequests.length, 1);
+    assert.strictEqual(server.state.statusRequests[0].body.status, 'completed');
+  });
+
+  it('keeps CI-style project token upload working without repo target config', async () => {
+    let server = createSdkStubServer();
+    cleanupTasks.push(() => server.close());
+
+    let apiUrl = await server.start();
+    let { homeDir, projectDir, screenshotsDir } =
+      await createTempCliWorkspace();
+
+    let cli = createCLIRunner(projectDir, {
+      VIZZLY_HOME: homeDir,
+      VIZZLY_API_URL: apiUrl,
+      VIZZLY_SERVER_URL: apiUrl,
+      VIZZLY_TOKEN: 'vzt_project_token',
+    });
+
+    let result = await cli.runSuccess(['upload', screenshotsDir, '--json']);
+    let data = getDataMessage(result.stdout);
+
+    assert.ok(data);
+    assert.strictEqual(data.buildId, 'build-1');
+
+    assert.strictEqual(server.state.buildRequests.length, 1);
+    assert.strictEqual(
+      server.state.buildRequests[0].headers.authorization,
+      'Bearer vzt_project_token'
+    );
+    assert.strictEqual(server.state.buildRequests[0].body.target, undefined);
+  });
+
+  it('sends repo target config on user-auth parallel finalize', async () => {
+    let server = createSdkStubServer();
+    cleanupTasks.push(() => server.close());
+
+    let apiUrl = await server.start();
+    let { homeDir, projectDir } = await createTempCliWorkspace();
+    await writeLoggedInUserAuth(homeDir, apiUrl);
+    await writeRepoTargetConfig(projectDir, apiUrl);
+
+    let cli = createCLIRunner(projectDir, {
+      VIZZLY_HOME: homeDir,
+      VIZZLY_API_URL: apiUrl,
+      VIZZLY_SERVER_URL: apiUrl,
+    });
+
+    let result = await cli.runSuccess(['finalize', 'parallel-123', '--json']);
+    let data = getDataMessage(result.stdout);
+
+    assert.ok(data);
+    assert.strictEqual(data.build.parallel_id, 'parallel-123');
+
+    assert.strictEqual(server.state.finalizeRequests.length, 1);
+    assert.strictEqual(
+      server.state.finalizeRequests[0].headers.authorization,
+      'Bearer user-access-token'
+    );
+    assert.deepStrictEqual(server.state.finalizeRequests[0].body, {
+      target: {
+        organizationSlug: 'acme',
+        projectSlug: 'web-app',
+      },
+    });
+  });
+});

--- a/tests/commands/upload.test.js
+++ b/tests/commands/upload.test.js
@@ -43,6 +43,20 @@ function createMockOutput() {
   };
 }
 
+function createMockConfig(overrides = {}) {
+  return {
+    apiKey: 'test-token',
+    apiUrl: 'https://api.test',
+    target: {
+      organizationSlug: 'acme',
+      projectSlug: 'marketing-site',
+    },
+    build: { environment: 'test' },
+    comparison: { threshold: 2.0 },
+    ...overrides,
+  };
+}
+
 describe('validateUploadOptions', () => {
   describe('screenshots path validation', () => {
     it('should pass with valid screenshots path', () => {
@@ -189,6 +203,30 @@ describe('validateUploadOptions', () => {
     });
   });
 
+  describe('target validation', () => {
+    it('should fail with --project but no --org', () => {
+      let errors = validateUploadOptions('./screenshots', {
+        project: 'web-app',
+      });
+      assert.ok(
+        errors.includes(
+          '--project requires --org. Pass both --org and --project, or use --project-id.'
+        )
+      );
+    });
+
+    it('should fail with --org but no --project', () => {
+      let errors = validateUploadOptions('./screenshots', {
+        org: 'acme',
+      });
+      assert.ok(
+        errors.includes(
+          '--org requires --project. Pass both --org and --project, or use --project-id.'
+        )
+      );
+    });
+  });
+
   describe('multiple validation errors', () => {
     it('should return all validation errors', () => {
       let errors = validateUploadOptions(null, {
@@ -299,12 +337,7 @@ describe('uploadCommand', () => {
       {},
       {},
       {
-        loadConfig: async () => ({
-          apiKey: null,
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig({ apiKey: null }),
         output,
         exit: code => {
           exitCode = code;
@@ -315,6 +348,35 @@ describe('uploadCommand', () => {
     assert.strictEqual(result.success, false);
     assert.strictEqual(result.reason, 'no-api-key');
     assert.strictEqual(exitCode, 1);
+  });
+
+  it('returns error when target cannot be resolved', async () => {
+    let output = createMockOutput();
+    let exitCode = null;
+
+    let result = await uploadCommand(
+      './screenshots',
+      {},
+      {},
+      {
+        loadConfig: async () =>
+          createMockConfig({ apiKey: 'user-token', target: undefined }),
+        output,
+        exit: code => {
+          exitCode = code;
+        },
+      }
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(exitCode, 1);
+    assert.ok(
+      output.calls.some(
+        c =>
+          c.method === 'error' &&
+          c.args[0].includes('This command needs a target project')
+      )
+    );
   });
 
   it('uploads screenshots and finalizes build', async () => {
@@ -328,12 +390,7 @@ describe('uploadCommand', () => {
       {},
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -368,6 +425,84 @@ describe('uploadCommand', () => {
     assert.ok(output.calls.some(c => c.method === 'complete'));
   });
 
+  it('passes resolved target to the upload flow for user auth', async () => {
+    let output = createMockOutput();
+    let capturedUploadOptions = null;
+
+    await uploadCommand(
+      './screenshots',
+      {},
+      {},
+      {
+        loadConfig: async () => createMockConfig({ apiKey: 'user-token' }),
+        detectBranch: async () => 'main',
+        detectCommit: async () => 'abc123',
+        detectCommitMessage: async () => 'Test commit',
+        detectPullRequestNumber: () => null,
+        generateBuildNameWithGit: async () => 'Test Build',
+        createUploader: () => ({
+          upload: async options => {
+            capturedUploadOptions = options;
+            return {
+              buildId: 'build-123',
+              url: 'https://app.vizzly.dev/builds/build-123',
+              stats: { uploaded: 1, total: 1, skipped: 0, bytes: 10 },
+            };
+          },
+        }),
+        createApiClient: () => ({}),
+        finalizeBuild: async () => {},
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.deepStrictEqual(capturedUploadOptions.target, {
+      organizationSlug: 'acme',
+      projectSlug: 'marketing-site',
+    });
+  });
+
+  it('keeps project token uploads working without an explicit target', async () => {
+    let output = createMockOutput();
+    let capturedUploadOptions = null;
+
+    let result = await uploadCommand(
+      './screenshots',
+      {},
+      {},
+      {
+        loadConfig: async () =>
+          createMockConfig({
+            apiKey: 'vzt_project-token',
+            target: undefined,
+          }),
+        detectBranch: async () => 'main',
+        detectCommit: async () => 'abc123',
+        detectCommitMessage: async () => 'Test commit',
+        detectPullRequestNumber: () => null,
+        generateBuildNameWithGit: async () => 'Test Build',
+        createUploader: () => ({
+          upload: async options => {
+            capturedUploadOptions = options;
+            return {
+              buildId: 'build-123',
+              url: 'https://app.vizzly.dev/builds/build-123',
+              stats: { uploaded: 1, total: 1, skipped: 0, bytes: 10 },
+            };
+          },
+        }),
+        createApiClient: () => ({}),
+        finalizeBuild: async () => {},
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(capturedUploadOptions.target, undefined);
+  });
+
   it('handles upload errors and marks build as failed', async () => {
     let output = createMockOutput();
     let exitCode = null;
@@ -378,12 +513,7 @@ describe('uploadCommand', () => {
       {},
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -423,12 +553,7 @@ describe('uploadCommand', () => {
       { wait: true },
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -465,12 +590,7 @@ describe('uploadCommand', () => {
       { wait: true },
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -511,12 +631,7 @@ describe('uploadCommand', () => {
       {},
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -553,12 +668,7 @@ describe('uploadCommand', () => {
       {},
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -598,12 +708,10 @@ describe('uploadCommand', () => {
       {},
       { verbose: true },
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test', name: 'Test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () =>
+          createMockConfig({
+            build: { environment: 'test', name: 'Test' },
+          }),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',
@@ -639,12 +747,7 @@ describe('uploadCommand', () => {
       {},
       {},
       {
-        loadConfig: async () => ({
-          apiKey: 'test-token',
-          apiUrl: 'https://api.test',
-          build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
-        }),
+        loadConfig: async () => createMockConfig(),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
         detectCommitMessage: async () => 'Test commit',

--- a/tests/commands/whoami.test.js
+++ b/tests/commands/whoami.test.js
@@ -1,0 +1,99 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { whoamiCommand } from '../../src/commands/whoami.js';
+
+function createMockOutput() {
+  let calls = [];
+
+  return {
+    calls,
+    configure: opts => calls.push({ method: 'configure', args: [opts] }),
+    data: data => calls.push({ method: 'data', args: [data] }),
+    header: value => calls.push({ method: 'header', args: [value] }),
+    print: value => calls.push({ method: 'print', args: [value] }),
+    blank: () => calls.push({ method: 'blank', args: [] }),
+    hint: value => calls.push({ method: 'hint', args: [value] }),
+    warn: value => calls.push({ method: 'warn', args: [value] }),
+    labelValue: (label, value) =>
+      calls.push({ method: 'labelValue', args: [label, value] }),
+    list: value => calls.push({ method: 'list', args: [value] }),
+    keyValue: value => calls.push({ method: 'keyValue', args: [value] }),
+    startSpinner: value =>
+      calls.push({ method: 'startSpinner', args: [value] }),
+    stopSpinner: () => calls.push({ method: 'stopSpinner', args: [] }),
+    error: (value, error) =>
+      calls.push({ method: 'error', args: [value, error] }),
+    cleanup: () => calls.push({ method: 'cleanup', args: [] }),
+  };
+}
+
+describe('commands/whoami', () => {
+  it('reports unauthenticated for the targeted apiUrl', async () => {
+    let output = createMockOutput();
+    let capturedApiUrl = null;
+
+    await whoamiCommand(
+      {},
+      { json: true, apiUrl: 'http://localhost:3000' },
+      {
+        getAuthTokens: async apiUrl => {
+          capturedApiUrl = apiUrl;
+          return null;
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedApiUrl, 'http://localhost:3000');
+    assert.deepStrictEqual(
+      output.calls.find(call => call.method === 'data')?.args[0],
+      { authenticated: false }
+    );
+  });
+
+  it('uses the targeted apiUrl scope for whoami requests', async () => {
+    let output = createMockOutput();
+    let capturedBaseUrl = null;
+    let capturedTokenStoreApiUrl = null;
+
+    await whoamiCommand(
+      {},
+      { json: true, apiUrl: 'http://localhost:3000' },
+      {
+        getAuthTokens: async apiUrl => ({
+          accessToken: `token-for-${apiUrl}`,
+          expiresAt: '2030-01-01T00:00:00.000Z',
+        }),
+        createAuthClient: ({ baseUrl }) => {
+          capturedBaseUrl = baseUrl;
+          return { baseUrl };
+        },
+        createTokenStore: apiUrl => {
+          capturedTokenStoreApiUrl = apiUrl;
+          return { apiUrl };
+        },
+        whoami: async (client, tokenStore) => {
+          assert.deepStrictEqual(client, { baseUrl: 'http://localhost:3000' });
+          assert.deepStrictEqual(tokenStore, {
+            apiUrl: 'http://localhost:3000',
+          });
+          return {
+            user: { email: 'test@example.com', name: 'Test User' },
+            organizations: [{ name: 'Acme', slug: 'acme' }],
+          };
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedBaseUrl, 'http://localhost:3000');
+    assert.strictEqual(capturedTokenStoreApiUrl, 'http://localhost:3000');
+
+    let payload = output.calls.find(call => call.method === 'data')?.args[0];
+    assert.strictEqual(payload.authenticated, true);
+    assert.strictEqual(payload.user.email, 'test@example.com');
+    assert.strictEqual(payload.organizations[0].slug, 'acme');
+  });
+});

--- a/tests/test-runner/core.test.js
+++ b/tests/test-runner/core.test.js
@@ -167,6 +167,20 @@ describe('test-runner/core', () => {
 
       assert.strictEqual(payload.metadata, undefined);
     });
+
+    it('includes explicit target when provided', () => {
+      let payload = buildApiBuildPayload({
+        target: {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        },
+      });
+
+      assert.deepStrictEqual(payload.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
+    });
   });
 
   describe('shouldDisableVizzly', () => {

--- a/tests/uploader/core.test.js
+++ b/tests/uploader/core.test.js
@@ -205,6 +205,23 @@ describe('uploader/core', () => {
       let result = buildBuildInfo({}, null);
       assert.strictEqual(result.branch, 'main');
     });
+
+    it('includes explicit target when provided', () => {
+      let result = buildBuildInfo(
+        {
+          target: {
+            organizationSlug: 'acme',
+            projectSlug: 'marketing-site',
+          },
+        },
+        'main'
+      );
+
+      assert.deepStrictEqual(result.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
+    });
   });
 
   describe('computeSha256', () => {

--- a/tests/utils/config-loader.test.js
+++ b/tests/utils/config-loader.test.js
@@ -6,6 +6,7 @@ import {
   getScreenshotPaths,
   loadConfig,
 } from '../../src/utils/config-loader.js';
+import { saveAuthTokens } from '../../src/utils/global-config.js';
 
 describe('utils/config-loader', () => {
   describe('getScreenshotPaths', () => {
@@ -111,6 +112,26 @@ describe('utils/config-loader', () => {
       assert.strictEqual(config.comparison.threshold, 1.5);
     });
 
+    it('loads target config from vizzly.config.js', async () => {
+      let configPath = join(testDir, 'vizzly.target.config.js');
+      writeFileSync(
+        configPath,
+        `export default {
+          target: {
+            organizationSlug: 'acme',
+            projectSlug: 'marketing-site'
+          }
+        };`
+      );
+
+      let config = await loadConfig(configPath);
+
+      assert.deepStrictEqual(config.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
+    });
+
     it('applies CLI overrides', async () => {
       let config = await loadConfig(null, {
         token: 'cli-token',
@@ -145,6 +166,31 @@ describe('utils/config-loader', () => {
       assert.strictEqual(config.build.name, 'CI Build #123');
     });
 
+    it('lets --api-url override config apiUrl', async () => {
+      writeFileSync(
+        join(testDir, 'vizzly.config.js'),
+        "export default { apiUrl: 'http://localhost:3000' };"
+      );
+
+      let config = await loadConfig(null, {
+        apiUrl: 'https://app.vizzly.dev',
+      });
+
+      assert.strictEqual(config.apiUrl, 'https://app.vizzly.dev');
+    });
+
+    it('lets VIZZLY_API_URL override config apiUrl even for the cloud default', async () => {
+      process.env.VIZZLY_API_URL = 'https://app.vizzly.dev';
+      writeFileSync(
+        join(testDir, 'vizzly.config.js'),
+        "export default { apiUrl: 'http://localhost:3000' };"
+      );
+
+      let config = await loadConfig();
+
+      assert.strictEqual(config.apiUrl, 'https://app.vizzly.dev');
+    });
+
     it('CLI buildName overrides VIZZLY_BUILD_NAME', async () => {
       process.env.VIZZLY_BUILD_NAME = 'env-build-name';
 
@@ -159,6 +205,22 @@ describe('utils/config-loader', () => {
       let config = await loadConfig(null, { token: 'cli-token' });
 
       assert.strictEqual(config.apiKey, 'cli-token');
+    });
+
+    it('uses login token scoped to the resolved apiUrl', async () => {
+      await saveAuthTokens(
+        { accessToken: 'local-login-token' },
+        'http://localhost:3000'
+      );
+      await saveAuthTokens(
+        { accessToken: 'cloud-login-token' },
+        'https://app.vizzly.dev'
+      );
+
+      let config = await loadConfig(null, { apiUrl: 'http://localhost:3000' });
+
+      assert.strictEqual(config.apiKey, 'local-login-token');
+      assert.strictEqual(config.apiUrl, 'http://localhost:3000');
     });
 
     it('applies branch/commit/message overrides', async () => {

--- a/tests/utils/config-schema.test.js
+++ b/tests/utils/config-schema.test.js
@@ -48,6 +48,20 @@ describe('utils/config-schema', () => {
       assert.strictEqual(result.build.commit, 'abc123');
     });
 
+    it('accepts a target project in config', () => {
+      let result = vizzlyConfigSchema.parse({
+        target: {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        },
+      });
+
+      assert.deepStrictEqual(result.target, {
+        organizationSlug: 'acme',
+        projectSlug: 'marketing-site',
+      });
+    });
+
     it('accepts array of screenshot directories', () => {
       let result = vizzlyConfigSchema.parse({
         upload: { screenshotsDir: ['./screenshots', './e2e/snapshots'] },
@@ -124,6 +138,24 @@ describe('utils/config-schema', () => {
         () => validateVizzlyConfig({ apiUrl: 'not-a-url' }),
         error => {
           assert.ok(error.message.includes('Invalid Vizzly configuration'));
+          return true;
+        }
+      );
+    });
+
+    it('throws error for partial target config', () => {
+      assert.throws(
+        () =>
+          validateVizzlyConfig({
+            target: { organizationSlug: 'acme' },
+          }),
+        error => {
+          assert.ok(error.message.includes('Invalid Vizzly configuration'));
+          assert.ok(
+            error.message.includes(
+              'target.organizationSlug and target.projectSlug must be provided together'
+            )
+          );
           return true;
         }
       );

--- a/tests/utils/global-config.test.js
+++ b/tests/utils/global-config.test.js
@@ -17,6 +17,7 @@ import {
   getGlobalConfigPath,
   hasValidTokens,
   loadGlobalConfig,
+  normalizeApiUrl,
   saveAuthTokens,
   saveGlobalConfig,
 } from '../../src/utils/global-config.js';
@@ -138,7 +139,13 @@ describe('utils/global-config', () => {
     });
 
     it('returns null when auth has no accessToken', async () => {
-      await saveGlobalConfig({ auth: { refreshToken: 'xyz' } });
+      await saveGlobalConfig({
+        authByApiUrl: {
+          [normalizeApiUrl('https://app.vizzly.dev')]: {
+            refreshToken: 'xyz',
+          },
+        },
+      });
 
       let tokens = await getAuthTokens();
 
@@ -147,10 +154,12 @@ describe('utils/global-config', () => {
 
     it('returns auth tokens when they exist', async () => {
       await saveGlobalConfig({
-        auth: {
-          accessToken: 'abc123',
-          refreshToken: 'xyz789',
-          expiresAt: '2025-01-01T00:00:00Z',
+        authByApiUrl: {
+          [normalizeApiUrl('https://app.vizzly.dev')]: {
+            accessToken: 'abc123',
+            refreshToken: 'xyz789',
+            expiresAt: '2025-01-01T00:00:00Z',
+          },
         },
       });
 
@@ -158,6 +167,45 @@ describe('utils/global-config', () => {
 
       assert.strictEqual(tokens.accessToken, 'abc123');
       assert.strictEqual(tokens.refreshToken, 'xyz789');
+    });
+
+    it('returns tokens scoped to the requested API URL', async () => {
+      await saveGlobalConfig({
+        authByApiUrl: {
+          [normalizeApiUrl('https://app.vizzly.dev')]: {
+            accessToken: 'cloud-token',
+          },
+          [normalizeApiUrl('http://localhost:3000')]: {
+            accessToken: 'local-token',
+          },
+        },
+      });
+
+      let cloudTokens = await getAuthTokens('https://app.vizzly.dev/');
+      let localTokens = await getAuthTokens('http://localhost:3000/');
+
+      assert.strictEqual(cloudTokens.accessToken, 'cloud-token');
+      assert.strictEqual(localTokens.accessToken, 'local-token');
+    });
+
+    it('migrates legacy auth to authByApiUrl for cloud', async () => {
+      await saveGlobalConfig({
+        auth: {
+          accessToken: 'legacy-token',
+          refreshToken: 'legacy-refresh',
+        },
+      });
+
+      let tokens = await getAuthTokens();
+      let config = await loadGlobalConfig();
+
+      assert.strictEqual(tokens.accessToken, 'legacy-token');
+      assert.strictEqual(config.auth, undefined);
+      assert.strictEqual(
+        config.authByApiUrl[normalizeApiUrl('https://app.vizzly.dev')]
+          .accessToken,
+        'legacy-token'
+      );
     });
   });
 
@@ -172,10 +220,11 @@ describe('utils/global-config', () => {
 
       let config = await loadGlobalConfig();
 
-      assert.strictEqual(config.auth.accessToken, 'token123');
-      assert.strictEqual(config.auth.refreshToken, 'refresh456');
-      assert.strictEqual(config.auth.expiresAt, '2025-06-01T00:00:00Z');
-      assert.strictEqual(config.auth.user.email, 'test@example.com');
+      let auth = config.authByApiUrl[normalizeApiUrl('https://app.vizzly.dev')];
+      assert.strictEqual(auth.accessToken, 'token123');
+      assert.strictEqual(auth.refreshToken, 'refresh456');
+      assert.strictEqual(auth.expiresAt, '2025-06-01T00:00:00Z');
+      assert.strictEqual(auth.user.email, 'test@example.com');
     });
 
     it('preserves other config when saving tokens', async () => {
@@ -185,7 +234,28 @@ describe('utils/global-config', () => {
       let config = await loadGlobalConfig();
 
       assert.strictEqual(config.other, 'data');
-      assert.strictEqual(config.auth.accessToken, 'token');
+      assert.strictEqual(
+        config.authByApiUrl[normalizeApiUrl('https://app.vizzly.dev')]
+          .accessToken,
+        'token'
+      );
+    });
+
+    it('stores tokens under the requested API URL', async () => {
+      await saveAuthTokens(
+        {
+          accessToken: 'local-token',
+        },
+        'http://localhost:3000/'
+      );
+
+      let config = await loadGlobalConfig();
+
+      assert.strictEqual(
+        config.authByApiUrl[normalizeApiUrl('http://localhost:3000')]
+          .accessToken,
+        'local-token'
+      );
     });
   });
 
@@ -196,20 +266,51 @@ describe('utils/global-config', () => {
 
       let config = await loadGlobalConfig();
 
-      assert.strictEqual(config.auth, undefined);
+      assert.strictEqual(config.authByApiUrl, undefined);
     });
 
     it('preserves other config', async () => {
       await saveGlobalConfig({
         other: 'data',
-        auth: { accessToken: 'token' },
+        authByApiUrl: {
+          [normalizeApiUrl('https://app.vizzly.dev')]: {
+            accessToken: 'token',
+          },
+        },
       });
       await clearAuthTokens();
 
       let config = await loadGlobalConfig();
 
       assert.strictEqual(config.other, 'data');
-      assert.strictEqual(config.auth, undefined);
+      assert.strictEqual(config.authByApiUrl, undefined);
+    });
+
+    it('only removes tokens for the targeted API URL', async () => {
+      await saveGlobalConfig({
+        authByApiUrl: {
+          [normalizeApiUrl('https://app.vizzly.dev')]: {
+            accessToken: 'cloud-token',
+          },
+          [normalizeApiUrl('http://localhost:3000')]: {
+            accessToken: 'local-token',
+          },
+        },
+      });
+
+      await clearAuthTokens('http://localhost:3000');
+
+      let config = await loadGlobalConfig();
+
+      assert.strictEqual(
+        config.authByApiUrl[normalizeApiUrl('https://app.vizzly.dev')]
+          .accessToken,
+        'cloud-token'
+      );
+      assert.strictEqual(
+        config.authByApiUrl[normalizeApiUrl('http://localhost:3000')],
+        undefined
+      );
     });
   });
 
@@ -282,6 +383,23 @@ describe('utils/global-config', () => {
       let token = await getAccessToken();
 
       assert.strictEqual(token, 'my-token');
+    });
+
+    it('returns access token for the targeted API URL only', async () => {
+      await saveGlobalConfig({
+        authByApiUrl: {
+          [normalizeApiUrl('https://app.vizzly.dev')]: {
+            accessToken: 'cloud-token',
+          },
+          [normalizeApiUrl('http://localhost:3000')]: {
+            accessToken: 'local-token',
+          },
+        },
+      });
+
+      let token = await getAccessToken('http://localhost:3000/');
+
+      assert.strictEqual(token, 'local-token');
     });
   });
 });

--- a/tests/utils/project-target.test.js
+++ b/tests/utils/project-target.test.js
@@ -1,0 +1,222 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  isProjectToken,
+  normalizeTarget,
+  resolveProjectTarget,
+  resolveTargetFromSources,
+  validateTargetOptions,
+} from '../../src/utils/project-target.js';
+
+describe('utils/project-target', () => {
+  describe('isProjectToken', () => {
+    it('detects project tokens by prefix', () => {
+      assert.strictEqual(isProjectToken('vzt_123'), true);
+      assert.strictEqual(isProjectToken('user-token'), false);
+      assert.strictEqual(isProjectToken(null), false);
+    });
+  });
+
+  describe('validateTargetOptions', () => {
+    it('accepts --project-id on its own', () => {
+      let errors = validateTargetOptions({ projectId: 'proj_123' });
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it('accepts --org with --project', () => {
+      let errors = validateTargetOptions({
+        org: 'acme',
+        project: 'marketing-site',
+      });
+      assert.deepStrictEqual(errors, []);
+    });
+
+    it('rejects --project without --org', () => {
+      let errors = validateTargetOptions({ project: 'marketing-site' });
+      assert.deepStrictEqual(errors, [
+        '--project requires --org. Pass both --org and --project, or use --project-id.',
+      ]);
+    });
+
+    it('rejects --org without --project', () => {
+      let errors = validateTargetOptions({ org: 'acme' });
+      assert.deepStrictEqual(errors, [
+        '--org requires --project. Pass both --org and --project, or use --project-id.',
+      ]);
+    });
+  });
+
+  describe('normalizeTarget', () => {
+    it('normalizes project id targets', () => {
+      assert.deepStrictEqual(normalizeTarget({ projectId: 'proj_123' }), {
+        projectId: 'proj_123',
+      });
+    });
+
+    it('normalizes slug targets from nested token context', () => {
+      assert.deepStrictEqual(
+        normalizeTarget({
+          organization: { slug: 'acme' },
+          project: { slug: 'marketing-site' },
+        }),
+        {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        }
+      );
+    });
+  });
+
+  describe('resolveTargetFromSources', () => {
+    it('prefers --project-id over every other source', () => {
+      let result = resolveTargetFromSources({
+        options: {
+          projectId: 'proj_from_flag',
+          org: 'flag-org',
+          project: 'flag-project',
+        },
+        configTarget: {
+          organizationSlug: 'config-org',
+          projectSlug: 'config-project',
+        },
+        tokenContext: {
+          organization: { slug: 'token-org' },
+          project: { slug: 'token-project' },
+        },
+      });
+
+      assert.deepStrictEqual(result, {
+        source: 'flag:project-id',
+        target: { projectId: 'proj_from_flag' },
+      });
+    });
+
+    it('prefers explicit slug flags over config', () => {
+      let result = resolveTargetFromSources({
+        options: { org: 'flag-org', project: 'flag-project' },
+        configTarget: {
+          organizationSlug: 'config-org',
+          projectSlug: 'config-project',
+        },
+      });
+
+      assert.deepStrictEqual(result, {
+        source: 'flag:slug',
+        target: {
+          organizationSlug: 'flag-org',
+          projectSlug: 'flag-project',
+        },
+      });
+    });
+
+    it('falls back to config target', () => {
+      let result = resolveTargetFromSources({
+        configTarget: {
+          organizationSlug: 'config-org',
+          projectSlug: 'config-project',
+        },
+      });
+
+      assert.deepStrictEqual(result, {
+        source: 'config',
+        target: {
+          organizationSlug: 'config-org',
+          projectSlug: 'config-project',
+        },
+      });
+    });
+
+    it('falls back to token context', () => {
+      let result = resolveTargetFromSources({
+        tokenContext: {
+          organization: { slug: 'token-org' },
+          project: { slug: 'token-project' },
+        },
+      });
+
+      assert.deepStrictEqual(result, {
+        source: 'token-context',
+        target: {
+          organizationSlug: 'token-org',
+          projectSlug: 'token-project',
+        },
+      });
+    });
+  });
+
+  describe('resolveProjectTarget', () => {
+    it('returns config target without calling token context', async () => {
+      let called = false;
+
+      let result = await resolveProjectTarget({
+        command: 'run',
+        config: {
+          apiKey: 'user-token',
+          target: {
+            organizationSlug: 'acme',
+            projectSlug: 'marketing-site',
+          },
+        },
+        createApiClient: () => {
+          called = true;
+          return {};
+        },
+        getTokenContext: async () => {
+          called = true;
+          return {};
+        },
+      });
+
+      assert.strictEqual(called, false);
+      assert.deepStrictEqual(result, {
+        source: 'config',
+        target: {
+          organizationSlug: 'acme',
+          projectSlug: 'marketing-site',
+        },
+      });
+    });
+
+    it('treats project tokens as their own target context', async () => {
+      let result = await resolveProjectTarget({
+        command: 'upload',
+        config: {
+          apiKey: 'vzt_project_token',
+          apiUrl: 'https://app.vizzly.dev/api',
+        },
+      });
+
+      assert.deepStrictEqual(result, {
+        source: 'project-token',
+        target: null,
+      });
+    });
+
+    it('returns null when target is optional and nothing resolves', async () => {
+      let result = await resolveProjectTarget({
+        command: 'preview',
+        config: { apiKey: 'user-token' },
+        requireTarget: false,
+      });
+
+      assert.strictEqual(result, null);
+    });
+
+    it('throws a clear error when target is required and missing', async () => {
+      await assert.rejects(
+        () =>
+          resolveProjectTarget({
+            command: 'run',
+            config: { apiKey: 'user-token' },
+          }),
+        error => {
+          assert.strictEqual(error.code, 'VALIDATION_ERROR');
+          assert.ok(
+            error.message.includes('This command needs a target project')
+          );
+          return true;
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Why
The CLI was still mixing user login state and project-targeted build creation, which made local interactive workflows feel broken after removing `project:select`. This PR makes project targeting explicit and repo-local while keeping CI token flows working.

## Summary
- add explicit target resolution for `run`, `upload`, `preview`, and `finalize` via `--project-id` or `--org` + `--project`
- support repo-local `target` config in `vizzly.config.js` and send explicit target payloads to the API when using user auth
- scope login state by `apiUrl` for cloud and self-hosted setups, and write global config atomically to avoid startup races while reading auth
- add unit and integration coverage for targeting precedence, api-url-scoped auth, and the upload/finalize user-auth flow

## Test Plan
- `node --test tests/commands/targeting.integration.test.js tests/utils/global-config.test.js tests/commands/logout.test.js tests/commands/whoami.test.js tests/commands/run.test.js tests/commands/upload.test.js tests/commands/finalize.test.js tests/commands/preview.test.js tests/utils/project-target.test.js`
- `npm test` *(currently still fails in unrelated `tests/utils/colors.test.js` cases)*