### PR TITLE
✨ Split init and auth wiring

### DIFF
--- a/src/commands/config-cmd.js
+++ b/src/commands/config-cmd.js
@@ -2,6 +2,7 @@
  * Config command - query and display configuration
  */
 
+import { CONFIG_DEFAULTS } from '../config/core.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import * as defaultOutput from '../utils/output.js';
 
@@ -40,10 +41,10 @@ export async function configCommand(
 
     // Build the config object to display
     let displayConfig = {
-      server: config.server || { port: 47392, timeout: 30000 },
+      server: config.server || CONFIG_DEFAULTS.server,
       build: config.build || {},
       upload: config.upload || {},
-      comparison: config.comparison || { threshold: 2.0 },
+      comparison: config.comparison || CONFIG_DEFAULTS.comparison,
       tdd: config.tdd || {},
     };
 

--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -29,7 +29,7 @@ function validateLimitRange(value, flagName, { min = 1, max }) {
   }
 
   if (!Number.isInteger(value) || value < min || value > max) {
-    return [`${flagName} must be a number between ${min} and ${max}`];
+    return [`${flagName} must be an integer between ${min} and ${max}`];
   }
 
   return [];
@@ -41,7 +41,7 @@ function validateOffset(value) {
   }
 
   if (!Number.isInteger(value) || value < 0) {
-    return ['--offset must be a non-negative number'];
+    return ['--offset must be a non-negative integer'];
   }
 
   return [];

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -7,74 +7,156 @@ import { loadPlugins } from '../plugin-loader.js';
 import { loadConfig } from '../utils/config-loader.js';
 import * as output from '../utils/output.js';
 
-/**
- * Simple configuration setup for Vizzly CLI
- */
-export class InitCommand {
-  constructor(plugins = []) {
-    this.plugins = plugins;
+let configValueSchema = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(configValueSchema),
+    z.record(z.string(), configValueSchema),
+  ])
+);
+let configSchemaValidator = z.record(z.string(), configValueSchema);
+
+function createInitDeps(deps = {}) {
+  return {
+    access: deps.access || fs.access,
+    cwd: deps.cwd || (() => process.cwd()),
+    loadConfig: deps.loadConfig || loadConfig,
+    loadPlugins: deps.loadPlugins || loadPlugins,
+    output: deps.output || output,
+    writeFile: deps.writeFile || fs.writeFile,
+  };
+}
+
+function configureOutput(output, options) {
+  output.configure({
+    json: options.json || false,
+    verbose: options.verbose || false,
+    color: options.color !== false,
+  });
+}
+
+export function getInitConfigPath(cwd = process.cwd()) {
+  return path.join(cwd, 'vizzly.config.js');
+}
+
+export async function fileExists(filePath, access = fs.access) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getPluginsWithConfig(plugins = []) {
+  return plugins.filter(plugin => plugin.configSchema);
+}
+
+export function getPluginConfigNames(plugins = []) {
+  return getPluginsWithConfig(plugins).map(plugin => plugin.name);
+}
+
+function formatObjectKey(key) {
+  if (/^[A-Za-z_$][\w$]*$/.test(key)) {
+    return key;
   }
 
-  async run(options = {}) {
-    // Check for existing config
-    let configPath = path.join(process.cwd(), 'vizzly.config.js');
-    let hasConfig = await this.fileExists(configPath);
+  return formatValue(key);
+}
 
-    if (hasConfig && !options.force) {
-      // JSON output for skipped
-      if (options.json) {
-        output.data({
-          status: 'skipped',
-          reason: 'config_exists',
-          configPath,
-          message:
-            'A vizzly.config.js file already exists. Use --force to overwrite.',
-        });
-        return { status: 'skipped', configPath };
-      }
+export function formatValue(value, depth = 0) {
+  let indent = '  '.repeat(depth);
+  let nextIndent = '  '.repeat(depth + 1);
 
-      output.header('init');
-      output.warn('A vizzly.config.js file already exists');
-      output.hint('Use --force to overwrite');
-      return { status: 'skipped', configPath };
-    }
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (typeof value === 'string') {
+    return `'${value
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'")
+      .replace(/\n/g, '\\n')}'`;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
 
-    try {
-      // Generate config file with defaults
-      await this.generateConfigFile(configPath, options);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '[]';
 
-      // Get plugins with config for JSON output
-      let pluginsWithConfig = this.plugins.filter(p => p.configSchema);
-      let pluginNames = pluginsWithConfig.map(p => p.name);
+    let items = value.map(item => {
+      let formatted = formatValue(item, depth + 1);
+      return `${nextIndent}${formatted}`;
+    });
 
-      // JSON output for success
-      if (options.json) {
-        output.data({
-          status: 'created',
-          configPath,
-          plugins: pluginNames,
-        });
-        return { status: 'created', configPath, plugins: pluginNames };
-      }
+    return `[\n${items.join(',\n')}\n${indent}]`;
+  }
 
-      // Show next steps
-      this.showNextSteps();
+  if (typeof value === 'object') {
+    let entries = Object.entries(value);
+    if (entries.length === 0) return '{}';
 
-      output.blank();
-      output.complete('Vizzly CLI setup complete');
+    let props = entries.map(([key, entryValue]) => {
+      let formatted = formatValue(entryValue, depth + 1);
+      return `${nextIndent}${formatObjectKey(key)}: ${formatted}`;
+    });
 
-      return { status: 'created', configPath, plugins: pluginNames };
-    } catch (error) {
-      throw new VizzlyError(
-        'Failed to initialize Vizzly configuration',
-        'INIT_FAILED',
-        { error: error.message }
+    return `{\n${props.join(',\n')}\n${indent}}`;
+  }
+
+  return String(value);
+}
+
+export function formatPluginConfig(plugin, output = null) {
+  try {
+    configSchemaValidator.parse(plugin.configSchema);
+
+    let configEntries = [];
+
+    for (let [key, value] of Object.entries(plugin.configSchema)) {
+      let formattedValue = formatValue(value, 1);
+      configEntries.push(
+        `  // ${plugin.name} plugin configuration\n  ${formatObjectKey(key)}: ${formattedValue}`
       );
     }
+
+    return configEntries.join(',\n\n');
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      let messages = error.issues.map(
+        zodError => `${zodError.path.join('.')}: ${zodError.message}`
+      );
+      output?.warn(
+        `Invalid config schema for plugin ${plugin.name}: ${messages.join(', ')}`
+      );
+    } else {
+      output?.warn(
+        `Failed to format config for plugin ${plugin.name}: ${error.message}`
+      );
+    }
+    return '';
+  }
+}
+
+export function generatePluginConfigs(plugins = [], output = null) {
+  let sections = [];
+
+  for (let plugin of plugins) {
+    if (plugin.configSchema) {
+      let configStr = formatPluginConfig(plugin, output);
+      if (configStr) {
+        sections.push(configStr);
+      }
+    }
   }
 
-  async generateConfigFile(configPath, options = {}) {
-    let coreConfig = `export default {
+  return sections.length > 0 ? sections.join(',\n\n') : '';
+}
+
+export function createConfigContent(plugins = [], output = null) {
+  let coreConfig = `export default {
   // Server configuration (for run command)
   server: {
     port: 47392,
@@ -96,7 +178,8 @@ export class InitCommand {
 
   // Comparison configuration (CIEDE2000 Delta E: 0=exact, 1=JND, 2=recommended)
   comparison: {
-    threshold: 2.0
+    threshold: 2.0,
+    minClusterSize: 2
   },
 
   // TDD configuration
@@ -104,190 +187,130 @@ export class InitCommand {
     openReport: false // Whether to auto-open HTML report in browser
   }`;
 
-    // Add plugin configurations
-    const pluginConfigs = this.generatePluginConfigs();
-    if (pluginConfigs) {
-      coreConfig += `,\n\n${pluginConfigs}`;
-    }
-
-    coreConfig += '\n};\n';
-
-    await fs.writeFile(configPath, coreConfig, 'utf8');
-
-    // Skip human-readable output in JSON mode
-    if (options.json) return;
-
-    output.header('init');
-    output.complete('Created vizzly.config.js');
-
-    // Log discovered plugins
-    let pluginsWithConfig = this.plugins.filter(p => p.configSchema);
-    if (pluginsWithConfig.length > 0) {
-      output.hint(`Added config for ${pluginsWithConfig.length} plugin(s):`);
-      output.list(
-        pluginsWithConfig.map(p => p.name),
-        { indent: 4 }
-      );
-    }
+  let pluginConfigs = generatePluginConfigs(plugins, output);
+  if (pluginConfigs) {
+    coreConfig += `,\n\n${pluginConfigs}`;
   }
 
-  /**
-   * Generate configuration sections for plugins
-   * @returns {string} Plugin config sections as formatted string
-   */
-  generatePluginConfigs() {
-    const sections = [];
+  return `${coreConfig}\n};\n`;
+}
 
-    for (const plugin of this.plugins) {
-      if (plugin.configSchema) {
-        const configStr = this.formatPluginConfig(plugin);
-        if (configStr) {
-          sections.push(configStr);
-        }
-      }
-    }
+function writeHumanCreatedOutput(output, plugins) {
+  output.header('init');
+  output.complete('Created vizzly.config.js');
 
-    return sections.length > 0 ? sections.join(',\n\n') : '';
+  let pluginsWithConfig = getPluginsWithConfig(plugins);
+  if (pluginsWithConfig.length > 0) {
+    output.hint(`Added config for ${pluginsWithConfig.length} plugin(s):`);
+    output.list(
+      pluginsWithConfig.map(plugin => plugin.name),
+      { indent: 4 }
+    );
+  }
+}
+
+function showNextSteps(output) {
+  output.blank();
+  output.labelValue('Next steps', '');
+  output.list([
+    'Set your API token: export VIZZLY_TOKEN="your-api-key"',
+    'Run your tests with Vizzly: npx vizzly run "npm test"',
+    'Upload screenshots: npx vizzly upload ./screenshots',
+  ]);
+}
+
+async function writeConfigFile({
+  configPath,
+  plugins,
+  options,
+  output,
+  writeFile,
+}) {
+  let coreConfig = createConfigContent(plugins, output);
+
+  await writeFile(configPath, coreConfig, 'utf8');
+
+  if (!options.json) {
+    writeHumanCreatedOutput(output, plugins);
+  }
+}
+
+async function loadInitPlugins(options, deps) {
+  if (options.plugins) {
+    return options.plugins;
   }
 
-  /**
-   * Format a plugin's config schema as JavaScript code
-   * @param {Object} plugin - Plugin with configSchema
-   * @returns {string} Formatted config string
-   */
-  formatPluginConfig(plugin) {
-    try {
-      // Validate config schema structure with Zod (defensive check)
-      const configValueSchema = z.lazy(() =>
-        z.union([
-          z.string(),
-          z.number(),
-          z.boolean(),
-          z.null(),
-          z.array(configValueSchema),
-          z.record(configValueSchema),
-        ])
-      );
-      const configSchemaValidator = z.record(configValueSchema);
-      configSchemaValidator.parse(plugin.configSchema);
-
-      const configEntries = [];
-
-      for (const [key, value] of Object.entries(plugin.configSchema)) {
-        const formattedValue = this.formatValue(value, 1);
-        configEntries.push(
-          `  // ${plugin.name} plugin configuration\n  ${key}: ${formattedValue}`
-        );
-      }
-
-      return configEntries.join(',\n\n');
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        const messages = error.errors.map(
-          e => `${e.path.join('.')}: ${e.message}`
-        );
-        output.warn(
-          `Invalid config schema for plugin ${plugin.name}: ${messages.join(', ')}`
-        );
-      } else {
-        output.warn(
-          `Failed to format config for plugin ${plugin.name}: ${error.message}`
-        );
-      }
-      return '';
-    }
-  }
-
-  /**
-   * Format a JavaScript value with proper indentation
-   * @param {*} value - Value to format
-   * @param {number} depth - Current indentation depth
-   * @returns {string} Formatted value
-   */
-  formatValue(value, depth = 0) {
-    const indent = '  '.repeat(depth);
-    const nextIndent = '  '.repeat(depth + 1);
-
-    if (value === null) return 'null';
-    if (value === undefined) return 'undefined';
-    if (typeof value === 'string') return `'${value.replace(/'/g, "\\'")}'`;
-    if (typeof value === 'number' || typeof value === 'boolean')
-      return String(value);
-
-    if (Array.isArray(value)) {
-      if (value.length === 0) return '[]';
-
-      const items = value.map(item => {
-        const formatted = this.formatValue(item, depth + 1);
-        return `${nextIndent}${formatted}`;
-      });
-
-      return `[\n${items.join(',\n')}\n${indent}]`;
-    }
-
-    if (typeof value === 'object') {
-      const entries = Object.entries(value);
-      if (entries.length === 0) return '{}';
-
-      const props = entries.map(([k, v]) => {
-        const formatted = this.formatValue(v, depth + 1);
-        return `${nextIndent}${k}: ${formatted}`;
-      });
-
-      return `{\n${props.join(',\n')}\n${indent}}`;
-    }
-
-    return String(value);
-  }
-
-  showNextSteps() {
-    output.blank();
-    output.labelValue('Next steps', '');
-    output.list([
-      'Set your API token: export VIZZLY_TOKEN="your-api-key"',
-      'Run your tests with Vizzly: npx vizzly run "npm test"',
-      'Upload screenshots: npx vizzly upload ./screenshots',
-    ]);
-  }
-
-  async fileExists(filePath) {
-    try {
-      await fs.access(filePath);
-      return true;
-    } catch {
-      return false;
-    }
+  try {
+    let config = await deps.loadConfig(options.config, {});
+    return await deps.loadPlugins(options.config, config, null);
+  } catch {
+    return [];
   }
 }
 
 // Export factory function for CLI
 export function createInitCommand(options) {
-  const command = new InitCommand(options.plugins);
-  return () => command.run(options);
+  return () => init(options);
 }
 
-// Simple export for direct CLI usage
-export async function init(options = {}) {
-  output.configure({
-    json: options.json || false,
-    verbose: options.verbose || false,
-    color: options.color !== false,
-  });
+export async function init(options = {}, deps = {}) {
+  let resolvedDeps = createInitDeps(deps);
 
-  let plugins = [];
+  configureOutput(resolvedDeps.output, options);
 
-  // Try to load plugins if not provided
-  if (!options.plugins) {
-    try {
-      const config = await loadConfig(options.config, {});
-      plugins = await loadPlugins(options.config, config, null);
-    } catch {
-      // Silent fail - plugins are optional for init
+  let plugins = await loadInitPlugins(options, resolvedDeps);
+  let configPath = getInitConfigPath(resolvedDeps.cwd());
+  let hasConfig = await fileExists(configPath, resolvedDeps.access);
+
+  if (hasConfig && !options.force) {
+    if (options.json) {
+      resolvedDeps.output.data({
+        status: 'skipped',
+        reason: 'config_exists',
+        configPath,
+        message:
+          'A vizzly.config.js file already exists. Use --force to overwrite.',
+      });
+      return { status: 'skipped', configPath };
     }
-  } else {
-    plugins = options.plugins;
+
+    resolvedDeps.output.header('init');
+    resolvedDeps.output.warn('A vizzly.config.js file already exists');
+    resolvedDeps.output.hint('Use --force to overwrite');
+    return { status: 'skipped', configPath };
   }
 
-  const command = new InitCommand(plugins);
-  return await command.run(options);
+  try {
+    await writeConfigFile({
+      configPath,
+      plugins,
+      options,
+      output: resolvedDeps.output,
+      writeFile: resolvedDeps.writeFile,
+    });
+
+    let pluginNames = getPluginConfigNames(plugins);
+
+    if (options.json) {
+      resolvedDeps.output.data({
+        status: 'created',
+        configPath,
+        plugins: pluginNames,
+      });
+      return { status: 'created', configPath, plugins: pluginNames };
+    }
+
+    showNextSteps(resolvedDeps.output);
+
+    resolvedDeps.output.blank();
+    resolvedDeps.output.complete('Vizzly CLI setup complete');
+
+    return { status: 'created', configPath, plugins: pluginNames };
+  } catch (error) {
+    throw new VizzlyError(
+      'Failed to initialize Vizzly configuration',
+      'INIT_FAILED',
+      { error: error.message }
+    );
+  }
 }

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -14,17 +14,156 @@ import { openBrowser } from '../utils/browser.js';
 import { getApiUrl } from '../utils/environment-config.js';
 import * as output from '../utils/output.js';
 
-/**
- * Login command implementation using OAuth device flow
- * @param {Object} options - Command options
- * @param {Object} globalOptions - Global CLI options
- */
-export async function loginCommand(options = {}, globalOptions = {}) {
+function createLoginDeps(deps = {}) {
+  return {
+    completeDeviceFlow: deps.completeDeviceFlow || completeDeviceFlow,
+    createAuthClient: deps.createAuthClient || createAuthClient,
+    createTokenStore: deps.createTokenStore || createTokenStore,
+    getApiUrl: deps.getApiUrl || getApiUrl,
+    initiateDeviceFlow: deps.initiateDeviceFlow || initiateDeviceFlow,
+    now: deps.now || (() => Date.now()),
+    openBrowser: deps.openBrowser || openBrowser,
+    output: deps.output || output,
+    pollDeviceAuthorization:
+      deps.pollDeviceAuthorization || pollDeviceAuthorization,
+    waitForEnter: deps.waitForEnter || waitForEnter,
+    exit: deps.exit || (code => process.exit(code)),
+  };
+}
+
+function configureOutput(output, globalOptions) {
   output.configure({
     json: globalOptions.json,
     verbose: globalOptions.verbose,
     color: !globalOptions.noColor,
   });
+}
+
+export function normalizeDeviceFlowResponse(deviceFlow) {
+  let verificationUri =
+    deviceFlow.verification_uri || deviceFlow.verificationUri;
+  let userCode = deviceFlow.user_code || deviceFlow.userCode;
+  let deviceCode = deviceFlow.device_code || deviceFlow.deviceCode;
+
+  if (!verificationUri || !userCode || !deviceCode) {
+    throw new Error('Invalid device flow response from server');
+  }
+
+  return {
+    verificationUri,
+    userCode,
+    deviceCode,
+    urlWithCode: `${verificationUri}?code=${encodeURIComponent(userCode)}`,
+  };
+}
+
+export function resolveAuthorizedTokenData(pollResponse) {
+  let accessToken =
+    pollResponse.tokens?.accessToken || pollResponse.tokens?.access_token;
+
+  if (accessToken) {
+    return pollResponse;
+  }
+
+  if (pollResponse.status === 'pending') {
+    throw new Error(
+      'Authorization not complete yet. Please complete the authorization in your browser and try running "vizzly login" again.'
+    );
+  }
+  if (pollResponse.status === 'expired') {
+    throw new Error('Device code expired. Please try logging in again.');
+  }
+  if (pollResponse.status === 'denied') {
+    throw new Error('Authorization denied. Please try logging in again.');
+  }
+
+  throw new Error(
+    'Unexpected response from authorization server. Please try logging in again.'
+  );
+}
+
+export function buildTokens(tokenData, now = Date.now()) {
+  let tokensData = tokenData.tokens || tokenData;
+  let tokenExpiresIn = tokensData.expiresIn || tokensData.expires_in;
+  let tokenExpiresAt = tokenExpiresIn
+    ? new Date(now + tokenExpiresIn * 1000).toISOString()
+    : tokenData.expires_at || tokenData.expiresAt;
+
+  return {
+    accessToken: tokensData.accessToken || tokensData.access_token,
+    refreshToken: tokensData.refreshToken || tokensData.refresh_token,
+    expiresAt: tokenExpiresAt,
+    user: tokenData.user,
+    organizations: tokenData.organizations,
+  };
+}
+
+export function getTokenExpiryHint(expiresAt, now = Date.now()) {
+  if (!expiresAt) {
+    return null;
+  }
+
+  let expiry = new Date(expiresAt);
+  let msUntilExpiry = expiry.getTime() - now;
+  let daysUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60 * 24));
+  let hoursUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60));
+  let minutesUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60));
+
+  if (daysUntilExpiry > 0) {
+    return `Token expires in ${daysUntilExpiry} day${daysUntilExpiry !== 1 ? 's' : ''}`;
+  }
+  if (hoursUntilExpiry > 0) {
+    return `Token expires in ${hoursUntilExpiry} hour${hoursUntilExpiry !== 1 ? 's' : ''}`;
+  }
+  if (minutesUntilExpiry > 0) {
+    return `Token expires in ${minutesUntilExpiry} minute${minutesUntilExpiry !== 1 ? 's' : ''}`;
+  }
+
+  return null;
+}
+
+export async function waitForEnter(stdin = process.stdin) {
+  await new Promise(resolve => {
+    let canSetRawMode = typeof stdin.setRawMode === 'function';
+    if (canSetRawMode) {
+      stdin.setRawMode(true);
+    }
+    stdin.resume();
+    stdin.once('data', () => {
+      if (canSetRawMode) {
+        stdin.setRawMode(false);
+      }
+      stdin.pause();
+      resolve();
+    });
+  });
+}
+
+/**
+ * Login command implementation using OAuth device flow
+ * @param {Object} options - Command options
+ * @param {Object} globalOptions - Global CLI options
+ */
+export async function loginCommand(
+  options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    completeDeviceFlow,
+    createAuthClient,
+    createTokenStore,
+    getApiUrl,
+    initiateDeviceFlow,
+    now,
+    openBrowser,
+    output,
+    pollDeviceAuthorization,
+    waitForEnter,
+    exit,
+  } = createLoginDeps(deps);
+
+  configureOutput(output, globalOptions);
 
   let colors = output.getColors();
 
