### PR TITLE
♻️ Extract TDD runtime context assembly

### DIFF
--- a/src/tdd/runtime-context.js
+++ b/src/tdd/runtime-context.js
@@ -1,0 +1,66 @@
+/**
+ * Runtime context assembly for TddService constructor.
+ * Keeps dependency merging and path bootstrap logic isolated and testable.
+ */
+
+export function buildTddDependencyOps(deps = {}, defaults = {}) {
+  let {
+    output = defaults.output,
+    colors = defaults.colors,
+    validatePathSecurity = defaults.validatePathSecurity,
+    initializeDirectories = defaults.initializeDirectories,
+    calculateHotspotCoverage = defaults.calculateHotspotCoverage,
+    fs = {},
+    api = {},
+    metadata = {},
+    baseline = {},
+    comparison = {},
+    signature = {},
+    results = {},
+  } = deps;
+
+  let fsOps = { ...defaults.fs, ...fs };
+  let apiOps = { ...defaults.api, ...api };
+  let metadataOps = { ...defaults.metadata, ...metadata };
+  let baselineOps = { ...defaults.baseline, ...baseline };
+  let comparisonOps = { ...defaults.comparison, ...comparison };
+  let signatureOps = { ...defaults.signature, ...signature };
+  let resultsOps = { ...defaults.results, ...results };
+
+  let runtimeDeps = {
+    output,
+    colors,
+    validatePathSecurity,
+    initializeDirectories,
+    calculateHotspotCoverage,
+    ...fsOps,
+    ...apiOps,
+    ...metadataOps,
+    ...baselineOps,
+    ...comparisonOps,
+    ...signatureOps,
+    ...resultsOps,
+  };
+
+  return {
+    runtimeDeps,
+    apiOps,
+  };
+}
+
+export function resolveTddWorkingDirectory(
+  workingDir,
+  validatePathSecurity,
+  output
+) {
+  try {
+    return validatePathSecurity(workingDir, workingDir);
+  } catch (error) {
+    output.error(`Invalid working directory: ${error.message}`);
+    throw new Error(`Working directory validation failed: ${error.message}`);
+  }
+}
+
+export function resolveTddPaths(workingDir, initializeDirectories) {
+  return initializeDirectories(workingDir);
+}

--- a/src/tdd/tdd-service.js
+++ b/src/tdd/tdd-service.js
@@ -56,7 +56,11 @@ import {
   loadRegionMetadata as defaultLoadRegionMetadata,
   saveRegionMetadata as defaultSaveRegionMetadata,
 } from './metadata/region-metadata.js';
