### PR TITLE
♻️ Split daemon process lifecycle helpers

### DIFF
--- a/src/commands/tdd-daemon-process.js
+++ b/src/commands/tdd-daemon-process.js
@@ -1,0 +1,115 @@
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+let defaultTimers = { setTimeout, clearTimeout };
+
+function wait(ms, timers = defaultTimers) {
+  return new Promise(resolve => {
+    timers.setTimeout(resolve, ms);
+  });
+}
+
+function isProcessRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parsePositiveInteger(value) {
+  let text = String(value).trim();
+  if (!/^\d+$/.test(text)) {
+    return null;
+  }
+
+  let number = Number(text);
+  return Number.isSafeInteger(number) && number > 0 ? number : null;
+}
+
+export function readDaemonPidFile(pidFile, deps = {}) {
+  let fileExists = deps.existsSync || existsSync;
+  let readFile = deps.readFileSync || readFileSync;
+
+  if (!fileExists(pidFile)) {
+    return null;
+  }
+
+  try {
+    return parsePositiveInteger(readFile(pidFile, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export async function findDaemonPidByPort(port, { spawnProcess = spawn } = {}) {
+  try {
+    let lsofProcess = spawnProcess('lsof', ['-ti', `:${port}`], {
+      stdio: 'pipe',
+    });
+
+    let lsofOutput = '';
+    lsofProcess.stdout.on('data', data => {
+      lsofOutput += data.toString();
+    });
+
+    return await new Promise(resolve => {
+      lsofProcess.on('close', code => {
+        if (code === 0 && lsofOutput.trim()) {
+          let foundPid = parsePositiveInteger(lsofOutput.trim().split('\n')[0]);
+          resolve(foundPid);
+          return;
+        }
+
+        resolve(null);
+      });
+
+      lsofProcess.on('error', () => {
+        resolve(null);
+      });
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveDaemonPid({
+  port,
+  pidFile = join(process.cwd(), '.vizzly', 'server.pid'),
+  readPid = readDaemonPidFile,
+  findByPort = findDaemonPidByPort,
+  fileDeps = {},
+} = {}) {
+  let pid = readPid(pidFile, fileDeps);
+  if (pid) {
+    return pid;
+  }
+
+  return await findByPort(port);
+}
+
+export async function waitForProcessExit(
+  pid,
+  {
+    timeoutMs = 2000,
+    intervalMs = 100,
+    processRunning = isProcessRunning,
+    timers = defaultTimers,
+  } = {}
+) {
+  let elapsedMs = 0;
+
+  while (elapsedMs < timeoutMs) {
+    if (!processRunning(pid)) {
+      return true;
+    }
+
+    let nextDelay = Math.min(intervalMs, timeoutMs - elapsedMs);
+    await wait(nextDelay, timers);
+    elapsedMs += nextDelay;
+  }
+
+  return !processRunning(pid);
+}

--- a/src/commands/tdd-daemon.js
+++ b/src/commands/tdd-daemon.js
@@ -12,6 +12,14 @@ import { getServerRegistry } from '../tdd/server-registry.js';
 import { withTimeout } from '../utils/async-utils.js';
 import * as output from '../utils/output.js';
 import { tddCommand } from './tdd.js';
+import { resolveDaemonPid, waitForProcessExit } from './tdd-daemon-process.js';
+
+export {
+  findDaemonPidByPort,
+  readDaemonPidFile,
+  resolveDaemonPid,
+  waitForProcessExit,
+} from './tdd-daemon-process.js';
 
 let defaultTimers = { setTimeout, clearTimeout };
 
@@ -141,86 +149,6 @@ function wait(ms, timers = defaultTimers) {
   return new Promise(resolve => {
     timers.setTimeout(resolve, ms);
   });
-}
-
-function isProcessRunning(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function parsePositiveInteger(value) {
-  let text = String(value).trim();
-  if (!/^\d+$/.test(text)) {
-    return null;
-  }
-
-  let number = Number(text);
-  return Number.isSafeInteger(number) && number > 0 ? number : null;
-}
-
-export function readDaemonPidFile(pidFile, deps = {}) {
-  let fileExists = deps.existsSync || existsSync;
-  let readFile = deps.readFileSync || readFileSync;
-
-  if (!fileExists(pidFile)) {
-    return null;
-  }
-
-  try {
-    return parsePositiveInteger(readFile(pidFile, 'utf8'));
-  } catch {
-    return null;
-  }
-}
-
-export async function findDaemonPidByPort(port, { spawnProcess = spawn } = {}) {
-  try {
-    let lsofProcess = spawnProcess('lsof', ['-ti', `:${port}`], {
-      stdio: 'pipe',
-    });
-
-    let lsofOutput = '';
-    lsofProcess.stdout.on('data', data => {
-      lsofOutput += data.toString();
-    });
-
-    return await new Promise(resolve => {
-      lsofProcess.on('close', code => {
-        if (code === 0 && lsofOutput.trim()) {
-          let foundPid = parsePositiveInteger(lsofOutput.trim().split('\n')[0]);
-          resolve(foundPid);
-          return;
-        }
-
-        resolve(null);
-      });
-
-      lsofProcess.on('error', () => {
-        resolve(null);
-      });
-    });
-  } catch {
-    return null;
-  }
-}
-
-export async function resolveDaemonPid({
-  port,
-  pidFile = getLocalDaemonFiles().pidFile,
-  readPid = readDaemonPidFile,
-  findByPort = findDaemonPidByPort,
-  fileDeps = {},
-} = {}) {
-  let pid = readPid(pidFile, fileDeps);
-  if (pid) {
-    return pid;
-  }
-
-  return await findByPort(port);
 }
 
 export function buildDaemonChildArgs({
@@ -353,30 +281,6 @@ export async function waitForServerRunning(
   }
 
   return false;
-}
-
-export async function waitForProcessExit(
-  pid,
-  {
-    timeoutMs = 2000,
-    intervalMs = 100,
-    processRunning = isProcessRunning,
-    timers = defaultTimers,
-  } = {}
-) {
-  let elapsedMs = 0;
-
-  while (elapsedMs < timeoutMs) {
-    if (!processRunning(pid)) {
-      return true;
-    }
-
-    let nextDelay = Math.min(intervalMs, timeoutMs - elapsedMs);
-    await wait(nextDelay, timers);
-    elapsedMs += nextDelay;
-  }
-
-  return !processRunning(pid);
 }
 
 /**


### PR DESCRIPTION
## Why

`tdd-daemon` is a high-risk lifecycle surface. This PR takes one focused slice: process and PID lifecycle helpers.

By extracting those helpers from command orchestration, we keep start/stop UX behavior stable while making daemon internals easier to reason about and safer to change in follow-up PRs.

## What Changed

- Added `src/commands/tdd-daemon-process.js` with:
  - `readDaemonPidFile(...)`
  - `findDaemonPidByPort(...)`
  - `resolveDaemonPid(...)`
  - `waitForProcessExit(...)`
- Updated `src/commands/tdd-daemon.js` to import/re-export these helpers.
- Preserved export compatibility for existing tests/import paths.

## Verification

- `node --test tests/commands/tdd-daemon.test.js`
- `npm run lint`

## Notes

This is PR 2 in the tech-debt train and is intentionally behavior-preserving.