@@ -43,17 +182,8 @@ export async function loginCommand(options = {}, globalOptions = {}) {
     output.stopSpinner();
 
     // Handle both snake_case and camelCase field names
-    let verificationUri =
-      deviceFlow.verification_uri || deviceFlow.verificationUri;
-    let userCode = deviceFlow.user_code || deviceFlow.userCode;
-    let deviceCode = deviceFlow.device_code || deviceFlow.deviceCode;
-
-    if (!verificationUri || !userCode || !deviceCode) {
-      throw new Error('Invalid device flow response from server');
-    }
-
-    // Build URL with pre-filled code
-    let urlWithCode = `${verificationUri}?code=${userCode}`;
+    let { deviceCode, urlWithCode, userCode } =
+      normalizeDeviceFlowResponse(deviceFlow);
 
     // Display user code prominently in a box
     output.printBox(
@@ -83,15 +213,7 @@ export async function loginCommand(options = {}, globalOptions = {}) {
     output.hint('After authorizing, press Enter to continue...');
 
     // Wait for user to press Enter
-    await new Promise(resolve => {
-      process.stdin.setRawMode(true);
-      process.stdin.resume();
-      process.stdin.once('data', () => {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
-        resolve();
-      });
-    });
+    await waitForEnter();
 
     // Check authorization status
     output.startSpinner('Checking authorization...');
@@ -100,41 +222,11 @@ export async function loginCommand(options = {}, globalOptions = {}) {
 
     output.stopSpinner();
 
-    let tokenData = null;
-
-    // Check if authorization was successful by looking for tokens
-    if (pollResponse.tokens?.accessToken) {
-      // Success! We got tokens
-      tokenData = pollResponse;
-    } else if (pollResponse.status === 'pending') {
-      throw new Error(
-        'Authorization not complete yet. Please complete the authorization in your browser and try running "vizzly login" again.'
-      );
-    } else if (pollResponse.status === 'expired') {
-      throw new Error('Device code expired. Please try logging in again.');
-    } else if (pollResponse.status === 'denied') {
-      throw new Error('Authorization denied. Please try logging in again.');
-    } else {
-      throw new Error(
-        'Unexpected response from authorization server. Please try logging in again.'
-      );
-    }
+    let tokenData = resolveAuthorizedTokenData(pollResponse);
 
     // Complete device flow and save tokens
     // Handle both snake_case and camelCase for token data, and nested tokens object
-    let tokensData = tokenData.tokens || tokenData;
-    let tokenExpiresIn = tokensData.expiresIn || tokensData.expires_in;
-    let tokenExpiresAt = tokenExpiresIn
-      ? new Date(Date.now() + tokenExpiresIn * 1000).toISOString()
-      : tokenData.expires_at || tokenData.expiresAt;
-
-    let tokens = {
-      accessToken: tokensData.accessToken || tokensData.access_token,
-      refreshToken: tokensData.refreshToken || tokensData.refresh_token,
-      expiresAt: tokenExpiresAt,
-      user: tokenData.user,
-      organizations: tokenData.organizations,
-    };
+    let tokens = buildTokens(tokenData, now());
     await completeDeviceFlow(tokenStore, tokens);
 
     // Display success
@@ -162,24 +254,9 @@ export async function loginCommand(options = {}, globalOptions = {}) {
     // Show token expiry info
     if (tokens.expiresAt) {
       output.blank();
-      let expiresAt = new Date(tokens.expiresAt);
-      let msUntilExpiry = expiresAt.getTime() - Date.now();
-      let daysUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60 * 24));
-      let hoursUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60));
-      let minutesUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60));
-
-      if (daysUntilExpiry > 0) {
-        output.hint(
-          `Token expires in ${daysUntilExpiry} day${daysUntilExpiry !== 1 ? 's' : ''}`
-        );
-      } else if (hoursUntilExpiry > 0) {
-        output.hint(
-          `Token expires in ${hoursUntilExpiry} hour${hoursUntilExpiry !== 1 ? 's' : ''}`
-        );
-      } else if (minutesUntilExpiry > 0) {
-        output.hint(
-          `Token expires in ${minutesUntilExpiry} minute${minutesUntilExpiry !== 1 ? 's' : ''}`
-        );
+      let expiryHint = getTokenExpiryHint(tokens.expiresAt, now());
+      if (expiryHint) {
+        output.hint(expiryHint);
       }
     }
 
