### PR TITLE
♻️ Split Storybook client wiring

### DIFF
--- a/clients/ember/bin/vizzly-testem-launcher.js
+++ b/clients/ember/bin/vizzly-testem-launcher.js
@@ -103,7 +103,10 @@ async function main() {
 
     // 2. Determine failOnDiff: env var > server.json > default (false)
     let failOnDiff = false;
-    if (process.env.VIZZLY_FAIL_ON_DIFF === 'true' || process.env.VIZZLY_FAIL_ON_DIFF === '1') {
+    if (
+      process.env.VIZZLY_FAIL_ON_DIFF === 'true' ||
+      process.env.VIZZLY_FAIL_ON_DIFF === '1'
+    ) {
       failOnDiff = true;
     } else {
       let serverInfo = getServerInfo();

--- a/clients/ember/src/launcher/screenshot-server.js
+++ b/clients/ember/src/launcher/screenshot-server.js
@@ -181,7 +181,9 @@ function httpPost(url, data) {
 
         if (res.statusCode >= 400) {
           reject(
-            new Error(`Vizzly server error: ${res.statusCode} - ${responseBody}`)
+            new Error(
+              `Vizzly server error: ${res.statusCode} - ${responseBody}`
+            )
           );
           return;
         }

--- a/clients/ember/src/test-support/index.js
+++ b/clients/ember/src/test-support/index.js
@@ -161,8 +161,10 @@ function prepareTestingContainer(width = 1280, height = 720, fullPage = false) {
  * @returns {boolean}
  */
 function shouldFailOnDiff() {
-  return window.__VIZZLY_FAIL_ON_DIFF__ === true ||
-         window.__VIZZLY_FAIL_ON_DIFF__ === 'true';
+  return (
+    window.__VIZZLY_FAIL_ON_DIFF__ === true ||
+    window.__VIZZLY_FAIL_ON_DIFF__ === 'true'
+  );
 }
 
 /**
@@ -285,7 +287,9 @@ export async function vizzlyScreenshot(name, options = {}) {
       // Check if this is a "no server" error - gracefully skip instead of failing
       // This allows tests to pass when Vizzly isn't running (like Percy behavior)
       if (errorText.includes('No Vizzly server found')) {
-        console.warn('[vizzly] Vizzly server not running. Skipping visual screenshot.');
+        console.warn(
+          '[vizzly] Vizzly server not running. Skipping visual screenshot.'
+        );
         return { status: 'skipped', reason: 'no-server' };
       }
 
@@ -302,12 +306,14 @@ export async function vizzlyScreenshot(name, options = {}) {
       if (shouldFail) {
         throw new VizzlyDiffError(
           `Visual difference detected for '${name}' (${result.diffPercentage?.toFixed(2)}% diff). ` +
-          `View diff in Vizzly dashboard.`
+            `View diff in Vizzly dashboard.`
         );
       }
 
       // Log warning but don't fail
-      console.warn(`[vizzly] Visual difference detected for '${name}'. View diff in Vizzly dashboard.`);
+      console.warn(
+        `[vizzly] Visual difference detected for '${name}'. View diff in Vizzly dashboard.`
+      );
     }
 
     return result;
@@ -320,7 +326,9 @@ export async function vizzlyScreenshot(name, options = {}) {
     // Log connection errors only once to avoid spam
     if (!hasLoggedConnectionError) {
       hasLoggedConnectionError = true;
-      console.warn(`[vizzly] Screenshots skipped - server not available. Run 'vizzly tdd start' to enable.`);
+      console.warn(
+        `[vizzly] Screenshots skipped - server not available. Run 'vizzly tdd start' to enable.`
+      );
     }
     return { status: 'skipped', reason: 'error', error: error.message };
   } finally {

--- a/clients/ember/tests/unit/screenshot-server.test.js
+++ b/clients/ember/tests/unit/screenshot-server.test.js
@@ -231,7 +231,10 @@ describe('screenshot-server', () => {
         // (unless there's a server.json in a parent directory)
         if (info !== null) {
           assert.ok(typeof info.url === 'string', 'should have url');
-          assert.ok(typeof info.failOnDiff === 'boolean', 'should have failOnDiff');
+          assert.ok(
+            typeof info.failOnDiff === 'boolean',
+            'should have failOnDiff'
+          );
         }
       } finally {
         process.chdir(originalCwd);
@@ -260,8 +263,16 @@ describe('screenshot-server', () => {
         let info = getServerInfo();
 
         assert.ok(info !== null, 'should find server.json');
-        assert.strictEqual(info.url, 'http://localhost:47392', 'should have correct url');
-        assert.strictEqual(info.failOnDiff, true, 'should read failOnDiff as true');
+        assert.strictEqual(
+          info.url,
+          'http://localhost:47392',
+          'should have correct url'
+        );
+        assert.strictEqual(
+          info.failOnDiff,
+          true,
+          'should read failOnDiff as true'
+        );
       } finally {
         process.chdir(originalCwd);
       }
@@ -287,8 +298,16 @@ describe('screenshot-server', () => {
         let info = getServerInfo();
 
         assert.ok(info !== null, 'should find server.json');
-        assert.strictEqual(info.url, 'http://localhost:47393', 'should have correct url');
-        assert.strictEqual(info.failOnDiff, false, 'should default failOnDiff to false');
+        assert.strictEqual(
+          info.url,
+          'http://localhost:47393',
+          'should have correct url'
+        );
+        assert.strictEqual(
+          info.failOnDiff,
+          false,
+          'should default failOnDiff to false'
+        );
       } finally {
         process.chdir(originalCwd);
       }

--- a/clients/ember/tests/unit/testem-config.test.js
+++ b/clients/ember/tests/unit/testem-config.test.js
@@ -155,7 +155,10 @@ describe('testem-config', () => {
 
       configure({}, {});
 
-      assert.ok(!existsSync(configPath), 'should not write empty playwright.json');
+      assert.ok(
+        !existsSync(configPath),
+        'should not write empty playwright.json'
+      );
     });
 
     it('handles lowercase browser names', () => {

--- a/clients/storybook/README.md
+++ b/clients/storybook/README.md
@@ -54,7 +54,7 @@ await run('./storybook-static', {
   viewports: 'mobile:375x667,desktop:1920x1080',
   concurrency: 3,
 }, {
-  logger: console,
+  output: console,
 });
 ```
 

--- a/clients/storybook/src/crawler.js
+++ b/clients/storybook/src/crawler.js
@@ -129,7 +129,9 @@ export function filterStories(stories, config) {
     let storyConfig = extractStoryConfig(story);
     if (storyConfig?.skip) {
       if (verbose) {
-        console.error(`  [filter] Skipping ${story.id} (parameters.vizzly.skip)`);
+        console.error(
+          `  [filter] Skipping ${story.id} (parameters.vizzly.skip)`
+        );
       }
       return false;
     }

--- a/clients/storybook/src/index.js
+++ b/clients/storybook/src/index.js
@@ -4,6 +4,8 @@
  * Uses a tab pool for efficient browser tab management
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, parse } from 'node:path';
 import { closeBrowser, launchBrowser } from './browser.js';
 import { loadConfig } from './config.js';
 import { discoverStories } from './crawler.js';
@@ -16,9 +18,6 @@ import { generateTasks, processAllTasks } from './tasks.js';
  * @returns {Promise<boolean>} True if TDD server is running
  */
 async function isTddModeAvailable() {
-  let { existsSync, readFileSync } = await import('node:fs');
-  let { join, parse, dirname } = await import('node:path');
-
   try {
     // Look for .vizzly/server.json
     let currentDir = process.cwd();
@@ -64,11 +63,17 @@ function hasApiToken(config) {
  * Uses a tab pool for efficient parallel screenshot capture
  * @param {string} storybookPath - Path to static Storybook build
  * @param {Object} options - CLI options
- * @param {Object} context - Plugin context (logger, config, services)
+ * @param {Object} context - Plugin context (output, config, services)
  * @returns {Promise<void>}
  */
 export async function run(storybookPath, options = {}, context = {}) {
-  let { logger, config: vizzlyConfig, services } = context;
+  let {
+    output: providedOutput,
+    logger: legacyOutput,
+    config: vizzlyConfig,
+    services,
+  } = context;
+  let output = providedOutput || legacyOutput;
   let browser = null;
   let pool = null;
   let serverInfo = null;
@@ -77,8 +82,10 @@ export async function run(storybookPath, options = {}, context = {}) {
   let buildId = null;
   let startTime = null;
 
-  if (!logger) {
-    throw new Error('Logger is required but was not provided in context');
+  if (!output) {
+    throw new Error(
+      'Output utilities are required but were not provided in context'
+    );
   }
 
   try {
@@ -90,9 +97,9 @@ export async function run(storybookPath, options = {}, context = {}) {
     let hasToken = hasApiToken(vizzlyConfig);
 
     if (isTdd) {
-      logger.info('📍 TDD mode: Using local server');
+      output.info('📍 TDD mode: Using local server');
     } else if (hasToken) {
-      logger.info('☁️  Run mode: Uploading to cloud');
+      output.info('☁️  Run mode: Uploading to cloud');
     }
 
     let buildUrl = null;
@@ -108,7 +115,7 @@ export async function run(storybookPath, options = {}, context = {}) {
         testRunner.once('build-created', buildInfo => {
           if (buildInfo.url) {
             buildUrl = buildInfo.url;
-            logger.info(`🔗 ${buildInfo.url}`);
+            output.info(`🔗 ${buildInfo.url}`);
           }
         });
 
@@ -125,7 +132,7 @@ export async function run(storybookPath, options = {}, context = {}) {
           pullRequestNumber = gitInfo.prNumber;
         } else {
           // Fallback for older CLI versions - use environment variables
-          logger.warn(
+          output.warn(
             '⚠️  Upgrade to @vizzly-testing/cli@>=0.25.0 for improved git detection'
           );
           branch = process.env.VIZZLY_BRANCH || 'main';
@@ -167,16 +174,16 @@ export async function run(storybookPath, options = {}, context = {}) {
         process.env.VIZZLY_ENABLED = 'true';
       } catch (error) {
         // Log the error and continue without cloud mode
-        logger.error(`Failed to initialize cloud mode: ${error.message}`);
-        logger.warn('⚠️  Falling back to local-only mode');
-        logger.info('   Screenshots will not be uploaded to cloud');
+        output.error(`Failed to initialize cloud mode: ${error.message}`);
+        output.warn('⚠️  Falling back to local-only mode');
+        output.info('   Screenshots will not be uploaded to cloud');
         testRunner = null;
       }
     }
 
     if (!isTdd && !hasToken) {
-      logger.warn('⚠️  No TDD server or API token found');
-      logger.info('   Run `vizzly tdd start` or set VIZZLY_TOKEN');
+      output.warn('⚠️  No TDD server or API token found');
+      output.info('   Run `vizzly tdd start` or set VIZZLY_TOKEN');
     }
 
     // Start HTTP server to serve Storybook static files
@@ -184,12 +191,12 @@ export async function run(storybookPath, options = {}, context = {}) {
 
     // Discover stories
     let stories = await discoverStories(config.storybookPath, config);
-    logger.info(
+    output.info(
       `📚 Found ${stories.length} stories in ${config.storybookPath}`
     );
 
     if (stories.length === 0) {
-      logger.warn('⚠️  No stories found');
+      output.warn('⚠️  No stories found');
       return;
     }
 
@@ -199,18 +206,18 @@ export async function run(storybookPath, options = {}, context = {}) {
 
     // Generate all tasks upfront (stories × viewports)
     let tasks = generateTasks(stories, serverInfo.url, config);
-    logger.info(
+    output.info(
       `📸 Processing ${tasks.length} screenshots (${config.concurrency} concurrent tabs)`
     );
 
     // Process all tasks through the tab pool
-    let errors = await processAllTasks(tasks, pool, config, logger);
+    let errors = await processAllTasks(tasks, pool, config, output);
 
     // Report summary
     if (errors.length > 0) {
-      logger.warn(`\n⚠️  ${errors.length} screenshot(s) failed:`);
+      output.warn(`\n⚠️  ${errors.length} screenshot(s) failed:`);
       errors.forEach(({ story, viewport, error }) => {
-        logger.error(`   ${story}@${viewport}: ${error}`);
+        output.error(`   ${story}@${viewport}: ${error}`);
       });
     }
 
@@ -220,11 +227,11 @@ export async function run(storybookPath, options = {}, context = {}) {
       await testRunner.finalizeBuild(buildId, false, true, executionTime);
 
       if (buildUrl) {
-        logger.info(`🔗 View results: ${buildUrl}`);
+        output.info(`🔗 View results: ${buildUrl}`);
       }
     }
   } catch (error) {
-    logger.error('Failed to process stories:', error.message);
+    output.error('Failed to process stories:', error.message);
 
     // Mark build as failed if in run mode
     if (testRunner && buildId) {

--- a/clients/storybook/src/navigation.js
+++ b/clients/storybook/src/navigation.js
@@ -47,7 +47,9 @@ export async function navigateToStory(page, storyId, baseUrl, options = {}) {
     await fullPageNavigation(page, storyId, baseUrl, timeout);
 
     if (verbose) {
-      console.error(`  [nav] ${storyId}: full-page took ${Date.now() - start}ms`);
+      console.error(
+        `  [nav] ${storyId}: full-page took ${Date.now() - start}ms`
+      );
     }
 
     if (entry) {
@@ -71,7 +73,9 @@ export async function navigateToStory(page, storyId, baseUrl, options = {}) {
     await clientSideNavigation(page, storyId, timeout);
 
     if (verbose) {
-      console.error(`  [nav] ${storyId}: client-side took ${Date.now() - start}ms`);
+      console.error(
+        `  [nav] ${storyId}: client-side took ${Date.now() - start}ms`
+      );
     }
     entry.currentStoryId = storyId;
   } catch (error) {
@@ -83,7 +87,9 @@ export async function navigateToStory(page, storyId, baseUrl, options = {}) {
     await fullPageNavigation(page, storyId, baseUrl, timeout);
 
     if (verbose) {
-      console.error(`  [nav] ${storyId}: fallback full-page took ${Date.now() - start}ms`);
+      console.error(
+        `  [nav] ${storyId}: fallback full-page took ${Date.now() - start}ms`
+      );
     }
     entry.currentStoryId = storyId;
   }
@@ -152,10 +158,10 @@ async function clientSideNavigation(page, storyId, timeout) {
         // Navigate to the story
         preview.channel.emit('setCurrentStory', { storyId: id });
 
-        // Timeout fallback - use configured timeout
+        // Trigger the full-page fallback when Storybook does not emit a render.
         timeoutId = setTimeout(() => {
           preview.channel.off('storyRendered', handleRendered);
-          resolve(); // Resolve anyway - story might have rendered
+          reject(new Error(`Storybook did not render ${id} before timeout`));
         }, timeoutMs);
       });
     },

--- a/clients/storybook/src/plugin.js
+++ b/clients/storybook/src/plugin.js
@@ -38,10 +38,10 @@ export default {
    * @param {import('commander').Command} program - Commander program instance
    * @param {Object} context - Plugin context
    * @param {Object} context.config - Vizzly configuration
-   * @param {Object} context.logger - Logger instance
+   * @param {Object} context.output - Output utilities
    * @param {Object} context.services - Service container
    */
-  register(program, { config, logger, services }) {
+  register(program, { config, output, services }) {
     program
       .command('storybook <path>')
       .description('Capture screenshots from static Storybook build')
@@ -78,14 +78,14 @@ export default {
           let mergedOptions = { ...globalOptions, ...options };
 
           await run(path, mergedOptions, {
-            logger,
+            output,
             config,
             services,
           });
         } catch (error) {
           console.error('Failed to run Storybook plugin:', error);
-          if (logger?.error) {
-            logger.error('Failed to run Storybook plugin:', error.message);
+          if (output?.error) {
+            output.error('Failed to run Storybook plugin:', error);
           }
           process.exit(1);
         }

--- a/clients/storybook/src/pool.js
+++ b/clients/storybook/src/pool.js
@@ -36,7 +36,10 @@ export function createTabPool(browser, size, options = {}) {
   let createContextEntry = async () => {
     let contextOptions = {};
     if (viewport) {
-      contextOptions.viewport = { width: viewport.width, height: viewport.height };
+      contextOptions.viewport = {
+        width: viewport.width,
+        height: viewport.height,
+      };
     }
     let context = await browser.newContext(contextOptions);
     let page = await context.newPage();

--- a/clients/storybook/src/server.js
+++ b/clients/storybook/src/server.js
@@ -15,12 +15,20 @@ import handler from 'serve-handler';
  */
 export async function startStaticServer(rootDir, port = 0) {
   let absoluteRoot = resolve(rootDir);
+  let sockets = new Set();
 
   let server = createServer((req, res) => {
     return handler(req, res, {
       public: absoluteRoot,
       cleanUrls: false,
       trailingSlash: false,
+    });
+  });
+
+  server.on('connection', socket => {
+    sockets.add(socket);
+    socket.on('close', () => {
+      sockets.delete(socket);
     });
   });
 
@@ -34,6 +42,7 @@ export async function startStaticServer(rootDir, port = 0) {
         server,
         port: actualPort,
         url,
+        sockets,
       });
     });
 
@@ -51,7 +60,25 @@ export async function stopStaticServer(serverInfo) {
     return;
   }
 
-  return new Promise(resolve => {
-    serverInfo.server.close(() => resolve());
+  let { server, sockets = new Set() } = serverInfo;
+
+  await new Promise((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    });
+
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections();
+      return;
+    }
+
+    for (let socket of sockets) {
+      socket.destroy();
+    }
   });
 }

--- a/clients/storybook/src/tasks.js
+++ b/clients/storybook/src/tasks.js
@@ -106,7 +106,11 @@ export async function processTask(tab, task, deps = {}) {
 
   // Log timing breakdown in verbose mode
   if (verbose) {
-    let total = timings.viewport + timings.navigate + (timings.hook || 0) + timings.screenshot;
+    let total =
+      timings.viewport +
+      timings.navigate +
+      (timings.hook || 0) +
+      timings.screenshot;
     let hookStr = timings.hook ? ` hook=${timings.hook}ms` : '';
     console.error(
       `  [timing] ${storyId}@${viewport.name}: viewport=${timings.viewport}ms nav=${timings.navigate}ms${hookStr} screenshot=${timings.screenshot}ms (total=${total}ms)`
@@ -205,14 +209,14 @@ function createOutputCoordinator() {
     /**
      * Queue an error message to be printed
      * @param {string} message - Error message
-     * @param {Object} logger - Logger instance
+     * @param {Object} output - Output utilities
      */
-    logError(message, logger) {
+    logError(message, output) {
       if (isInteractiveTTY()) {
         // Queue error to be printed before next progress update
         pendingErrors.push(message);
       }
-      logger.error(message);
+      output.error(message);
     },
 
     /**
@@ -236,18 +240,18 @@ function createOutputCoordinator() {
  * @param {Array<Object>} tasks - Array of task objects
  * @param {Object} pool - Tab pool { acquire, release }
  * @param {Object} config - Configuration object
- * @param {Object} logger - Logger instance
+ * @param {Object} output - Output utilities
  * @param {Object} [deps] - Optional dependencies for testing
  * @returns {Promise<Array>} Array of errors encountered
  */
-export async function processAllTasks(tasks, pool, config, logger, deps = {}) {
+export async function processAllTasks(tasks, pool, config, output, deps = {}) {
   let errors = [];
   let completed = 0;
   let total = tasks.length;
   let startTime = Date.now();
   let taskTimes = [];
   let interactive = isInteractiveTTY();
-  let output = createOutputCoordinator();
+  let progressOutput = createOutputCoordinator();
 
   // Minimum samples before showing ETA (avoids wild estimates from cold start)
   let minSamplesForEta = Math.min(5, Math.ceil(total * 0.1));
@@ -337,12 +341,12 @@ export async function processAllTasks(tasks, pool, config, logger, deps = {}) {
 
         if (interactive) {
           // Update single progress line
-          output.writeProgress(
+          progressOutput.writeProgress(
             `   📸 [${completed}/${total}] ${percent}% ${eta} - ${formatStory(task.story)}@${task.viewport.name}`
           );
         } else {
           // Non-interactive: log each completion
-          logger.info(
+          output.info(
             `   ✓ [${completed}/${total}] ${formatStory(task.story)}@${task.viewport.name} ${eta}`
           );
         }
@@ -359,9 +363,9 @@ export async function processAllTasks(tasks, pool, config, logger, deps = {}) {
           error: result.error.message + retryNote,
         });
 
-        output.logError(
+        progressOutput.logError(
           `   ✗ ${formatStory(task.story)}@${task.viewport.name}: ${result.error.message}${retryNote}`,
-          logger
+          output
         );
 
         if (result.tab) {
@@ -373,16 +377,16 @@ export async function processAllTasks(tasks, pool, config, logger, deps = {}) {
   );
 
   // Flush any remaining output
-  output.flush();
+  progressOutput.flush();
 
   // Log total time
   let totalTime = Date.now() - startTime;
-  logger.info(
+  output.info(
     `   ✅ Completed ${total} screenshots in ${formatDuration(totalTime)}`
   );
 
   if (errors.length > 0) {
-    logger.warn(`   ⚠️  ${errors.length} failed`);
+    output.warn(`   ⚠️  ${errors.length} failed`);
   }
 
   return errors;

--- a/clients/storybook/tests/concurrency.test.js
+++ b/clients/storybook/tests/concurrency.test.js
@@ -5,27 +5,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-// Simple concurrency control - process items with limited parallelism
-async function mapWithConcurrency(items, fn, concurrency) {
-  let results = [];
-  let executing = [];
-
-  for (let item of items) {
-    let promise = fn(item).then(result => {
-      executing.splice(executing.indexOf(promise), 1);
-      return result;
-    });
-
-    results.push(promise);
-    executing.push(promise);
-
-    if (executing.length >= concurrency) {
-      await Promise.race(executing);
-    }
-  }
-
-  await Promise.all(results);
-}
+import { mapWithConcurrency } from '../src/tasks.js';
 
 describe('mapWithConcurrency', () => {
   it('should process all items', async () => {
@@ -54,7 +34,7 @@ describe('mapWithConcurrency', () => {
       async _item => {
         activeCount++;
         maxConcurrent = Math.max(maxConcurrent, activeCount);
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise(resolve => setImmediate(resolve));
         activeCount--;
       },
       2

--- a/clients/storybook/tests/crawler.test.js
+++ b/clients/storybook/tests/crawler.test.js
@@ -191,7 +191,10 @@ describe('filterStories', () => {
     ];
     let filtered = filterStories(storiesWithBoth, config);
 
-    assert.equal(filtered.find(s => s.id === 'card--both-skipped'), undefined);
+    assert.equal(
+      filtered.find(s => s.id === 'card--both-skipped'),
+      undefined
+    );
   });
 
   it('should apply both include and skip filters', () => {

--- a/clients/storybook/tests/navigation.test.js
+++ b/clients/storybook/tests/navigation.test.js
@@ -109,6 +109,51 @@ describe('navigateToStory', () => {
     assert.strictEqual(tab._poolEntry.currentStoryId, 'button--secondary');
   });
 
+  it('falls back to full navigation when Storybook never renders the story', async () => {
+    let originalWindow = globalThis.window;
+    let gotoCalls = [];
+    let listeners = new Map();
+
+    globalThis.window = {
+      __STORYBOOK_PREVIEW__: {
+        channel: {
+          on: (event, handler) => {
+            listeners.set(event, handler);
+          },
+          off: event => {
+            listeners.delete(event);
+          },
+          emit: () => {},
+        },
+      },
+    };
+
+    let tab = {
+      _poolEntry: {
+        storybookInitialized: true,
+        currentStoryId: 'button--primary',
+      },
+      goto: mock.fn(async url => {
+        gotoCalls.push(url);
+      }),
+      evaluate: mock.fn(async (fn, args) => fn(args)),
+    };
+
+    try {
+      await navigateToStory(tab, 'button--secondary', 'http://localhost:6006', {
+        timeout: 0,
+      });
+    } finally {
+      globalThis.window = originalWindow;
+    }
+
+    assert.strictEqual(tab.evaluate.mock.callCount(), 1);
+    assert.strictEqual(gotoCalls.length, 1);
+    assert.ok(gotoCalls[0].includes('button--secondary'));
+    assert.strictEqual(listeners.has('storyRendered'), false);
+    assert.strictEqual(tab._poolEntry.currentStoryId, 'button--secondary');
+  });
+
   it('falls back to domcontentloaded on timeout', async () => {
     let gotoCalls = [];
     let callCount = 0;

--- a/clients/storybook/tests/sdk-integration.test.js
+++ b/clients/storybook/tests/sdk-integration.test.js
@@ -13,13 +13,18 @@
 
 import assert from 'node:assert';
 import { execSync, spawn } from 'node:child_process';
+import { once } from 'node:events';
 import { existsSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 import { closeBrowser, launchBrowser, navigateToUrl } from '../src/browser.js';
-import { discoverStories, generateStoryUrl, readIndexJson } from '../src/crawler.js';
+import {
+  discoverStories,
+  generateStoryUrl,
+  readIndexJson,
+} from '../src/crawler.js';
 import { getBeforeScreenshotHook, getStoryConfig } from '../src/hooks.js';
 import { captureAndSendScreenshot } from '../src/screenshot.js';
 import { startStaticServer, stopStaticServer } from '../src/server.js';
@@ -41,6 +46,15 @@ async function prepareStoryPage(browser, url, viewport) {
   return page;
 }
 
+async function stopProcess(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill('SIGTERM');
+  await once(child, 'exit');
+}
+
 // Paths
 let testDir = join(tmpdir(), `vizzly-storybook-e2e-${Date.now()}`);
 let exampleStorybookPath = resolve(import.meta.dirname, '../example-storybook');
@@ -56,14 +70,6 @@ describe('Storybook E2E with example-storybook', { skip: !runE2E }, () => {
   let tddServer = null;
   let serverInfo = null;
   let browser = null;
-
-  // Mock logger for tests (unused but kept for future use)
-  let _logger = {
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-    debug: () => {},
-  };
 
   before(async () => {
     // Check if example-storybook is built, if not build it
@@ -134,11 +140,7 @@ describe('Storybook E2E with example-storybook', { skip: !runE2E }, () => {
     if (serverInfo) await stopStaticServer(serverInfo);
 
     if (tddServer && !externalServer) {
-      tddServer.kill('SIGTERM');
-      await new Promise(resolve => {
-        tddServer.on('exit', resolve);
-        setTimeout(resolve, 2000);
-      });
+      await stopProcess(tddServer);
     }
 
     if (!externalServer) {

--- a/clients/storybook/tests/server.test.js
+++ b/clients/storybook/tests/server.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { startStaticServer, stopStaticServer } from '../src/server.js';
+
+describe('storybook static server', () => {
+  let workspace;
+  let serverInfo;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'vizzly-storybook-server-'));
+    await mkdir(join(workspace, 'dist'));
+    await writeFile(
+      join(workspace, 'dist', 'index.html'),
+      '<h1>Storybook</h1>'
+    );
+  });
+
+  afterEach(async () => {
+    await stopStaticServer(serverInfo);
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('serves files and stops accepting requests after shutdown', async () => {
+    serverInfo = await startStaticServer(join(workspace, 'dist'));
+
+    let response = await fetch(`${serverInfo.url}/index.html`);
+    assert.equal(response.status, 200);
+    assert.match(await response.text(), /Storybook/);
+
+    await stopStaticServer(serverInfo);
+    serverInfo = null;
+
+    await assert.rejects(fetch(response.url));
+  });
+});

--- a/clients/storybook/tests/tasks.test.js
+++ b/clients/storybook/tests/tasks.test.js
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert';
 import { describe, it, mock } from 'node:test';
-import { generateTasks, processTask, processAllTasks } from '../src/tasks.js';
+import { generateTasks, processAllTasks, processTask } from '../src/tasks.js';
 
 describe('generateTasks', () => {
   it('generates tasks for each story × viewport combination', () => {
@@ -84,7 +84,9 @@ describe('generateTasks', () => {
     let tasks = generateTasks(stories, baseUrl, config, deps);
 
     // Tasks should be grouped by viewport
-    let viewportOrder = tasks.map(t => `${t.viewport.width}x${t.viewport.height}`);
+    let viewportOrder = tasks.map(
+      t => `${t.viewport.width}x${t.viewport.height}`
+    );
     // Same viewports should be adjacent
     let desktopIndices = viewportOrder
       .map((v, i) => (v === '1920x1080' ? i : -1))
@@ -95,11 +97,15 @@ describe('generateTasks', () => {
 
     // All desktop tasks should be contiguous (indices are consecutive)
     assert.ok(
-      desktopIndices.every((idx, i) => i === 0 || idx === desktopIndices[i - 1] + 1)
+      desktopIndices.every(
+        (idx, i) => i === 0 || idx === desktopIndices[i - 1] + 1
+      )
     );
     // All mobile tasks should be contiguous
     assert.ok(
-      mobileIndices.every((idx, i) => i === 0 || idx === mobileIndices[i - 1] + 1)
+      mobileIndices.every(
+        (idx, i) => i === 0 || idx === mobileIndices[i - 1] + 1
+      )
     );
   });
 

--- a/clients/vitest/tests/e2e/example.test.js
+++ b/clients/vitest/tests/e2e/example.test.js
@@ -25,7 +25,7 @@ beforeAll(async () => {
   document.head.appendChild(link);
 
   // Wait for CSS to load
-  await new Promise((resolve) => {
+  await new Promise(resolve => {
     link.onload = resolve;
     link.onerror = resolve;
   });

--- a/examples/custom-plugin/README.md
+++ b/examples/custom-plugin/README.md
@@ -8,7 +8,7 @@ This example plugin adds several commands to demonstrate different plugin capabi
 
 - `vizzly hello` - Simple greeting command
 - `vizzly greet <name>` - Command with arguments and options
-- `vizzly check-api` - Command that accesses Vizzly services
+- `vizzly check-services` - Command that accesses Vizzly services
 - `vizzly list-screenshots` - Command with file system operations
 
 ## Installation
@@ -52,7 +52,7 @@ vizzly --help
 # Try the commands
 vizzly hello
 vizzly greet "World" --loud
-vizzly check-api
+vizzly check-services
 vizzly list-screenshots
 ```
 
@@ -87,7 +87,7 @@ let gitInfo = await git.detect({ buildPrefix: 'MyPlugin' });
 
 // Build lifecycle
 let buildId = await testRunner.createBuild(options);
-await testRunner.finalizeBuild(buildId, wait, success, executionTime);
+await testRunner.finalizeBuild(buildId, isTddMode, success, executionTime);
 
 // Server control
 await serverManager.start(buildId, tddMode, setBaseline);
@@ -97,14 +97,12 @@ await serverManager.stop();
 ## Creating Your Own Plugin
 
 1. Create a new directory for your plugin
-2. Create `package.json` with `vizzly.plugin` field:
+2. Create `package.json` with a `vizzlyPlugin` field:
 
 ```json
 {
   "name": "@vizzly-testing/my-plugin",
-  "vizzly": {
-    "plugin": "./plugin.js"
-  }
+  "vizzlyPlugin": "./plugin.js"
 }
 ```
 
@@ -114,12 +112,12 @@ await serverManager.stop();
 export default {
   name: 'my-plugin',
   version: '1.0.0',
-  register(program, { config, logger, services }) {
+  register(program, { config, output, services }) {
     program
       .command('my-command')
       .description('My custom command')
       .action(() => {
-        logger.info('Running my command!');
+        output.info('Running my command!');
       });
   }
 };

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
     "test:swift:e2e": "npm run build && node clients/swift/scripts/run-e2e.js",
     "test:tui": "node --test --test-reporter=spec tests/tui/*.test.js",
     "test:tui:docker": "./tests/tui/run-tui-tests.sh",
-    "lint": "biome check src tests",
-    "lint:fix": "biome check --write --unsafe src tests",
-    "format": "biome format --write src tests",
-    "format:check": "biome format src tests",
+    "lint": "biome check src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",
+    "lint:fix": "biome check --write --unsafe src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",
+    "format": "biome format --write src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",
+    "format:check": "biome format src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",
     "fix": "npm run format && npm run lint:fix"
   },
   "engines": {

--- a/src/plugin-loader.js
+++ b/src/plugin-loader.js
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { glob } from 'glob';
 import { z } from 'zod';
@@ -12,15 +12,15 @@ import * as output from './utils/output.js';
  * @returns {Promise<Array>} Array of loaded plugins
  */
 export async function loadPlugins(configPath, config) {
-  const plugins = [];
-  const loadedNames = new Set();
+  let plugins = [];
+  let loadedNames = new Set();
 
   // 1. Auto-discover plugins from @vizzly-testing/* packages
-  const discoveredPlugins = await discoverInstalledPlugins();
+  let discoveredPlugins = await discoverInstalledPlugins();
 
-  for (const pluginInfo of discoveredPlugins) {
+  for (let pluginInfo of discoveredPlugins) {
     try {
-      const plugin = await loadPlugin(pluginInfo.path);
+      let plugin = await loadPlugin(pluginInfo.path);
       if (plugin && !loadedNames.has(plugin.name)) {
         plugins.push(plugin);
         loadedNames.add(plugin.name);
@@ -37,16 +37,16 @@ export async function loadPlugins(configPath, config) {
 
   // 2. Load explicit plugins from config
   if (config?.plugins && Array.isArray(config.plugins)) {
-    for (const pluginSpec of config.plugins) {
+    for (let pluginSpec of config.plugins) {
       try {
-        const pluginPath = resolvePluginPath(pluginSpec, configPath);
-        const plugin = await loadPlugin(pluginPath);
+        let pluginPath = resolvePluginPath(pluginSpec, configPath);
+        let plugin = await loadPlugin(pluginPath);
 
         if (plugin && !loadedNames.has(plugin.name)) {
           plugins.push(plugin);
           loadedNames.add(plugin.name);
         } else if (plugin && loadedNames.has(plugin.name)) {
-          const existingPlugin = plugins.find(p => p.name === plugin.name);
+          let existingPlugin = plugins.find(p => p.name === plugin.name);
           output.warn(
             `Plugin ${plugin.name} already loaded (v${existingPlugin.version || 'unknown'}), ` +
               `skipping v${plugin.version || 'unknown'} from config`
@@ -67,12 +67,12 @@ export async function loadPlugins(configPath, config) {
  * Discover installed plugins from node_modules/@vizzly-testing/*
  * @returns {Promise<Array>} Array of plugin info objects
  */
-async function discoverInstalledPlugins() {
-  const plugins = [];
+export async function discoverInstalledPlugins() {
+  let plugins = [];
 
   try {
     // Find all @vizzly-testing packages
-    const packageJsonPaths = await glob(
+    let packageJsonPaths = await glob(
       'node_modules/@vizzly-testing/*/package.json',
       {
         cwd: process.cwd(),
@@ -80,39 +80,20 @@ async function discoverInstalledPlugins() {
       }
     );
 
-    for (const pkgPath of packageJsonPaths) {
+    for (let pkgPath of packageJsonPaths) {
       try {
-        const packageJson = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        let packageJson = JSON.parse(readFileSync(pkgPath, 'utf-8'));
 
         // Check if package has a plugin field
         // Support both new `vizzlyPlugin` and legacy `vizzly.plugin` for backwards compatibility
-        const pluginField =
-          packageJson.vizzlyPlugin || packageJson.vizzly?.plugin;
+        let pluginField = getPluginField(packageJson);
         if (pluginField) {
-          const pluginRelativePath = pluginField;
-
-          // Security: Ensure plugin path is relative and doesn't traverse up
-          if (
-            pluginRelativePath.startsWith('/') ||
-            pluginRelativePath.includes('..')
-          ) {
-            output.warn(
-              `Invalid plugin path in ${packageJson.name}: path must be relative and cannot traverse directories`
-            );
-            continue;
-          }
-
-          // Resolve plugin path relative to package directory
-          const packageDir = dirname(pkgPath);
-          const pluginPath = resolve(packageDir, pluginRelativePath);
-
-          // Additional security: Ensure resolved path is still within package directory
-          if (!pluginPath.startsWith(packageDir)) {
-            output.warn(
-              `Plugin path escapes package directory: ${packageJson.name}`
-            );
-            continue;
-          }
+          let packageDir = dirname(pkgPath);
+          let pluginPath = resolvePackagePluginPath(
+            packageJson.name,
+            packageDir,
+            pluginField
+          );
 
           plugins.push({
             packageName: packageJson.name,
@@ -132,28 +113,65 @@ async function discoverInstalledPlugins() {
   return plugins;
 }
 
+function getPluginField(packageJson) {
+  return packageJson.vizzlyPlugin || packageJson.vizzly?.plugin;
+}
+
+export function resolvePackagePluginPath(
+  packageName,
+  packageDir,
+  pluginRelativePath
+) {
+  if (typeof pluginRelativePath !== 'string' || pluginRelativePath === '') {
+    throw new Error(
+      `Invalid plugin path in ${packageName}: path must be a non-empty string`
+    );
+  }
+
+  if (isAbsolute(pluginRelativePath)) {
+    throw new Error(
+      `Invalid plugin path in ${packageName}: path must be relative`
+    );
+  }
+
+  let pluginPath = resolve(packageDir, pluginRelativePath);
+  let relativePath = relative(packageDir, pluginPath);
+
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Invalid plugin path in ${packageName}: path cannot escape package directory`
+    );
+  }
+
+  return pluginPath;
+}
+
 /**
  * Load a plugin from a file path
  * @param {string} pluginPath - Path to plugin file
  * @returns {Promise<Object|null>} Loaded plugin or null
  */
-async function loadPlugin(pluginPath) {
+export async function loadPlugin(pluginPath) {
   try {
     // Convert to file URL for ESM import
-    const pluginUrl = pathToFileURL(pluginPath).href;
+    let pluginUrl = pathToFileURL(pluginPath).href;
 
     // Dynamic import
-    const pluginModule = await import(pluginUrl);
+    let pluginModule = await import(pluginUrl);
 
     // Get the default export
-    const plugin = pluginModule.default || pluginModule;
+    let plugin = pluginModule.default || pluginModule;
 
     // Validate plugin structure
     validatePluginStructure(plugin);
 
     return plugin;
   } catch (error) {
-    const newError = new Error(
+    let newError = new Error(
       `Failed to load plugin from ${pluginPath}: ${error.message}`
     );
     newError.cause = error;
@@ -190,9 +208,7 @@ function validatePluginStructure(plugin) {
     // configSchema is optional and primarily for documentation
   } catch (error) {
     if (error instanceof z.ZodError) {
-      const messages = error.issues.map(
-        e => `${e.path.join('.')}: ${e.message}`
-      );
+      let messages = error.issues.map(e => `${e.path.join('.')}: ${e.message}`);
       throw new Error(`Invalid plugin structure: ${messages.join(', ')}`);
     }
     throw error;
@@ -205,25 +221,32 @@ function validatePluginStructure(plugin) {
  * @param {string|null} configPath - Path to config file
  * @returns {string} Resolved plugin path
  */
-function resolvePluginPath(pluginSpec, configPath) {
+export function resolvePluginPath(pluginSpec, configPath) {
+  if (typeof pluginSpec !== 'string' || pluginSpec === '') {
+    throw new Error('Plugin spec must be a non-empty string');
+  }
+
   // If it's a package name (starts with @ or is alphanumeric), try to resolve from node_modules
   if (pluginSpec.startsWith('@') || /^[a-zA-Z0-9-]+$/.test(pluginSpec)) {
     // Try to resolve as a package
     try {
-      const packageJsonPath = resolve(
+      let packageJsonPath = resolve(
         process.cwd(),
         'node_modules',
         pluginSpec,
         'package.json'
       );
-      const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+      let packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 
       // Support both new `vizzlyPlugin` and legacy `vizzly.plugin`
-      const pluginField =
-        packageJson.vizzlyPlugin || packageJson.vizzly?.plugin;
+      let pluginField = getPluginField(packageJson);
       if (pluginField) {
-        const packageDir = dirname(packageJsonPath);
-        return resolve(packageDir, pluginField);
+        let packageDir = dirname(packageJsonPath);
+        return resolvePackagePluginPath(
+          packageJson.name || pluginSpec,
+          packageDir,
+          pluginField
+        );
       }
 
       throw new Error(
@@ -239,10 +262,10 @@ function resolvePluginPath(pluginSpec, configPath) {
   // Otherwise treat as a file path
   if (configPath) {
     // Resolve relative to config file
-    const configDir = dirname(configPath);
+    let configDir = dirname(configPath);
     return resolve(configDir, pluginSpec);
-  } else {
-    // Resolve relative to cwd
-    return resolve(process.cwd(), pluginSpec);
   }
+
+  // Resolve relative to cwd
+  return resolve(process.cwd(), pluginSpec);
 }

--- a/tests/plugin-loader.test.js
+++ b/tests/plugin-loader.test.js
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import {
+  loadPlugin,
+  resolvePackagePluginPath,
+  resolvePluginPath,
+} from '../src/plugin-loader.js';
+
+async function createTempWorkspace() {
+  return mkdtemp(join(tmpdir(), 'vizzly-plugin-loader-'));
+}
+
+async function writePackage(workspace, packageName, packageJson) {
+  let packageDir = join(workspace, 'node_modules', packageName);
+  await mkdir(packageDir, { recursive: true });
+  await writeFile(
+    join(packageDir, 'package.json'),
+    JSON.stringify(packageJson, null, 2)
+  );
+  return packageDir;
+}
+
+describe('plugin-loader', () => {
+  let originalCwd;
+  let workspace;
+
+  beforeEach(async () => {
+    originalCwd = process.cwd();
+    workspace = await realpath(await createTempWorkspace());
+    process.chdir(workspace);
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  describe('resolvePackagePluginPath', () => {
+    it('resolves package plugin paths inside the package directory', () => {
+      let packageDir = join(workspace, 'node_modules', 'storybook-plugin');
+
+      let pluginPath = resolvePackagePluginPath(
+        'storybook-plugin',
+        packageDir,
+        'dist/plugin.js'
+      );
+
+      assert.equal(pluginPath, join(packageDir, 'dist', 'plugin.js'));
+    });
+
+    it('rejects absolute package plugin paths', () => {
+      let packageDir = join(workspace, 'node_modules', 'bad-plugin');
+
+      assert.throws(
+        () =>
+          resolvePackagePluginPath('bad-plugin', packageDir, '/tmp/plugin.js'),
+        /path must be relative/
+      );
+    });
+
+    it('rejects package plugin paths that escape the package directory', () => {
+      let packageDir = join(workspace, 'node_modules', 'bad-plugin');
+
+      assert.throws(
+        () =>
+          resolvePackagePluginPath(
+            'bad-plugin',
+            packageDir,
+            '../other/plugin.js'
+          ),
+        /cannot escape package directory/
+      );
+    });
+  });
+
+  describe('resolvePluginPath', () => {
+    it('resolves explicit package plugins through vizzlyPlugin', async () => {
+      let packageDir = await writePackage(workspace, 'storybook-plugin', {
+        name: 'storybook-plugin',
+        vizzlyPlugin: 'dist/plugin.js',
+      });
+
+      let pluginPath = resolvePluginPath('storybook-plugin', null);
+
+      assert.equal(pluginPath, join(packageDir, 'dist', 'plugin.js'));
+    });
+
+    it('keeps legacy package plugin field support behind the same path safety checks', async () => {
+      let packageDir = await writePackage(workspace, 'legacy-plugin', {
+        name: 'legacy-plugin',
+        vizzly: { plugin: 'plugin.js' },
+      });
+
+      let pluginPath = resolvePluginPath('legacy-plugin', null);
+
+      assert.equal(pluginPath, join(packageDir, 'plugin.js'));
+    });
+
+    it('rejects unsafe plugin fields from explicit package specs', async () => {
+      await writePackage(workspace, 'bad-plugin', {
+        name: 'bad-plugin',
+        vizzlyPlugin: '../outside.js',
+      });
+
+      assert.throws(
+        () => resolvePluginPath('bad-plugin', null),
+        /cannot escape package directory/
+      );
+    });
+
+    it('resolves file paths relative to the config file', () => {
+      let configPath = join(workspace, 'configs', 'vizzly.config.js');
+
+      let pluginPath = resolvePluginPath('./plugins/custom.js', configPath);
+
+      assert.equal(
+        pluginPath,
+        join(workspace, 'configs', 'plugins', 'custom.js')
+      );
+    });
+  });
+
+  describe('loadPlugin', () => {
+    it('loads a valid ESM plugin default export', async () => {
+      let pluginPath = join(workspace, 'plugin.js');
+      await writeFile(
+        pluginPath,
+        `export default {
+  name: 'custom-plugin',
+  version: '1.0.0',
+  register() {}
+};`
+      );
+
+      let plugin = await loadPlugin(pluginPath);
+
+      assert.equal(plugin.name, 'custom-plugin');
+      assert.equal(plugin.version, '1.0.0');
+      assert.equal(typeof plugin.register, 'function');
+    });
+
+    it('rejects plugins without a register function', async () => {
+      let pluginPath = join(workspace, 'invalid-plugin.js');
+      await writeFile(
+        pluginPath,
+        `export default {
+  name: 'invalid-plugin'
+};`
+      );
+
+      await assert.rejects(
+        () => loadPlugin(pluginPath),
+        /Invalid plugin structure/
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Why

The Storybook client is one of the main package integrations for the CLI, and it has its own server, navigation, pooling, screenshot, and plugin-loading behavior. It needs to be reviewable independently from core CLI/server changes because package consumers should be able to validate the Storybook integration without reading the entire CLI audit.

This PR isolates the Storybook package cleanup plus the closely related plugin-loader and Ember/Vitest compatibility touchpoints that support client package behavior.

## What Changed

- Cleaned up Storybook client wiring around crawler, navigation, server lifecycle, tab pool, plugin entrypoint, and task processing.
- Added Storybook tests for server behavior, navigation fallback, task behavior, concurrency, and SDK integration coverage.
- Updated plugin-loader coverage and package-facing example/docs where client integrations rely on the same plugin contract.
- Kept static-site changes out of this PR so each package can be reviewed separately.

## Verification

- `npm run build`
- `node --test clients/storybook/tests/concurrency.test.js clients/storybook/tests/crawler.test.js clients/storybook/tests/navigation.test.js clients/storybook/tests/server.test.js clients/storybook/tests/tasks.test.js tests/plugin-loader.test.js`

## Stack

9/10 in the CLI audit stack.

Base: `rd/cli-audit-tdd-status`  
Head: `rd/cli-audit-storybook-client`