-
+import {
+  buildTddDependencyOps,
+  resolveTddPaths,
+  resolveTddWorkingDirectory,
+} from './runtime-context.js';
 import {
   baselineExists as defaultBaselineExists,
   clearBaselineData as defaultClearBaselineData,
@@ -110,124 +114,72 @@ export class TddService {
     authService = null,
     deps = {}
   ) {
-    // Grouped dependencies with defaults
-    let {
-      // Core utilities
-      output = defaultOutput,
-      colors = defaultColors,
-      validatePathSecurity = defaultValidatePathSecurity,
-      initializeDirectories = defaultInitializeDirectories,
-
-      // File system operations
-      fs = {},
-
-      // API operations
-      api = {},
-
-      // Baseline metadata operations
-      metadata = {},
-
-      // Baseline file management
-      baseline = {},
-
-      // Screenshot comparison
-      comparison = {},
-
-      // Signature generation and security
-      signature = {},
-
-      // Result building
-      results = {},
-
-      // Other
-      calculateHotspotCoverage = defaultCalculateHotspotCoverage,
-    } = deps;
-
-    // Merge grouped deps with defaults
-    let fsOps = {
-      existsSync: defaultExistsSync,
-      mkdirSync: defaultMkdirSync,
-      readFileSync: defaultReadFileSync,
-      writeFileSync: defaultWriteFileSync,
-      ...fs,
+    let defaults = {
+      output: defaultOutput,
+      colors: defaultColors,
+      validatePathSecurity: defaultValidatePathSecurity,
+      initializeDirectories: defaultInitializeDirectories,
+      calculateHotspotCoverage: defaultCalculateHotspotCoverage,
+      fs: {
+        existsSync: defaultExistsSync,
+        mkdirSync: defaultMkdirSync,
+        readFileSync: defaultReadFileSync,
+        writeFileSync: defaultWriteFileSync,
+      },
+      api: {
+        createApiClient: defaultCreateApiClient,
+        getTddBaselines: defaultGetTddBaselines,
+        getBuilds: defaultGetBuilds,
+        getComparison: defaultGetComparison,
+        getBatchHotspots: defaultGetBatchHotspots,
+        fetchWithTimeout: defaultFetchWithTimeout,
+        getDefaultBranch: defaultGetDefaultBranch,
+      },
+      metadata: {
+        loadBaselineMetadata: defaultLoadBaselineMetadata,
+        saveBaselineMetadata: defaultSaveBaselineMetadata,
+        createEmptyBaselineMetadata: defaultCreateEmptyBaselineMetadata,
+        upsertScreenshotInMetadata: defaultUpsertScreenshotInMetadata,
+        loadHotspotMetadata: defaultLoadHotspotMetadata,
+        saveHotspotMetadata: defaultSaveHotspotMetadata,
+        loadRegionMetadata: defaultLoadRegionMetadata,
+        saveRegionMetadata: defaultSaveRegionMetadata,
+      },
+      baseline: {
+        baselineExists: defaultBaselineExists,
+        clearBaselineData: defaultClearBaselineData,
+        getBaselinePath: defaultGetBaselinePath,
+        getCurrentPath: defaultGetCurrentPath,
+        getDiffPath: defaultGetDiffPath,
+        saveBaseline: defaultSaveBaseline,
+        saveCurrent: defaultSaveCurrent,
+      },
+      comparison: {
+        compareImages: defaultCompareImages,
+        buildPassedComparison: defaultBuildPassedComparison,
+        buildNewComparison: defaultBuildNewComparison,
+        buildFailedComparison: defaultBuildFailedComparison,
+        buildErrorComparison: defaultBuildErrorComparison,
+        isDimensionMismatchError: defaultIsDimensionMismatchError,
+      },
+      signature: {
+        generateScreenshotSignature: defaultGenerateScreenshotSignature,
+        generateBaselineFilename: defaultGenerateBaselineFilename,
+        generateComparisonId: defaultGenerateComparisonId,
+        sanitizeScreenshotName: defaultSanitizeScreenshotName,
+        validateScreenshotProperties: defaultValidateScreenshotProperties,
+        safePath: defaultSafePath,
+      },
+      results: {
+        buildResults: defaultBuildResults,
+        getFailedComparisons: defaultGetFailedComparisons,
+        getNewComparisons: defaultGetNewComparisons,
+      },
     };
+    let { runtimeDeps, apiOps } = buildTddDependencyOps(deps, defaults);
+    let { output, validatePathSecurity, initializeDirectories } = runtimeDeps;
 
-    let apiOps = {
-      createApiClient: defaultCreateApiClient,
-      getTddBaselines: defaultGetTddBaselines,
-      getBuilds: defaultGetBuilds,
-      getComparison: defaultGetComparison,
-      getBatchHotspots: defaultGetBatchHotspots,
-      fetchWithTimeout: defaultFetchWithTimeout,
-      getDefaultBranch: defaultGetDefaultBranch,
-      ...api,
-    };
-
-    let metadataOps = {
-      loadBaselineMetadata: defaultLoadBaselineMetadata,
-      saveBaselineMetadata: defaultSaveBaselineMetadata,
-      createEmptyBaselineMetadata: defaultCreateEmptyBaselineMetadata,
-      upsertScreenshotInMetadata: defaultUpsertScreenshotInMetadata,
-      loadHotspotMetadata: defaultLoadHotspotMetadata,
-      saveHotspotMetadata: defaultSaveHotspotMetadata,
-      loadRegionMetadata: defaultLoadRegionMetadata,
-      saveRegionMetadata: defaultSaveRegionMetadata,
-      ...metadata,
-    };
-
-    let baselineOps = {
-      baselineExists: defaultBaselineExists,
-      clearBaselineData: defaultClearBaselineData,
-      getBaselinePath: defaultGetBaselinePath,
-      getCurrentPath: defaultGetCurrentPath,
-      getDiffPath: defaultGetDiffPath,
-      saveBaseline: defaultSaveBaseline,
-      saveCurrent: defaultSaveCurrent,
-      ...baseline,
-    };
-
-    let comparisonOps = {
-      compareImages: defaultCompareImages,
-      buildPassedComparison: defaultBuildPassedComparison,
-      buildNewComparison: defaultBuildNewComparison,
-      buildFailedComparison: defaultBuildFailedComparison,
-      buildErrorComparison: defaultBuildErrorComparison,
-      isDimensionMismatchError: defaultIsDimensionMismatchError,
-      ...comparison,
-    };
-
-    let signatureOps = {
-      generateScreenshotSignature: defaultGenerateScreenshotSignature,
-      generateBaselineFilename: defaultGenerateBaselineFilename,
-      generateComparisonId: defaultGenerateComparisonId,
-      sanitizeScreenshotName: defaultSanitizeScreenshotName,
-      validateScreenshotProperties: defaultValidateScreenshotProperties,
-      safePath: defaultSafePath,
-      ...signature,
-    };
-
-    let resultsOps = {
-      buildResults: defaultBuildResults,
-      getFailedComparisons: defaultGetFailedComparisons,
-      getNewComparisons: defaultGetNewComparisons,
-      ...results,
-    };
-
-    // Store flattened dependencies for use in methods
-    this._deps = {
-      output,
-      colors,
-      validatePathSecurity,
-      initializeDirectories,
-      calculateHotspotCoverage,
-      ...fsOps,
-      ...apiOps,
-      ...metadataOps,
-      ...baselineOps,
-      ...comparisonOps,
-      ...signatureOps,
-      ...resultsOps,
-    };
+    this._deps = runtimeDeps;
 
     this.config = config;
     this.setBaseline = setBaseline;
@@ -240,15 +192,13 @@ export class TddService {
     });
 
     // Validate and secure the working directory
-    try {
-      this.workingDir = validatePathSecurity(workingDir, workingDir);
-    } catch (error) {
-      output.error(`Invalid working directory: ${error.message}`);
-      throw new Error(`Working directory validation failed: ${error.message}`);
-    }
+    this.workingDir = resolveTddWorkingDirectory(
+      workingDir,
+      validatePathSecurity,
+      output
+    );
 
-    // Initialize directories using extracted module
-    let paths = initializeDirectories(this.workingDir);
+    let paths = resolveTddPaths(this.workingDir, initializeDirectories);
     this.baselinePath = paths.baselinePath;
     this.currentPath = paths.currentPath;
     this.diffPath = paths.diffPath;

--- a/tests/tdd/runtime-context.test.js
+++ b/tests/tdd/runtime-context.test.js
@@ -1,0 +1,85 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  buildTddDependencyOps,
+  resolveTddPaths,
+  resolveTddWorkingDirectory,
+} from '../../src/tdd/runtime-context.js';
+
+describe('tdd/runtime-context', () => {
+  it('merges grouped dependencies with defaults', () => {
+    let defaults = {
+      output: { info: () => {} },
+      colors: { green: s => s },
+      validatePathSecurity: path => path,
+      initializeDirectories: () => ({}),
+      calculateHotspotCoverage: () => ({}),
+      fs: { existsSync: () => false, readFileSync: () => Buffer.from('x') },
+      api: { createApiClient: () => ({}) },
+      metadata: { loadBaselineMetadata: () => null },
+      baseline: { baselineExists: () => false },
+      comparison: { compareImages: async () => ({}) },
+      signature: { generateComparisonId: sig => sig },
+      results: { buildResults: () => ({ total: 0 }) },
+    };
+    let customCreateApiClient = () => ({ custom: true });
+    let customExistsSync = () => true;
+
+    let { runtimeDeps, apiOps } = buildTddDependencyOps(
+      {
+        fs: { existsSync: customExistsSync },
+        api: { createApiClient: customCreateApiClient },
+      },
+      defaults
+    );
+
+    assert.strictEqual(runtimeDeps.existsSync, customExistsSync);
+    assert.strictEqual(runtimeDeps.createApiClient, customCreateApiClient);
+    assert.strictEqual(
+      runtimeDeps.loadBaselineMetadata,
+      defaults.metadata.loadBaselineMetadata
+    );
+    assert.strictEqual(apiOps.createApiClient, customCreateApiClient);
+  });
+
+  it('returns validated working directory when path is valid', () => {
+    let output = { error: () => {} };
+    let validated = resolveTddWorkingDirectory(
+      '/tmp/work',
+      path => path,
+      output
+    );
+
+    assert.strictEqual(validated, '/tmp/work');
+  });
+
+  it('logs and throws when working directory validation fails', () => {
+    let logged = null;
+    let output = { error: message => (logged = message) };
+
+    assert.throws(
+      () =>
+        resolveTddWorkingDirectory(
+          '/tmp/work',
+          () => {
+            throw new Error('bad path');
+          },
+          output
+        ),
+      /Working directory validation failed: bad path/
+    );
+    assert.strictEqual(logged, 'Invalid working directory: bad path');
+  });
+
+  it('delegates path initialization', () => {
+    let paths = resolveTddPaths('/tmp/work', dir => ({
+      baselinePath: `${dir}/.vizzly/baselines`,
+      currentPath: `${dir}/.vizzly/current`,
+      diffPath: `${dir}/.vizzly/diffs`,
+    }));
+
+    assert.strictEqual(paths.baselinePath, '/tmp/work/.vizzly/baselines');
+    assert.strictEqual(paths.currentPath, '/tmp/work/.vizzly/current');
+    assert.strictEqual(paths.diffPath, '/tmp/work/.vizzly/diffs');
+  });
+});


### PR DESCRIPTION
## Why

`src/tdd/tdd-service.js` is one of the highest-risk maintenance surfaces in the CLI. Before deeper runtime decomposition, we need a safer constructor shape with explicit seams.

This PR extracts constructor runtime/dependency assembly into a dedicated module so we can keep behavior stable while making follow-up splits smaller and safer.

## What Changed

- Added `src/tdd/runtime-context.js`:
  - `buildTddDependencyOps(...)`
  - `resolveTddWorkingDirectory(...)`
  - `resolveTddPaths(...)`
- Updated `src/tdd/tdd-service.js` constructor to use the extracted runtime-context helpers.
- Added focused unit coverage in `tests/tdd/runtime-context.test.js`.

## Verification

- `npm run lint`
- `node --test tests/tdd/runtime-context.test.js tests/tdd/tdd-service.test.js`

## Notes

This is intentionally behavior-preserving. It is PR 1 in the new tech-debt train and sets up the next TDD runtime split slices.