@@ -198,15 +275,18 @@ export async function loginCommand(options = {}, globalOptions = {}) {
       output.hint(
         "If you don't have an account, sign up at https://vizzly.dev"
       );
-      process.exit(1);
+      output.cleanup();
+      exit(1);
     } else if (error.code === 'RATE_LIMIT_ERROR') {
       output.error('Too many login attempts', error);
       output.blank();
       output.hint('Please wait a few minutes before trying again');
-      process.exit(1);
+      output.cleanup();
+      exit(1);
     } else {
       output.error('Login failed', error);
-      process.exit(1);
+      output.cleanup();
+      exit(1);
     }
   }
 }
@@ -216,7 +296,7 @@ export async function loginCommand(options = {}, globalOptions = {}) {
  * @param {Object} options - Command options
  */
 export function validateLoginOptions() {
-  const errors = [];
+  let errors = [];
 
   // No specific validation needed for login command
   // OAuth device flow handles everything via browser

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -4,20 +4,35 @@
  */
 
 import {
-  createAuthClient,
-  createTokenStore,
-  getAuthTokens,
-  logout,
+  createAuthClient as defaultCreateAuthClient,
+  createTokenStore as defaultCreateTokenStore,
+  getAuthTokens as defaultGetAuthTokens,
+  logout as defaultLogout,
 } from '../auth/index.js';
-import { getApiUrl } from '../utils/environment-config.js';
-import * as output from '../utils/output.js';
+import { getApiUrl as defaultGetApiUrl } from '../utils/environment-config.js';
+import * as defaultOutput from '../utils/output.js';
 
 /**
  * Logout command implementation
  * @param {Object} options - Command options
  * @param {Object} globalOptions - Global CLI options
+ * @param {Object} deps - Dependencies for testing
  */
-export async function logoutCommand(options = {}, globalOptions = {}) {
+export async function logoutCommand(
+  options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    createAuthClient = defaultCreateAuthClient,
+    createTokenStore = defaultCreateTokenStore,
+    getApiUrl = defaultGetApiUrl,
+    getAuthTokens = defaultGetAuthTokens,
+    logout = defaultLogout,
+    output = defaultOutput,
+    exit = code => process.exit(code),
+  } = deps;
+
   output.configure({
     json: globalOptions.json,
     verbose: globalOptions.verbose,
@@ -64,7 +79,8 @@ export async function logoutCommand(options = {}, globalOptions = {}) {
   } catch (error) {
     output.stopSpinner();
     output.error('Logout failed', error);
-    process.exit(1);
+    output.cleanup();
+    exit(1);
   }
 }
 
@@ -73,7 +89,7 @@ export async function logoutCommand(options = {}, globalOptions = {}) {
  * @param {Object} options - Command options
  */
 export function validateLogoutOptions() {
-  const errors = [];
+  let errors = [];
 
   // No specific validation needed for logout command
 

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -4,20 +4,78 @@
  */
 
 import {
-  createAuthClient,
-  createTokenStore,
-  getAuthTokens,
-  whoami,
+  createAuthClient as defaultCreateAuthClient,
+  createTokenStore as defaultCreateTokenStore,
+  getAuthTokens as defaultGetAuthTokens,
+  whoami as defaultWhoami,
 } from '../auth/index.js';
-import { getApiUrl } from '../utils/environment-config.js';
-import * as output from '../utils/output.js';
+import { getApiUrl as defaultGetApiUrl } from '../utils/environment-config.js';
+import * as defaultOutput from '../utils/output.js';
+
+export function getTokenExpiryStatus(expiresAt, now = new Date()) {
+  let expiresDate = new Date(expiresAt);
+  let msUntilExpiry = expiresDate.getTime() - now.getTime();
+  let daysUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60 * 24));
+  let hoursUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60));
+  let minutesUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60));
+
+  if (msUntilExpiry <= 0) {
+    return {
+      level: 'warn',
+      message: 'Token has expired',
+      refreshHint: 'Run "vizzly login" to refresh your authentication',
+    };
+  }
+
+  if (daysUntilExpiry > 0) {
+    return {
+      level: 'hint',
+      message: `Token expires in ${daysUntilExpiry} day${daysUntilExpiry !== 1 ? 's' : ''} (${expiresDate.toLocaleDateString()})`,
+    };
+  }
+
+  if (hoursUntilExpiry > 0) {
+    return {
+      level: 'hint',
+      message: `Token expires in ${hoursUntilExpiry} hour${hoursUntilExpiry !== 1 ? 's' : ''}`,
+    };
+  }
+
+  if (minutesUntilExpiry > 0) {
+    return {
+      level: 'hint',
+      message: `Token expires in ${minutesUntilExpiry} minute${minutesUntilExpiry !== 1 ? 's' : ''}`,
+    };
+  }
+
+  return {
+    level: 'warn',
+    message: 'Token expires in less than a minute',
+    refreshHint: 'Run "vizzly login" to refresh your authentication',
+  };
+}
 
 /**
  * Whoami command implementation
  * @param {Object} options - Command options
  * @param {Object} globalOptions - Global CLI options
+ * @param {Object} deps - Dependencies for testing
  */
-export async function whoamiCommand(options = {}, globalOptions = {}) {
+export async function whoamiCommand(
+  options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    createAuthClient = defaultCreateAuthClient,
+    createTokenStore = defaultCreateTokenStore,
+    getApiUrl = defaultGetApiUrl,
+    getAuthTokens = defaultGetAuthTokens,
+    output = defaultOutput,
+    whoami = defaultWhoami,
+    exit = code => process.exit(code),
+  } = deps;
+
   output.configure({
     json: globalOptions.json,
     verbose: globalOptions.verbose,
@@ -110,35 +168,21 @@ export async function whoamiCommand(options = {}, globalOptions = {}) {
     // Show token expiry info
     if (auth.expiresAt) {
       output.blank();
-      let expiresAt = new Date(auth.expiresAt);
-      let now = new Date();
-      let msUntilExpiry = expiresAt.getTime() - now.getTime();
-      let daysUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60 * 24));
-      let hoursUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60 * 60));
-      let minutesUntilExpiry = Math.floor(msUntilExpiry / (1000 * 60));
-
-      if (msUntilExpiry <= 0) {
-        output.warn('Token has expired');
-        output.hint('Run "vizzly login" to refresh your authentication');
-      } else if (daysUntilExpiry > 0) {
-        output.hint(
-          `Token expires in ${daysUntilExpiry} day${daysUntilExpiry !== 1 ? 's' : ''} (${expiresAt.toLocaleDateString()})`
-        );
-      } else if (hoursUntilExpiry > 0) {
-        output.hint(
-          `Token expires in ${hoursUntilExpiry} hour${hoursUntilExpiry !== 1 ? 's' : ''}`
-        );
-      } else if (minutesUntilExpiry > 0) {
-        output.hint(
-          `Token expires in ${minutesUntilExpiry} minute${minutesUntilExpiry !== 1 ? 's' : ''}`
-        );
+      let expiry = getTokenExpiryStatus(auth.expiresAt);
+      if (expiry.level === 'warn') {
+        output.warn(expiry.message);
       } else {
-        output.warn('Token expires in less than a minute');
-        output.hint('Run "vizzly login" to refresh your authentication');
+        output.hint(expiry.message);
+      }
+
+      if (expiry.refreshHint) {
+        output.hint(expiry.refreshHint);
       }
 
       if (globalOptions.verbose) {
-        output.hint(`Token expires at: ${expiresAt.toISOString()}`);
+        output.hint(
+          `Token expires at: ${new Date(auth.expiresAt).toISOString()}`
+        );
       }
     }
 
@@ -159,10 +203,11 @@ export async function whoamiCommand(options = {}, globalOptions = {}) {
         output.hint('Run "vizzly login" to authenticate again');
       }
       output.cleanup();
-      process.exit(1);
+      exit(1);
     } else {
       output.error('Failed to get user information', error);
-      process.exit(1);
+      output.cleanup();
+      exit(1);
     }
   }
 }
@@ -172,7 +217,7 @@ export async function whoamiCommand(options = {}, globalOptions = {}) {
  * @param {Object} options - Command options
  */
 export function validateWhoamiOptions() {
-  const errors = [];
+  let errors = [];
 
   // No specific validation needed for whoami command
 

--- a/tests/commands/config-cmd.test.js
+++ b/tests/commands/config-cmd.test.js
@@ -44,7 +44,7 @@ describe('commands/config', () => {
         {
           loadConfig: async () => ({
             server: { port: 47392, timeout: 30000 },
-            comparison: { threshold: 2.0 },
+            comparison: { threshold: 2.0, minClusterSize: 2 },
             tdd: { openReport: false },
           }),
           output,
@@ -56,6 +56,30 @@ describe('commands/config', () => {
       assert.ok(dataCall);
       assert.strictEqual(dataCall.args[0].config.server.port, 47392);
       assert.strictEqual(dataCall.args[0].config.comparison.threshold, 2.0);
+      assert.strictEqual(dataCall.args[0].config.comparison.minClusterSize, 2);
+    });
+
+    it('shows complete comparison defaults when config omits that section', async () => {
+      let output = createMockOutput();
+
+      await configCommand(
+        null,
+        {},
+        { json: true },
+        {
+          loadConfig: async () => ({
+            server: { port: 47392, timeout: 30000 },
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let dataCall = output.calls.find(c => c.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0].config.comparison, {
+        threshold: 2.0,
+        minClusterSize: 2,
+      });
     });
 
     it('outputs specific key as JSON', async () => {

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -52,7 +52,25 @@ describe('commands/context', () => {
     it('rejects out-of-range comparison context limits', () => {
       let errors = validateContextComparisonOptions({ similarLimit: 51 });
       assert.ok(
-        errors.includes('--similar-limit must be a number between 1 and 50')
+        errors.includes('--similar-limit must be an integer between 1 and 50')
+      );
+    });
+
+    it('rejects malformed and decimal comparison context limits', () => {
+      assert.ok(
+        validateContextComparisonOptions({
+          similarLimit: Number('10abc'),
+        }).includes('--similar-limit must be an integer between 1 and 50')
+      );
+      assert.ok(
+        validateContextComparisonOptions({ recentLimit: 4.5 }).includes(
+          '--recent-limit must be an integer between 1 and 50'
+        )
+      );
+      assert.ok(
+        validateContextComparisonOptions({ windowSize: 2.5 }).includes(
+          '--window-size must be an integer between 1 and 50'
+        )
       );
     });
 
@@ -63,12 +81,25 @@ describe('commands/context', () => {
 
     it('rejects out-of-range similar limit', () => {
       let errors = validateContextSimilarOptions({ limit: 0 });
-      assert.ok(errors.includes('--limit must be a number between 1 and 50'));
+      assert.ok(errors.includes('--limit must be an integer between 1 and 50'));
     });
 
     it('rejects negative review queue offsets', () => {
       let errors = validateContextReviewQueueOptions({ offset: -1 });
-      assert.ok(errors.includes('--offset must be a non-negative number'));
+      assert.ok(errors.includes('--offset must be a non-negative integer'));
+    });
+
+    it('rejects malformed and decimal review queue pagination', () => {
+      assert.ok(
+        validateContextReviewQueueOptions({ limit: Number('20abc') }).includes(
+          '--limit must be an integer between 1 and 100'
+        )
+      );
+      assert.ok(
+        validateContextReviewQueueOptions({ offset: 1.5 }).includes(
+          '--offset must be a non-negative integer'
+        )
+      );
     });
   });
 

--- a/tests/commands/init.test.js
+++ b/tests/commands/init.test.js
@@ -1,0 +1,268 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+import { promisify } from 'node:util';
+import {
+  createConfigContent,
+  formatPluginConfig,
+  formatValue,
+  getInitConfigPath,
+  init,
+} from '../../src/commands/init.js';
+
+let execFileAsync = promisify(execFile);
+
+function createMockOutput() {
+  let calls = [];
+  return {
+    calls,
+    blank: () => calls.push({ method: 'blank', args: [] }),
+    complete: message => calls.push({ method: 'complete', args: [message] }),
+    configure: opts => calls.push({ method: 'configure', args: [opts] }),
+    data: value => calls.push({ method: 'data', args: [value] }),
+    header: command => calls.push({ method: 'header', args: [command] }),
+    hint: message => calls.push({ method: 'hint', args: [message] }),
+    labelValue: (label, value) =>
+      calls.push({ method: 'labelValue', args: [label, value] }),
+    list: (items, options) =>
+      calls.push({ method: 'list', args: [items, options] }),
+    warn: message => calls.push({ method: 'warn', args: [message] }),
+  };
+}
+
+async function createTempProject() {
+  return mkdtemp(path.join(tmpdir(), 'vizzly-init-test-'));
+}
+
+describe('commands/init', () => {
+  describe('config helpers', () => {
+    it('formats plugin config as valid object properties', () => {
+      let pluginConfig = formatPluginConfig({
+        name: 'custom',
+        configSchema: {
+          'api-token': "rob's-token",
+          nested: {
+            'branch-name': 'main',
+            paths: ['screenshots', 'visuals'],
+          },
+        },
+      });
+
+      assert.match(pluginConfig, /'api-token': 'rob\\'s-token'/);
+      assert.match(pluginConfig, /'branch-name': 'main'/);
+      assert.match(pluginConfig, /paths: \[/);
+    });
+
+    it('escapes strings without changing supported scalar values', () => {
+      assert.strictEqual(
+        formatValue("rob's\\path\nnext"),
+        "'rob\\'s\\\\path\\nnext'"
+      );
+      assert.strictEqual(formatValue(true), 'true');
+      assert.strictEqual(formatValue(null), 'null');
+      assert.strictEqual(formatValue([1, 'two']), "[\n  1,\n  'two'\n]");
+    });
+
+    it('creates config content with plugin sections', () => {
+      let config = createConfigContent([
+        {
+          name: 'storybook',
+          configSchema: {
+            storybook: {
+              url: 'http://localhost:6006',
+            },
+          },
+        },
+      ]);
+
+      assert.match(config, /export default \{/);
+      assert.match(config, /server: \{/);
+      assert.match(config, /storybook plugin configuration/);
+      assert.match(config, /url: 'http:\/\/localhost:6006'/);
+      assert.match(config, /\n\};\n$/);
+    });
+
+    it('creates syntactically valid config when plugin keys need quoting', async () => {
+      let cwd = await createTempProject();
+      let configPath = path.join(cwd, 'vizzly.config.js');
+      let config = createConfigContent([
+        {
+          name: 'custom',
+          configSchema: {
+            'api-token': "rob's-token",
+          },
+        },
+      ]);
+
+      await writeFile(configPath, config);
+
+      let { NODE_V8_COVERAGE: _coverage, ...env } = process.env;
+      await execFileAsync(process.execPath, ['--check', configPath], { env });
+
+      assert.match(config, /'api-token': 'rob\\'s-token'/);
+    });
+  });
+
+  describe('init', () => {
+    it('creates a default config and prints human next steps', async () => {
+      let cwd = await createTempProject();
+      let output = createMockOutput();
+
+      let result = await init(
+        {
+          plugins: [
+            {
+              name: 'storybook',
+              configSchema: { storybook: { url: 'http://localhost:6006' } },
+            },
+          ],
+        },
+        {
+          cwd: () => cwd,
+          output,
+        }
+      );
+
+      let configPath = getInitConfigPath(cwd);
+      let config = await readFile(configPath, 'utf8');
+
+      assert.deepStrictEqual(result, {
+        status: 'created',
+        configPath,
+        plugins: ['storybook'],
+      });
+      assert.match(config, /Build \{timestamp\}/);
+      assert.match(config, /minClusterSize: 2/);
+      assert.match(config, /storybook plugin configuration/);
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'complete' &&
+            call.args[0] === 'Created vizzly.config.js'
+        )
+      );
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'complete' &&
+            call.args[0] === 'Vizzly CLI setup complete'
+        )
+      );
+    });
+
+    it('returns JSON output when config is created in JSON mode', async () => {
+      let cwd = await createTempProject();
+      let output = createMockOutput();
+
+      await init(
+        {
+          json: true,
+          plugins: [{ name: 'plain-plugin' }],
+        },
+        {
+          cwd: () => cwd,
+          output,
+        }
+      );
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0], {
+        status: 'created',
+        configPath: getInitConfigPath(cwd),
+        plugins: [],
+      });
+      assert.ok(!output.calls.some(call => call.method === 'header'));
+    });
+
+    it('skips an existing config without overwriting it', async () => {
+      let cwd = await createTempProject();
+      let configPath = getInitConfigPath(cwd);
+      let output = createMockOutput();
+
+      await writeFile(configPath, 'export default { existing: true };\n');
+
+      let result = await init(
+        {
+          plugins: [],
+        },
+        {
+          cwd: () => cwd,
+          output,
+        }
+      );
+
+      let config = await readFile(configPath, 'utf8');
+
+      assert.deepStrictEqual(result, { status: 'skipped', configPath });
+      assert.strictEqual(config, 'export default { existing: true };\n');
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'warn' &&
+            call.args[0] === 'A vizzly.config.js file already exists'
+        )
+      );
+    });
+
+    it('overwrites an existing config when forced', async () => {
+      let cwd = await createTempProject();
+      let configPath = getInitConfigPath(cwd);
+
+      await writeFile(configPath, 'export default { existing: true };\n');
+
+      let result = await init(
+        {
+          force: true,
+          json: true,
+          plugins: [],
+        },
+        {
+          cwd: () => cwd,
+          output: createMockOutput(),
+        }
+      );
+
+      let config = await readFile(configPath, 'utf8');
+
+      assert.strictEqual(result.status, 'created');
+      assert.match(config, /server: \{/);
+      assert.doesNotMatch(config, /existing: true/);
+    });
+
+    it('loads plugins from config when plugins are not provided', async () => {
+      let cwd = await createTempProject();
+      let output = createMockOutput();
+      let loadedConfig = null;
+
+      await init(
+        { json: true, config: 'vizzly.config.js' },
+        {
+          cwd: () => cwd,
+          loadConfig: async (configPath, defaults) => {
+            loadedConfig = { configPath, defaults };
+            return { apiUrl: 'https://api.example.test' };
+          },
+          loadPlugins: async (_configPath, config) => [
+            {
+              name: 'loaded',
+              config,
+              configSchema: { loaded: true },
+            },
+          ],
+          output,
+        }
+      );
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+
+      assert.deepStrictEqual(loadedConfig, {
+        configPath: 'vizzly.config.js',
+        defaults: {},
+      });
+      assert.deepStrictEqual(dataCall.args[0].plugins, ['loaded']);
+    });
+  });
+});

--- a/tests/commands/login.test.js
+++ b/tests/commands/login.test.js
@@ -1,0 +1,337 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  buildTokens,
+  getTokenExpiryHint,
+  loginCommand,
+  normalizeDeviceFlowResponse,
+  resolveAuthorizedTokenData,
+  validateLoginOptions,
+} from '../../src/commands/login.js';
+
+function createMockOutput() {
+  let calls = [];
+  return {
+    calls,
+    configure: opts => calls.push({ method: 'configure', args: [opts] }),
+    header: command => calls.push({ method: 'header', args: [command] }),
+    printBox: (lines, options) =>
+      calls.push({ method: 'printBox', args: [lines, options] }),
+    blank: () => calls.push({ method: 'blank', args: [] }),
+    complete: message => calls.push({ method: 'complete', args: [message] }),
+    warn: message => calls.push({ method: 'warn', args: [message] }),
+    hint: message => calls.push({ method: 'hint', args: [message] }),
+    keyValue: value => calls.push({ method: 'keyValue', args: [value] }),
+    labelValue: (label, value) =>
+      calls.push({ method: 'labelValue', args: [label, value] }),
+    list: items => calls.push({ method: 'list', args: [items] }),
+    error: (message, error) =>
+      calls.push({ method: 'error', args: [message, error] }),
+    startSpinner: message =>
+      calls.push({ method: 'startSpinner', args: [message] }),
+    stopSpinner: () => calls.push({ method: 'stopSpinner', args: [] }),
+    cleanup: () => calls.push({ method: 'cleanup', args: [] }),
+    getColors: () => ({
+      bold: value => value,
+      brand: {
+        amber: value => value,
+        info: value => value,
+      },
+    }),
+  };
+}
+
+function createLoginHarness({ browserOpened = true, pollResponse } = {}) {
+  let output = createMockOutput();
+  let authClientConfig = null;
+  let completedTokens = null;
+  let polledDeviceCode = null;
+  let exitCode = null;
+  let waitCount = 0;
+
+  return {
+    output,
+    get authClientConfig() {
+      return authClientConfig;
+    },
+    get completedTokens() {
+      return completedTokens;
+    },
+    get polledDeviceCode() {
+      return polledDeviceCode;
+    },
+    get exitCode() {
+      return exitCode;
+    },
+    get waitCount() {
+      return waitCount;
+    },
+    deps: {
+      completeDeviceFlow: async (_tokenStore, tokens) => {
+        completedTokens = tokens;
+      },
+      createAuthClient: config => {
+        authClientConfig = config;
+        return { kind: 'auth-client' };
+      },
+      createTokenStore: () => ({ kind: 'token-store' }),
+      getApiUrl: () => 'https://api.default.test',
+      initiateDeviceFlow: async () => ({
+        verification_uri: 'https://auth.example.test/device',
+        user_code: 'ABCD-EFGH',
+        device_code: 'device-code-1',
+      }),
+      now: () => Date.parse('2026-05-18T12:00:00.000Z'),
+      openBrowser: async () => browserOpened,
+      output,
+      pollDeviceAuthorization: async (_client, deviceCode) => {
+        polledDeviceCode = deviceCode;
+        return (
+          pollResponse || {
+            tokens: {
+              accessToken: 'access-token',
+              refreshToken: 'refresh-token',
+              expiresIn: 86400,
+            },
+            user: {
+              name: 'Robert',
+              email: 'robert@example.test',
+            },
+            organizations: [{ name: 'Vizzly', slug: 'vizzly' }],
+          }
+        );
+      },
+      waitForEnter: async () => {
+        waitCount += 1;
+      },
+      exit: code => {
+        exitCode = code;
+      },
+    },
+  };
+}
+
+describe('commands/login', () => {
+  describe('validateLoginOptions', () => {
+    it('returns no errors', () => {
+      assert.deepStrictEqual(validateLoginOptions({}), []);
+    });
+  });
+
+  describe('device flow helpers', () => {
+    it('normalizes snake_case and camelCase device flow responses', () => {
+      assert.deepStrictEqual(
+        normalizeDeviceFlowResponse({
+          verification_uri: 'https://auth.test/device',
+          user_code: 'A B',
+          device_code: 'device-1',
+        }),
+        {
+          verificationUri: 'https://auth.test/device',
+          userCode: 'A B',
+          deviceCode: 'device-1',
+          urlWithCode: 'https://auth.test/device?code=A%20B',
+        }
+      );
+      assert.deepStrictEqual(
+        normalizeDeviceFlowResponse({
+          verificationUri: 'https://auth.test/device',
+          userCode: 'CODE',
+          deviceCode: 'device-2',
+        }).deviceCode,
+        'device-2'
+      );
+      assert.throws(
+        () => normalizeDeviceFlowResponse({}),
+        /Invalid device flow response/
+      );
+    });
+
+    it('resolves authorization responses into tokens or user-facing errors', () => {
+      let authorized = { tokens: { accessToken: 'token' } };
+      let snakeCaseAuthorized = { tokens: { access_token: 'token' } };
+
+      assert.strictEqual(resolveAuthorizedTokenData(authorized), authorized);
+      assert.strictEqual(
+        resolveAuthorizedTokenData(snakeCaseAuthorized),
+        snakeCaseAuthorized
+      );
+      assert.throws(
+        () => resolveAuthorizedTokenData({ status: 'pending' }),
+        /Authorization not complete/
+      );
+      assert.throws(
+        () => resolveAuthorizedTokenData({ status: 'expired' }),
+        /Device code expired/
+      );
+      assert.throws(
+        () => resolveAuthorizedTokenData({ status: 'denied' }),
+        /Authorization denied/
+      );
+    });
+
+    it('builds stored tokens and expiry hints deterministically', () => {
+      let now = Date.parse('2026-05-18T12:00:00.000Z');
+
+      assert.deepStrictEqual(
+        buildTokens(
+          {
+            tokens: {
+              access_token: 'access-token',
+              refresh_token: 'refresh-token',
+              expires_in: 3600,
+            },
+            user: { email: 'robert@example.test' },
+            organizations: [{ slug: 'vizzly' }],
+          },
+          now
+        ),
+        {
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: '2026-05-18T13:00:00.000Z',
+          user: { email: 'robert@example.test' },
+          organizations: [{ slug: 'vizzly' }],
+        }
+      );
+      assert.strictEqual(
+        getTokenExpiryHint('2026-05-20T12:00:00.000Z', now),
+        'Token expires in 2 days'
+      );
+      assert.strictEqual(
+        getTokenExpiryHint('2026-05-18T14:00:00.000Z', now),
+        'Token expires in 2 hours'
+      );
+      assert.strictEqual(
+        getTokenExpiryHint('2026-05-18T12:30:00.000Z', now),
+        'Token expires in 30 minutes'
+      );
+    });
+  });
+
+  describe('loginCommand', () => {
+    it('completes device login and stores tokens', async () => {
+      let harness = createLoginHarness();
+
+      await loginCommand(
+        { apiUrl: 'https://api.override.test' },
+        {},
+        harness.deps
+      );
+
+      assert.deepStrictEqual(harness.authClientConfig, {
+        baseUrl: 'https://api.override.test',
+      });
+      assert.strictEqual(harness.polledDeviceCode, 'device-code-1');
+      assert.strictEqual(harness.waitCount, 1);
+      assert.deepStrictEqual(harness.completedTokens, {
+        accessToken: 'access-token',
+        refreshToken: 'refresh-token',
+        expiresAt: '2026-05-19T12:00:00.000Z',
+        user: {
+          name: 'Robert',
+          email: 'robert@example.test',
+        },
+        organizations: [{ name: 'Vizzly', slug: 'vizzly' }],
+      });
+      assert.ok(
+        harness.output.calls.some(
+          call => call.method === 'complete' && call.args[0] === 'Authenticated'
+        )
+      );
+      assert.ok(harness.output.calls.some(call => call.method === 'cleanup'));
+    });
+
+    it('shows a manual browser hint when browser open fails', async () => {
+      let harness = createLoginHarness({ browserOpened: false });
+
+      await loginCommand({}, {}, harness.deps);
+
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'warn' &&
+            call.args[0] === 'Could not open browser automatically'
+        )
+      );
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'hint' &&
+            call.args[0] === 'Please open the URL manually'
+        )
+      );
+    });
+
+    it('exits with a helpful message when authorization is still pending', async () => {
+      let harness = createLoginHarness({
+        pollResponse: { status: 'pending' },
+      });
+
+      await loginCommand({}, {}, harness.deps);
+
+      assert.strictEqual(harness.exitCode, 1);
+      assert.strictEqual(harness.completedTokens, null);
+      assert.ok(
+        harness.output.calls.some(
+          call => call.method === 'error' && call.args[0] === 'Login failed'
+        )
+      );
+      assert.ok(harness.output.calls.some(call => call.method === 'cleanup'));
+    });
+
+    it('uses auth-specific recovery hints for auth errors', async () => {
+      let harness = createLoginHarness();
+      let authError = new Error('bad auth');
+      authError.name = 'AuthError';
+      harness.deps.initiateDeviceFlow = async () => {
+        throw authError;
+      };
+
+      await loginCommand({}, {}, harness.deps);
+
+      assert.strictEqual(harness.exitCode, 1);
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'error' && call.args[0] === 'Authentication failed'
+        )
+      );
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'hint' &&
+            call.args[0] ===
+              "If you don't have an account, sign up at https://vizzly.dev"
+        )
+      );
+    });
+
+    it('uses rate-limit recovery hints for rate-limit errors', async () => {
+      let harness = createLoginHarness();
+      let rateLimitError = new Error('slow down');
+      rateLimitError.code = 'RATE_LIMIT_ERROR';
+      harness.deps.initiateDeviceFlow = async () => {
+        throw rateLimitError;
+      };
+
+      await loginCommand({}, {}, harness.deps);
+
+      assert.strictEqual(harness.exitCode, 1);
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'error' &&
+            call.args[0] === 'Too many login attempts'
+        )
+      );
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'hint' &&
+            call.args[0] === 'Please wait a few minutes before trying again'
+        )
+      );
+    });
+  });
+});

--- a/tests/commands/logout.test.js
+++ b/tests/commands/logout.test.js
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  logoutCommand,
+  validateLogoutOptions,
+} from '../../src/commands/logout.js';
+
+function createMockOutput() {
+  let calls = [];
+  return {
+    calls,
+    configure: opts => calls.push({ method: 'configure', args: [opts] }),
+    data: obj => calls.push({ method: 'data', args: [obj] }),
+    header: command => calls.push({ method: 'header', args: [command] }),
+    print: message => calls.push({ method: 'print', args: [message] }),
+    blank: () => calls.push({ method: 'blank', args: [] }),
+    hint: message => calls.push({ method: 'hint', args: [message] }),
+    complete: message => calls.push({ method: 'complete', args: [message] }),
+    error: (message, error) =>
+      calls.push({ method: 'error', args: [message, error] }),
+    startSpinner: message =>
+      calls.push({ method: 'startSpinner', args: [message] }),
+    stopSpinner: () => calls.push({ method: 'stopSpinner', args: [] }),
+    cleanup: () => calls.push({ method: 'cleanup', args: [] }),
+  };
+}
+
+let auth = {
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+};
+
+describe('commands/logout', () => {
+  describe('validateLogoutOptions', () => {
+    it('returns no errors', () => {
+      assert.deepStrictEqual(validateLogoutOptions({}), []);
+    });
+  });
+
+  describe('logoutCommand', () => {
+    it('returns not_logged_in JSON when no token is stored', async () => {
+      let output = createMockOutput();
+
+      await logoutCommand(
+        {},
+        { json: true },
+        {
+          getAuthTokens: async () => null,
+          output,
+        }
+      );
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0], {
+        loggedOut: false,
+        reason: 'not_logged_in',
+      });
+      assert.ok(output.calls.some(call => call.method === 'cleanup'));
+    });
+
+    it('logs out with the configured auth client and token store', async () => {
+      let output = createMockOutput();
+      let capturedBaseUrl = null;
+      let capturedTokenStore = null;
+
+      await logoutCommand(
+        { apiUrl: 'https://api.example.test' },
+        { json: true },
+        {
+          getAuthTokens: async () => auth,
+          createAuthClient: ({ baseUrl }) => {
+            capturedBaseUrl = baseUrl;
+            return { kind: 'client' };
+          },
+          createTokenStore: () => ({ kind: 'store' }),
+          logout: async (_client, tokenStore) => {
+            capturedTokenStore = tokenStore;
+          },
+          output,
+        }
+      );
+
+      assert.strictEqual(capturedBaseUrl, 'https://api.example.test');
+      assert.deepStrictEqual(capturedTokenStore, { kind: 'store' });
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0], { loggedOut: true });
+    });
+
+    it('prints human-readable logout confirmation', async () => {
+      let output = createMockOutput();
+
+      await logoutCommand(
+        {},
+        {},
+        {
+          getAuthTokens: async () => auth,
+          getApiUrl: () => 'https://api.test',
+          createAuthClient: () => ({}),
+          createTokenStore: () => ({}),
+          logout: async () => {},
+          output,
+        }
+      );
+
+      assert.ok(
+        output.calls.some(
+          call => call.method === 'complete' && call.args[0] === 'Logged out'
+        )
+      );
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'hint' &&
+            call.args[0] === 'Run "vizzly login" to authenticate again'
+        )
+      );
+    });
+
+    it('reports logout failures and exits with status 1', async () => {
+      let output = createMockOutput();
+      let exitCode = null;
+
+      await logoutCommand(
+        {},
+        {},
+        {
+          getAuthTokens: async () => auth,
+          createAuthClient: () => ({}),
+          createTokenStore: () => ({}),
+          logout: async () => {
+            throw new Error('network failed');
+          },
+          output,
+          exit: code => {
+            exitCode = code;
+          },
+        }
+      );
+
+      assert.strictEqual(exitCode, 1);
+      assert.ok(output.calls.some(call => call.method === 'error'));
+      assert.ok(output.calls.some(call => call.method === 'cleanup'));
+    });
+  });
+});

--- a/tests/commands/whoami.test.js
+++ b/tests/commands/whoami.test.js
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  getTokenExpiryStatus,
+  validateWhoamiOptions,
+  whoamiCommand,
+} from '../../src/commands/whoami.js';
+
+function createMockOutput() {
+  let calls = [];
+  return {
+    calls,
+    configure: opts => calls.push({ method: 'configure', args: [opts] }),
+    data: obj => calls.push({ method: 'data', args: [obj] }),
+    header: command => calls.push({ method: 'header', args: [command] }),
+    print: message => calls.push({ method: 'print', args: [message] }),
+    blank: () => calls.push({ method: 'blank', args: [] }),
+    hint: message => calls.push({ method: 'hint', args: [message] }),
+    warn: message => calls.push({ method: 'warn', args: [message] }),
+    error: (message, error) =>
+      calls.push({ method: 'error', args: [message, error] }),
+    keyValue: values => calls.push({ method: 'keyValue', args: [values] }),
+    labelValue: (label, value) =>
+      calls.push({ method: 'labelValue', args: [label, value] }),
+    list: items => calls.push({ method: 'list', args: [items] }),
+    startSpinner: message =>
+      calls.push({ method: 'startSpinner', args: [message] }),
+    stopSpinner: () => calls.push({ method: 'stopSpinner', args: [] }),
+    cleanup: () => calls.push({ method: 'cleanup', args: [] }),
+  };
+}
+
+let auth = {
+  accessToken: 'access-token',
+  refreshToken: 'refresh-token',
+  expiresAt: '2026-05-19T12:00:00.000Z',
+};
+
+let response = {
+  user: {
+    id: 'user-1',
+    name: 'Robert',
+    username: 'rob',
+    email: 'rob@example.com',
+  },
+  organizations: [
+    {
+      id: 'org-1',
+      name: 'Vizzly',
+      slug: 'vizzly',
+      role: 'owner',
+    },
+  ],
+};
+
+describe('commands/whoami', () => {
+  describe('validateWhoamiOptions', () => {
+    it('returns no errors', () => {
+      assert.deepStrictEqual(validateWhoamiOptions({}), []);
+    });
+  });
+
+  describe('getTokenExpiryStatus', () => {
+    it('formats expired tokens with a refresh hint', () => {
+      let result = getTokenExpiryStatus(
+        '2026-05-18T11:59:00.000Z',
+        new Date('2026-05-18T12:00:00.000Z')
+      );
+
+      assert.deepStrictEqual(result, {
+        level: 'warn',
+        message: 'Token has expired',
+        refreshHint: 'Run "vizzly login" to refresh your authentication',
+      });
+    });
+
+    it('formats hour-level expiry', () => {
+      let result = getTokenExpiryStatus(
+        '2026-05-18T14:00:00.000Z',
+        new Date('2026-05-18T12:00:00.000Z')
+      );
+
+      assert.deepStrictEqual(result, {
+        level: 'hint',
+        message: 'Token expires in 2 hours',
+      });
+    });
+
+    it('formats less-than-minute expiry with a refresh hint', () => {
+      let result = getTokenExpiryStatus(
+        '2026-05-18T12:00:30.000Z',
+        new Date('2026-05-18T12:00:00.000Z')
+      );
+
+      assert.deepStrictEqual(result, {
+        level: 'warn',
+        message: 'Token expires in less than a minute',
+        refreshHint: 'Run "vizzly login" to refresh your authentication',
+      });
+    });
+  });
+
+  describe('whoamiCommand', () => {
+    it('returns unauthenticated JSON when no token is stored', async () => {
+      let output = createMockOutput();
+
+      await whoamiCommand(
+        {},
+        { json: true },
+        {
+          getAuthTokens: async () => null,
+          output,
+        }
+      );
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0], { authenticated: false });
+      assert.ok(output.calls.some(call => call.method === 'cleanup'));
+    });
+
+    it('fetches user info with the configured auth client', async () => {
+      let output = createMockOutput();
+      let capturedBaseUrl = null;
+      let capturedTokenStore = null;
+
+      await whoamiCommand(
+        { apiUrl: 'https://api.example.test' },
+        { json: true },
+        {
+          getAuthTokens: async () => auth,
+          createAuthClient: ({ baseUrl }) => {
+            capturedBaseUrl = baseUrl;
+            return { kind: 'client' };
+          },
+          createTokenStore: () => ({ kind: 'store' }),
+          whoami: async (_client, tokenStore) => {
+            capturedTokenStore = tokenStore;
+            return response;
+          },
+          output,
+        }
+      );
+
+      assert.strictEqual(capturedBaseUrl, 'https://api.example.test');
+      assert.deepStrictEqual(capturedTokenStore, { kind: 'store' });
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.strictEqual(dataCall.args[0].authenticated, true);
+      assert.deepStrictEqual(dataCall.args[0].user, response.user);
+      assert.deepStrictEqual(
+        dataCall.args[0].organizations,
+        response.organizations
+      );
+      assert.strictEqual(dataCall.args[0].tokenExpiresAt, auth.expiresAt);
+    });
+
+    it('prints human-readable user and organization information', async () => {
+      let output = createMockOutput();
+
+      await whoamiCommand(
+        {},
+        { verbose: true },
+        {
+          getAuthTokens: async () => auth,
+          getApiUrl: () => 'https://api.test',
+          createAuthClient: () => ({}),
+          createTokenStore: () => ({}),
+          whoami: async () => response,
+          output,
+        }
+      );
+
+      let keyValueCall = output.calls.find(call => call.method === 'keyValue');
+      assert.strictEqual(keyValueCall.args[0].User, 'Robert');
+      assert.strictEqual(keyValueCall.args[0].Email, 'rob@example.com');
+      assert.strictEqual(keyValueCall.args[0]['User ID'], 'user-1');
+
+      let listCall = output.calls.find(call => call.method === 'list');
+      assert.deepStrictEqual(listCall.args[0], ['Vizzly @vizzly [owner]']);
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'hint' && call.args[0].includes('Token expires')
+        )
+      );
+    });
+
+    it('reports auth errors and exits with status 1', async () => {
+      let output = createMockOutput();
+      let exitCode = null;
+      let error = new Error('expired');
+      error.name = 'AuthError';
+
+      await whoamiCommand(
+        {},
+        { json: true },
+        {
+          getAuthTokens: async () => auth,
+          createAuthClient: () => ({}),
+          createTokenStore: () => ({}),
+          whoami: async () => {
+            throw error;
+          },
+          output,
+          exit: code => {
+            exitCode = code;
+          },
+        }
+      );
+
+      assert.strictEqual(exitCode, 1);
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0], {
+        authenticated: false,
+        error: 'expired',
+      });
+      assert.ok(output.calls.some(call => call.method === 'cleanup'));
+    });
+  });
+});

--- a/tests/helpers/cli-runner.js
+++ b/tests/helpers/cli-runner.js
@@ -45,8 +45,6 @@ function createCleanEnv(overrides = {}) {
     // Remove any tokens
     VIZZLY_TOKEN: undefined,
     VIZZLY_API_KEY: undefined,
-    // Pass through V8 coverage directory so child processes contribute to coverage
-    NODE_V8_COVERAGE: process.env.NODE_V8_COVERAGE,
     ...overrides,
   };
 }
@@ -70,7 +68,13 @@ export async function runCLI(args, options = {}) {
     mkdirSync(cwd, { recursive: true });
   }
 
-  let cleanEnv = createCleanEnv(env);
+  let vizzlyHome = env.VIZZLY_HOME || join(cwd, '.vizzly-home');
+  mkdirSync(vizzlyHome, { recursive: true });
+
+  let cleanEnv = createCleanEnv({
+    VIZZLY_HOME: vizzlyHome,
+    ...env,
+  });
 
   return new Promise((resolve, reject) => {
     let child = spawn('node', [CLI_PATH, ...args], {


### PR DESCRIPTION
## Why

The first user experience with the CLI is setup and authentication. Those commands need to fail clearly, avoid touching real user state in tests, and keep config/auth concerns explicit. Before this cleanup, init/auth coverage was uneven and a few flows were harder to reason about because setup, token handling, and command output expectations were spread across command implementations.

This PR groups the setup and identity commands together so reviewers can validate the onboarding/auth story as one slice: config inspection, init behavior, login/logout, whoami, and local context.

## What Changed

- Hardened `init`, `config`, `context`, `login`, `logout`, and `whoami` command behavior.
- Expanded command tests around successful output, clear failure modes, and isolated CLI state.
- Updated the CLI runner helper where the command tests needed a safer shared boundary.
- Kept the slice focused on setup/auth rather than mixing in API, server, or uploader behavior.

## Verification

- `npm run lint`
- `node --test tests/commands/config-cmd.test.js tests/commands/context.test.js tests/commands/init.test.js tests/commands/login.test.js tests/commands/logout.test.js tests/commands/whoami.test.js`

## Stack

3/10 in the CLI audit stack.

Base: `rd/cli-audit-shared-utils`  
Head: `rd/cli-audit-init-auth`
