### PR TITLE
✨ Polish CLI context release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Vizzly CLI
 
-> Reviewed UI context for people and LLM agents
+> Visual review for agents and teams
 
 [![npm version](https://img.shields.io/npm/v/@vizzly-testing/cli.svg)](https://www.npmjs.com/package/@vizzly-testing/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Vizzly keeps the visual truth behind your UI: approved baselines, meaningful diffs, review state, comments, and preview links in one place. That makes it useful for humans reviewing product changes and for LLM agents that need to understand what the UI is supposed to look like before they edit it.
 
-Unlike tools that re-render components in isolation, Vizzly captures screenshots directly from your functional tests: the real thing. Whether you're validating AI-generated code or testing manual changes, you get reviewed UI context before anything hits production.
+Unlike tools that re-render components in isolation, Vizzly captures screenshots directly from your functional tests: the real thing. Whether you're validating AI-generated code or testing manual changes, you get reviewed visual evidence before anything hits production.
 
 ## Why Vizzly?
 
@@ -77,7 +77,7 @@ vizzly context build current --source local --agent
 vizzly context screenshot build-detail-screenshots --source local --json
 ```
 
-`--json` is the durable automation path. `--agent` gives a compact Markdown handoff for prompt assembly and local dogfooding.
+`--json` is the durable automation path. `--agent` gives a compact handoff for prompt assembly and local dogfooding. Add `--full` when an agent really needs the complete build context payload, or `--include screenshots,diffs,comments` when the compact JSON needs selected detail.
 
 Local context is read-only and file-backed. It reads your existing `.vizzly` workspace state from
 TDD runs, including screenshots, diffs, and any saved hotspot or region metadata.

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -203,12 +203,77 @@ cloud data or your local `.vizzly` workspace.
 
 ```bash
 vizzly context build abc123 --json
+vizzly context build abc123 --agent --json
+vizzly context build abc123 --agent --json --include diffs,comments
+vizzly context build abc123 --agent --json --full
 vizzly context build current --source local --json
 vizzly context build current --source local --agent
 ```
 
-Use `--json` for durable automation. Use `--agent` when you want a compact Markdown handoff for
-prompt assembly.
+Use `--json` for durable automation. Use `--agent --json` when you want the compact handoff that
+agents should read first. Add `--include screenshots,diffs,comments` for selected detail, or
+`--full` when you need the complete build context payload.
+
+Compact agent JSON:
+
+```json
+{
+  "resource": "build_agent_context",
+  "source": "cloud",
+  "project": {
+    "organization": "acme",
+    "slug": "storybook",
+    "name": "Storybook"
+  },
+  "build": {
+    "id": "abc123",
+    "status": "completed",
+    "approval_status": "pending"
+  },
+  "baseline": {
+    "selected": {
+      "id": "baseline-build",
+      "name": "Approved Main",
+      "approval_status": "approved"
+    },
+    "selection_reason": "latest approved build"
+  },
+  "status": {
+    "needs_review": true,
+    "reasons": ["comparisons_need_review"],
+    "pending_comparisons": 3,
+    "unresolved_comments": 0
+  },
+  "summary": {
+    "comparisons": {
+      "total": 12,
+      "changed": 2,
+      "new": 1
+    }
+  },
+  "evidence": [
+    {
+      "id": "cmp-1",
+      "name": "Dashboard",
+      "result": "changed",
+      "needs_review": true,
+      "diff": {
+        "percentage": 0.42,
+        "fingerprint_hash": "00000000001ec127",
+        "region_count": 12,
+        "image_url": "https://..."
+      }
+    }
+  ],
+  "next_actions": [
+    "Inspect the changed and new comparisons before editing related UI.",
+    "Use approved baselines as the expected visual behavior.",
+    "Leave approval decisions to human reviewers."
+  ]
+}
+```
+
+Full build context JSON:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@vizzly-testing/cli",
   "version": "0.30.0",
-  "description": "Reviewed UI context for people and LLM agents",
+  "description": "Visual review for agents and teams",
   "keywords": [
     "llm-context",
-    "ui-context",
     "visual-context",
     "approved-baselines",
     "visual-testing",
@@ -76,6 +75,7 @@
     "test:swift:e2e": "npm run build && node clients/swift/scripts/run-e2e.js",
     "test:tui": "node --test --test-reporter=spec tests/tui/*.test.js",
     "test:tui:docker": "./tests/tui/run-tui-tests.sh",
+    "smoke:prod:pack": "node scripts/smoke-prod-pack.js",
     "lint": "biome check src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",
     "lint:fix": "biome check --write --unsafe src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",
     "format": "biome format --write src tests clients/storybook/src clients/storybook/tests clients/static-site/src clients/static-site/tests clients/vitest/src clients/vitest/tests clients/ember/src clients/ember/tests clients/ember/bin",

--- a/scripts/smoke-prod-pack.js
+++ b/scripts/smoke-prod-pack.js
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+let execFileAsync = promisify(execFile);
+
+function log(message) {
+  console.log(`[smoke:prod:pack] ${message}`);
+}
+
+function readJson(text, label) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Failed to parse ${label} JSON: ${error.message}\n${text}`);
+  }
+}
+
+async function run(command, args, options = {}) {
+  let { stdout, stderr } = await execFileAsync(command, args, {
+    maxBuffer: 1024 * 1024 * 20,
+    ...options,
+  });
+
+  if (stderr?.trim()) {
+    process.stderr.write(stderr);
+  }
+
+  return stdout;
+}
+
+async function runPackaged(binPath, args, env) {
+  let stdout = await run(process.execPath, [binPath, ...args], { env });
+  let parsed = readJson(stdout, `vizzly ${args.join(' ')}`);
+
+  if (parsed.status !== 'data') {
+    throw new Error(
+      `Unexpected CLI status for ${args.join(' ')}: ${parsed.status}`
+    );
+  }
+
+  return parsed.data;
+}
+
+async function loadAuth(sourceHome) {
+  let configPath = join(sourceHome, 'config.json');
+
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `No Vizzly auth config found at ${configPath}. Run "vizzly login" before prod smoke.`
+    );
+  }
+
+  let config = readJson(await readFile(configPath, 'utf8'), configPath);
+
+  if (!config.auth?.accessToken) {
+    throw new Error(
+      `No user access token found in ${configPath}. Run "vizzly login" first.`
+    );
+  }
+
+  return config.auth;
+}
+
+async function revokeProjectToken({
+  apiUrl,
+  auth,
+  organizationSlug,
+  projectSlug,
+  tokenId,
+}) {
+  if (!tokenId) {
+    return;
+  }
+
+  let response = await fetch(
+    `${apiUrl}/api/project/${projectSlug}/tokens/${tokenId}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${auth.accessToken}`,
+        'X-Organization': organizationSlug,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    let body = await response.text();
+    throw new Error(
+      `Failed to revoke smoke token ${tokenId}: ${response.status} ${body}`
+    );
+  }
+}
+
+async function main() {
+  let apiUrl =
+    process.env.VIZZLY_PROD_SMOKE_API_URL || 'https://app.vizzly.dev';
+  let organizationSlug = process.env.VIZZLY_PROD_SMOKE_ORG || 'vizzly';
+  let projectSlug = process.env.VIZZLY_PROD_SMOKE_PROJECT || 'frontend';
+  let sourceHome = process.env.VIZZLY_HOME || join(homedir(), '.vizzly');
+  let keepTmp = process.env.VIZZLY_PROD_SMOKE_KEEP_TMP === 'true';
+  let workspace = process.cwd();
+  let tmpRoot = await mkdtemp(join(tmpdir(), 'vizzly-prod-smoke-'));
+  let smokeHome = join(tmpRoot, 'home');
+  let packDir = join(tmpRoot, 'pack');
+  let installDir = join(tmpRoot, 'install');
+  let cacheDir = join(tmpRoot, 'npm-cache');
+  let tokenId = null;
+
+  try {
+    log('building CLI');
+    await run('npm', ['run', 'build'], { cwd: workspace });
+
+    log('packing CLI');
+    await mkdir(packDir, { recursive: true });
+    let packOutput = await run(
+      'npm',
+      ['pack', '--pack-destination', packDir, '--cache', cacheDir],
+      { cwd: workspace }
+    );
+    let tarballName = packOutput.trim().split('\n').at(-1);
+    let tarballPath = join(packDir, tarballName);
+
+    log(`installing ${tarballName}`);
+    await mkdir(installDir, { recursive: true });
+    await writeFile(
+      join(installDir, 'package.json'),
+      JSON.stringify({ private: true, type: 'module' }, null, 2)
+    );
+    await run(
+      'npm',
+      [
+        'install',
+        '--omit=dev',
+        '--ignore-scripts',
+        '--cache',
+        cacheDir,
+        tarballPath,
+      ],
+      { cwd: installDir }
+    );
+
+    let binPath = join(
+      installDir,
+      'node_modules',
+      '@vizzly-testing',
+      'cli',
+      'bin',
+      'vizzly.js'
+    );
+    let auth = await loadAuth(sourceHome);
+    await mkdir(smokeHome, { recursive: true });
+    await writeFile(
+      join(smokeHome, 'config.json'),
+      JSON.stringify({ auth }, null, 2),
+      { mode: 0o600 }
+    );
+
+    let env = {
+      ...process.env,
+      VIZZLY_API_URL: apiUrl,
+      VIZZLY_HOME: smokeHome,
+      VIZZLY_DISABLE_KEYCHAIN: 'true',
+    };
+
+    log('verifying user auth');
+    let whoami = await runPackaged(binPath, ['whoami', '--json'], env);
+    if (!whoami.authenticated) {
+      throw new Error(
+        'Packaged CLI did not authenticate with copied smoke auth.'
+      );
+    }
+
+    log(`linking ${organizationSlug}/${projectSlug}`);
+    let link = await runPackaged(
+      binPath,
+      [
+        'project',
+        'link',
+        `${organizationSlug}/${projectSlug}`,
+        '--name',
+        `prod-smoke-${Date.now()}`,
+        '--json',
+      ],
+      env
+    );
+
+    let smokeConfig = readJson(
+      await readFile(join(smokeHome, 'config.json'), 'utf8'),
+      'smoke config'
+    );
+    let linkedProject = Object.values(smokeConfig.projectLink?.links || {})[0];
+    tokenId = linkedProject?.tokenId || null;
+
+    if (!link.linked || !tokenId) {
+      throw new Error('Project link did not create a scoped smoke token.');
+    }
+
+    delete smokeConfig.auth;
+    await writeFile(
+      join(smokeHome, 'config.json'),
+      JSON.stringify(smokeConfig, null, 2),
+      {
+        mode: 0o600,
+      }
+    );
+
+    log('verifying linked project token');
+    let builds = await runPackaged(
+      binPath,
+      ['builds', '--project', projectSlug, '--limit', '1', '--json'],
+      env
+    );
+    let build = builds.builds?.[0];
+
+    if (!build?.id) {
+      throw new Error(
+        `No production builds found for ${organizationSlug}/${projectSlug}.`
+      );
+    }
+
+    log(`fetching compact agent context for ${build.id}`);
+    let context = await runPackaged(
+      binPath,
+      ['context', 'build', build.id, '--source', 'cloud', '--agent', '--json'],
+      env
+    );
+
+    if (context.resource !== 'build_agent_context') {
+      throw new Error(`Expected build_agent_context, got ${context.resource}`);
+    }
+
+    if (context.screenshots) {
+      throw new Error(
+        'Compact agent context unexpectedly included screenshots by default.'
+      );
+    }
+
+    if (
+      !Array.isArray(context.next_actions) ||
+      context.next_actions.length === 0
+    ) {
+      throw new Error('Compact agent context did not include next actions.');
+    }
+
+    log('revoking smoke token');
+    await revokeProjectToken({
+      apiUrl,
+      auth,
+      organizationSlug,
+      projectSlug,
+      tokenId,
+    });
+    tokenId = null;
+
+    log('passed');
+  } finally {
+    if (tokenId) {
+      try {
+        let auth = await loadAuth(sourceHome);
+        await revokeProjectToken({
+          apiUrl,
+          auth,
+          organizationSlug,
+          projectSlug,
+          tokenId,
+        });
+      } catch (error) {
+        console.error(
+          `[smoke:prod:pack] failed to revoke smoke token: ${error.message}`
+        );
+      }
+    }
+
+    if (keepTmp) {
+      log(`kept temp dir: ${tmpRoot}`);
+    } else {
+      await rm(tmpRoot, { recursive: true, force: true });
+    }
+
+    if (existsSync(join(workspace, '$HOME'))) {
+      await rm(join(workspace, '$HOME'), { recursive: true, force: true });
+    }
+  }
+}
+
+await main();

--- a/src/cli.js
+++ b/src/cli.js
@@ -92,7 +92,7 @@ const formatHelp = (cmd, helper) => {
     // Cute grizzly bear mascot with square eyes (like the Vizzly logo!)
     lines.push(c.brand.amber('   ʕ□ᴥ□ʔ'));
     lines.push(`   ${c.brand.amber(c.bold('vizzly'))} ${c.dim(`v${version}`)}`);
-    lines.push(`   ${c.gray('Reviewed UI context for people and agents')}`);
+    lines.push(`   ${c.gray('Visual review for agents and teams')}`);
   } else {
     // Compact header for subcommands
     lines.push(`  ${c.brand.amber(c.bold('vizzly'))} ${c.white(cmd.name())}`);
@@ -233,7 +233,7 @@ const formatHelp = (cmd, helper) => {
   if (isRootCommand) {
     lines.push(`  ${c.brand.amber('▸')} ${c.bold('Quick Start')}`);
     lines.push('');
-    lines.push(`      ${c.dim('# Local UI context')}`);
+    lines.push(`      ${c.dim('# Local visual review')}`);
     lines.push(`      ${c.gray('$')} ${c.white('vizzly tdd start')}`);
     lines.push('');
     lines.push(`      ${c.dim('# CI pipeline')}`);
@@ -332,7 +332,7 @@ function normalizeJsonArgv(argv, commandNames) {
 
 program
   .name('vizzly')
-  .description('Vizzly CLI for reviewed UI context')
+  .description('Vizzly CLI for visual review')
   .version(getPackageVersion())
   .option('-c, --config <path>', 'Config file path')
   .option('--token <token>', 'Vizzly API token')
@@ -448,10 +448,10 @@ program
     await uploadCommand(path, options, globalOptions);
   });
 
-// TDD command with subcommands - local reviewed UI context with an interactive dashboard
+// TDD command with subcommands - local visual review with an interactive dashboard
 const tddCmd = program
   .command('tdd')
-  .description('Run tests in TDD mode with local UI context');
+  .description('Run tests in TDD mode with local visual review');
 
 // TDD Start - Background server
 tddCmd
@@ -523,7 +523,7 @@ tddCmd
 // TDD Run - One-off test run with ephemeral server (generates static report)
 tddCmd
   .command('run <command>')
-  .description('Run tests once in TDD mode with local UI context')
+  .description('Run tests once in TDD mode with local visual review')
   .option('--port <port>', 'Port for TDD server', '47392')
   .option('--branch <branch>', 'Git branch override')
   .option('--environment <env>', 'Environment name', 'test')
@@ -768,14 +768,19 @@ Examples:
 
 let contextCmd = program
   .command('context')
-  .description('Fetch reviewed UI context for agents and reviewers');
+  .description('Fetch build context for agents and reviewers');
 
 contextCmd
   .command('build')
-  .description('Fetch reviewed UI context for a build')
+  .description('Fetch build context for agents and reviewers')
   .argument('<build-id>', 'Build ID to fetch context for')
   .option('--source <source>', 'Context source: auto, cloud, or local', 'auto')
-  .option('--agent', 'Output compact Markdown context for LLM agents')
+  .option('--agent', 'Output compact context for LLM agents')
+  .option('--full', 'Return the full build context payload with --agent --json')
+  .option(
+    '--include <items>',
+    'Add detail to compact agent JSON: screenshots,diffs,comments'
+  )
   .addHelpText(
     'after',
     `
@@ -783,8 +788,9 @@ Examples:
   $ vizzly context build abc123
   $ vizzly context build current --source local
   $ vizzly context build current --source local --agent
-  $ vizzly context build abc123 --json
-  $ vizzly context build abc123 --json build.id,summary.comparisons
+  $ vizzly context build abc123 --agent --json
+  $ vizzly context build abc123 --agent --json --include diffs,comments
+  $ vizzly context build abc123 --agent --json --full
 `
   )
   .action(async (buildId, options) => {

--- a/src/commands/config-cmd.js
+++ b/src/commands/config-cmd.js
@@ -57,6 +57,16 @@ export async function configCommand(
       };
     }
 
+    if (config.linkedProject) {
+      displayConfig.linkedProject = {
+        organization: config.linkedProject.organizationSlug,
+        project: config.linkedProject.projectSlug,
+        tokenPrefix: config.linkedProject.tokenPrefix,
+        storage: config.linkedProject.storage,
+        expiresAt: config.linkedProject.expiresAt || null,
+      };
+    }
+
     // If a specific key is requested, extract it
     if (key) {
       let value = getNestedValue(displayConfig, key);
@@ -115,6 +125,10 @@ export async function configCommand(
 
       if (displayConfig.api) {
         displaySection(output, 'API', displayConfig.api);
+      }
+
+      if (displayConfig.linkedProject) {
+        displaySection(output, 'Linked Project', displayConfig.linkedProject);
       }
     } else {
       output.hint('Use --verbose to see all configuration options');

--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -14,6 +14,7 @@ import { createLocalWorkspaceContextProvider as defaultCreateLocalWorkspaceConte
 import { resolveContextSource as defaultResolveContextSource } from '../context/provider-resolver.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import * as defaultOutput from '../utils/output.js';
+import { readSession as defaultReadSession } from '../utils/session.js';
 
 function buildAuthErrorMessage() {
   return 'Authentication required. Use --token, set VIZZLY_TOKEN, run "vizzly login", or link a project.';
@@ -21,6 +22,10 @@ function buildAuthErrorMessage() {
 
 function buildSourceErrorMessage() {
   return '--source must be one of: auto, cloud, local';
+}
+
+function buildIncludeErrorMessage() {
+  return '--include must contain only: screenshots, diffs, comments';
 }
 
 function validateLimitRange(value, flagName, { min = 1, max }) {
@@ -59,6 +64,22 @@ function validateSourceOption(value) {
   return [];
 }
 
+function parseIncludeOption(value) {
+  if (!value) {
+    return [];
+  }
+
+  let rawItems = Array.isArray(value) ? value : String(value).split(',');
+  return rawItems.map(item => item.trim()).filter(Boolean);
+}
+
+function validateIncludeOption(value) {
+  let allowed = new Set(['screenshots', 'diffs', 'comments']);
+  let invalid = parseIncludeOption(value).filter(item => !allowed.has(item));
+
+  return invalid.length > 0 ? [buildIncludeErrorMessage()] : [];
+}
+
 function validateScopedProjectOptions(options = {}) {
   let errors = [];
 
@@ -67,6 +88,15 @@ function validateScopedProjectOptions(options = {}) {
   }
 
   return errors;
+}
+
+function hasExplicitCloudScope(options = {}, config = {}) {
+  return Boolean(
+    options.org ||
+      options.project ||
+      config.linkedProject?.organizationSlug ||
+      config.linkedProject?.projectSlug
+  );
 }
 
 function createClient(config, createApiClient) {
@@ -137,6 +167,26 @@ function buildLocalFingerprintCapabilityError() {
   return error;
 }
 
+function resolveBuildContextId(buildId, runtime, deps = {}) {
+  let { readSession = defaultReadSession } = deps;
+
+  if (buildId !== 'current' || runtime.source !== 'cloud') {
+    return buildId;
+  }
+
+  let session = readSession({ cwd: runtime.projectRoot });
+
+  if (session?.buildId && !session.expired) {
+    return session.buildId;
+  }
+
+  let error = new Error(
+    'No current cloud build found. Run "vizzly run" first, or pass a build ID.'
+  );
+  error.code = 'NO_CURRENT_CLOUD_BUILD';
+  throw error;
+}
+
 function shouldExplainLocalSimilarityGap(
   requestedSource,
   command,
@@ -178,6 +228,7 @@ async function loadContextRuntime(
       command,
       target,
       projectRoot,
+      hasCloudScope: hasExplicitCloudScope(options, config),
     },
     {
       createLocalWorkspaceContextProvider,
@@ -277,6 +328,175 @@ function getComparisonFingerprint(comparison = {}) {
     comparison.analysis?.fingerprint_hash ||
     null
   );
+}
+
+function getComparisonDiffImageUrl(comparison = {}) {
+  return (
+    comparison.diff?.image_url || comparison.analysis?.diff_image_url || null
+  );
+}
+
+function getComparisonRegionCount(comparison = {}) {
+  let regions = comparison.diff?.regions || comparison.analysis?.diff_regions;
+  return Array.isArray(regions) ? regions.length : 0;
+}
+
+function getComparisonScreenshot(comparison = {}) {
+  return comparison.screenshot || {};
+}
+
+function getComparisonBaseline(comparison = {}) {
+  return comparison.baseline || comparison.screenshot?.baseline || {};
+}
+
+function buildCompactDiff(comparison = {}, includeDiffs = false) {
+  let diff = comparison.diff || comparison.analysis || {};
+  let compact = {
+    percentage: getComparisonDiffPercentage(comparison),
+    changed_pixels: diff.changed_pixels ?? comparison.changed_pixels ?? null,
+    total_pixels: diff.total_pixels ?? comparison.total_pixels ?? null,
+    threshold: diff.threshold ?? comparison.threshold ?? null,
+    fingerprint_hash: getComparisonFingerprint(comparison),
+    region_count: getComparisonRegionCount(comparison),
+    image_url: getComparisonDiffImageUrl(comparison),
+  };
+
+  if (includeDiffs) {
+    compact.regions = diff.regions || diff.diff_regions || [];
+    compact.cluster_metadata = diff.cluster_metadata || null;
+    compact.ssim_score = diff.ssim_score ?? null;
+    compact.gmsd_score = diff.gmsd_score ?? null;
+    compact.diff_lines = diff.diff_lines || [];
+  }
+
+  return compact;
+}
+
+function buildCompactComparison(
+  comparison = {},
+  { includeDiffs = false } = {}
+) {
+  let screenshot = getComparisonScreenshot(comparison);
+  let baseline = getComparisonBaseline(comparison);
+
+  return {
+    id: comparison.id || null,
+    name: getComparisonName(comparison),
+    result: getComparisonDisplayState(comparison),
+    approval_status: comparison.approval_status || null,
+    needs_review: Boolean(comparison.needs_review),
+    is_flaky: Boolean(comparison.is_flaky),
+    screenshot: {
+      id: screenshot.id || null,
+      url: screenshot.url || screenshot.original_url || null,
+    },
+    baseline: {
+      id: baseline.id || null,
+      build_id: baseline.build_id || null,
+      url: baseline.url || baseline.original_url || null,
+    },
+    diff: buildCompactDiff(comparison, includeDiffs),
+  };
+}
+
+function summarizeComparisons(comparisons = []) {
+  return {
+    total: comparisons.length,
+    changed: comparisons.filter(isChangedComparison).length,
+    new: comparisons.filter(isNewComparison).length,
+    needs_review: comparisons.filter(comparison => comparison.needs_review)
+      .length,
+  };
+}
+
+function buildAgentNextActions(context = {}, comparisonSummary = {}) {
+  if (context.status?.needs_review) {
+    return [
+      'Inspect the changed and new comparisons before editing related UI.',
+      'Use approved baselines as the expected visual behavior.',
+      'Leave approval decisions to human reviewers.',
+    ];
+  }
+
+  if (comparisonSummary.total > 0) {
+    return [
+      'Use the approved baseline and reviewed screenshots as current visual truth.',
+      'Prefer targeted edits that preserve identical comparisons.',
+    ];
+  }
+
+  return [
+    'No comparisons were returned for this build context.',
+    'Open the build URL for more detail if this is unexpected.',
+  ];
+}
+
+function formatAgentStatus(status = {}) {
+  return {
+    needs_review: Boolean(status.needs_review),
+    reasons: status.reasons || [],
+    pending_comparisons: status.pending_comparisons || 0,
+    unresolved_comments: status.unresolved_comments || 0,
+  };
+}
+
+function formatAgentSummary(context = {}, comparisons = []) {
+  return {
+    comparisons:
+      context.summary?.comparisons || summarizeComparisons(comparisons),
+    review: context.summary?.review || {},
+    comments: context.summary?.comments || {
+      build: getBuildCommentsCount(context),
+      screenshot: getScreenshotCommentsCount(context),
+    },
+  };
+}
+
+function buildAgentBuildPayload(
+  context,
+  { source = null, include = [], evidenceLimit = 10 } = {}
+) {
+  let comparisons = context.comparisons || [];
+  let includeSet = new Set(include);
+  let includeDiffs = includeSet.has('diffs');
+  let changed = comparisons.filter(isChangedComparison);
+  let fresh = comparisons.filter(isNewComparison);
+  let evidence = [...changed, ...fresh]
+    .slice(0, evidenceLimit)
+    .map(comparison => buildCompactComparison(comparison, { includeDiffs }));
+  let comparisonSummary = summarizeComparisons(comparisons);
+  let payload = {
+    resource: 'build_agent_context',
+    source: context.source || source || 'cloud',
+    scope: context.scope || null,
+    project: {
+      organization: context.scope?.organization?.slug || null,
+      slug: context.scope?.project?.slug || null,
+      name: context.scope?.project?.name || null,
+      visibility: context.scope?.project?.visibility || null,
+    },
+    build: context.build || null,
+    baseline: {
+      selected: context.baseline?.selected || null,
+      selection_reason: context.baseline?.selection_reason || null,
+    },
+    status: formatAgentStatus(context.status),
+    summary: formatAgentSummary(context, comparisons),
+    evidence,
+    links: context.links || {},
+    preview: context.preview || null,
+    next_actions: buildAgentNextActions(context, comparisonSummary),
+  };
+
+  if (includeSet.has('screenshots')) {
+    payload.screenshots = context.screenshots || [];
+  }
+
+  if (includeSet.has('comments')) {
+    payload.comments = context.comments || {};
+  }
+
+  return payload;
 }
 
 function getBuildCommentsCount(context = {}) {
@@ -688,9 +908,22 @@ export async function contextBuildCommand(
       return;
     }
 
+    let resolvedBuildId = resolveBuildContextId(buildId, runtime, deps);
+
     output.startSpinner('Fetching build context...');
-    let context = await runtime.provider.getBuildContext(buildId);
+    let context = await runtime.provider.getBuildContext(resolvedBuildId);
     output.stopSpinner();
+
+    if (globalOptions.json && options.agent && !options.full) {
+      output.data(
+        buildAgentBuildPayload(context, {
+          source: runtime.source,
+          include: parseIncludeOption(options.include),
+        })
+      );
+      output.cleanup();
+      return;
+    }
 
     if (globalOptions.json) {
       output.data(context);
@@ -939,7 +1172,9 @@ export async function contextReviewQueueCommand(
 }
 
 export function validateContextBuildOptions(_options = {}) {
-  return validateSourceOption(_options.source);
+  let errors = validateSourceOption(_options.source);
+  errors.push(...validateIncludeOption(_options.include));
+  return errors;
 }
 
 export function validateContextComparisonOptions(options = {}) {

--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -133,7 +133,13 @@ export async function projectLinkCommand(
     output.complete(
       `Linked ${linkedProject.organizationSlug}/${linkedProject.projectSlug}`
     );
-    output.hint(`Cloud uploads will use ${linkedProject.tokenPrefix}...`);
+    output.hint(
+      `Active project: ${linkedProject.organizationSlug}/${linkedProject.projectSlug}`
+    );
+    output.hint(
+      `Cloud uploads and project-scoped context will use ${linkedProject.tokenPrefix}...`
+    );
+    output.hint(`Credential storage: ${linkedProject.storage}`);
     output.cleanup();
   } catch (error) {
     output.stopSpinner();

--- a/src/context/provider-resolver.js
+++ b/src/context/provider-resolver.js
@@ -6,6 +6,7 @@ export function resolveContextSource(options = {}, deps = {}) {
     command,
     target = null,
     projectRoot = process.cwd(),
+    hasCloudScope = false,
   } = options;
   let {
     createLocalWorkspaceContextProvider = defaultCreateLocalWorkspaceContextProvider,
@@ -35,6 +36,10 @@ export function resolveContextSource(options = {}, deps = {}) {
     }
 
     return 'local';
+  }
+
+  if (hasCloudScope) {
+    return 'cloud';
   }
 
   if (

--- a/src/utils/global-config.js
+++ b/src/utils/global-config.js
@@ -9,13 +9,39 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import * as output from './output.js';
 
+export function expandHomePath(path) {
+  if (!path) {
+    return path;
+  }
+
+  let home = homedir();
+
+  if (path === '$HOME') {
+    return home;
+  }
+
+  if (path.startsWith('$HOME/')) {
+    return join(home, path.slice('$HOME/'.length));
+  }
+
+  if (path === '~') {
+    return home;
+  }
+
+  if (path.startsWith('~/')) {
+    return join(home, path.slice(2));
+  }
+
+  return path;
+}
+
 /**
  * Get the path to the global Vizzly directory
  * @returns {string} Path to VIZZLY_HOME or ~/.vizzly
  */
 export function getGlobalConfigDir() {
   if (process.env.VIZZLY_HOME) {
-    return process.env.VIZZLY_HOME;
+    return expandHomePath(process.env.VIZZLY_HOME);
   }
   return join(homedir(), '.vizzly');
 }

--- a/tests/commands/config-cmd.test.js
+++ b/tests/commands/config-cmd.test.js
@@ -183,5 +183,43 @@ describe('commands/config', () => {
         !JSON.stringify(dataCall.args[0]).includes('supersecrettoken12345')
       );
     });
+
+    it('shows the active linked project without exposing the token', async () => {
+      let output = createMockOutput();
+
+      await configCommand(
+        null,
+        {},
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'vzt_supersecrettoken12345',
+            apiUrl: 'https://app.vizzly.dev',
+            server: { port: 47392 },
+            linkedProject: {
+              organizationSlug: 'vizzly',
+              projectSlug: 'frontend',
+              tokenPrefix: 'vzt_123',
+              storage: 'keychain',
+              expiresAt: null,
+            },
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let dataCall = output.calls.find(c => c.method === 'data');
+      assert.deepStrictEqual(dataCall.args[0].config.linkedProject, {
+        organization: 'vizzly',
+        project: 'frontend',
+        tokenPrefix: 'vzt_123',
+        storage: 'keychain',
+        expiresAt: null,
+      });
+      assert.ok(
+        !JSON.stringify(dataCall.args[0]).includes('supersecrettoken12345')
+      );
+    });
   });
 });

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -49,6 +49,15 @@ describe('commands/context', () => {
       assert.ok(errors.includes('--source must be one of: auto, cloud, local'));
     });
 
+    it('rejects invalid compact agent include values', () => {
+      let errors = validateContextBuildOptions({ include: 'screenshots,logs' });
+      assert.ok(
+        errors.includes(
+          '--include must contain only: screenshots, diffs, comments'
+        )
+      );
+    });
+
     it('rejects out-of-range comparison context limits', () => {
       let errors = validateContextComparisonOptions({ similarLimit: 51 });
       assert.ok(
@@ -153,6 +162,232 @@ describe('commands/context', () => {
       assert.ok(dataCall);
       assert.strictEqual(dataCall.args[0].resource, 'build_context');
       assert.strictEqual(dataCall.args[0].build.id, 'build-1');
+    });
+
+    it('returns compact agent JSON by default instead of the full context payload', async () => {
+      let output = createMockOutput();
+
+      await contextBuildCommand(
+        'build-1',
+        { agent: true },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => ({
+            resource: 'build_context',
+            source: 'cloud',
+            scope: {
+              organization: { slug: 'acme', name: 'Acme' },
+              project: { slug: 'web', name: 'Web', visibility: 'private' },
+            },
+            build: {
+              id: 'build-1',
+              name: 'main-abc123',
+              status: 'completed',
+              approval_status: 'pending',
+            },
+            baseline: {
+              selected: {
+                id: 'baseline-1',
+                name: 'Approved Main',
+                approval_status: 'approved',
+              },
+              selection_reason: 'latest approved build',
+            },
+            status: {
+              needs_review: true,
+              reasons: ['comparisons_need_review'],
+              pending_comparisons: 2,
+              unresolved_comments: 0,
+            },
+            summary: {
+              comparisons: { total: 2, changed: 1, new: 1, identical: 0 },
+            },
+            screenshots: [{ id: 'ss-1', name: 'Dashboard' }],
+            comparisons: [
+              {
+                id: 'cmp-1',
+                screenshot_name: 'Dashboard',
+                result: 'changed',
+                needs_review: true,
+                diff: {
+                  percentage: 1.23,
+                  changed_pixels: 123,
+                  total_pixels: 10000,
+                  threshold: 2,
+                  image_url: 'https://cdn.test/diff.png',
+                  regions: [{ pixelCount: 50 }],
+                  fingerprint_hash: 'fp-dashboard',
+                },
+                screenshot: {
+                  id: 'ss-1',
+                  original_url: 'https://cdn.test/current.png',
+                },
+                baseline: {
+                  id: 'base-ss-1',
+                  build_id: 'baseline-1',
+                  original_url: 'https://cdn.test/baseline.png',
+                },
+              },
+              {
+                id: 'cmp-2',
+                screenshot_name: 'Settings',
+                result: 'new',
+                needs_review: true,
+              },
+            ],
+            comments: {
+              build: [{ id: 'comment-1', message: 'looks risky' }],
+            },
+            links: { build_url: 'https://app.test/acme/web/builds/build-1' },
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+      let payload = dataCall.args[0];
+
+      assert.strictEqual(payload.resource, 'build_agent_context');
+      assert.strictEqual(payload.project.organization, 'acme');
+      assert.strictEqual(payload.build.id, 'build-1');
+      assert.strictEqual(payload.baseline.selected.name, 'Approved Main');
+      assert.strictEqual(payload.status.needs_review, true);
+      assert.strictEqual(payload.evidence.length, 2);
+      assert.strictEqual(payload.evidence[0].name, 'Dashboard');
+      assert.strictEqual(payload.evidence[0].diff.region_count, 1);
+      assert.ok(!payload.screenshots);
+      assert.ok(!payload.comments);
+      assert.ok(
+        payload.next_actions.some(action =>
+          action.includes('Inspect the changed and new comparisons')
+        )
+      );
+    });
+
+    it('allows compact agent JSON to include requested detail', async () => {
+      let output = createMockOutput();
+
+      await contextBuildCommand(
+        'build-1',
+        { agent: true, include: 'screenshots,diffs,comments' },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => ({
+            resource: 'build_context',
+            scope: {
+              organization: { slug: 'acme' },
+              project: { slug: 'web' },
+            },
+            build: { id: 'build-1' },
+            status: { needs_review: true, pending_comparisons: 1 },
+            screenshots: [{ id: 'ss-1', name: 'Dashboard' }],
+            comparisons: [
+              {
+                id: 'cmp-1',
+                screenshot_name: 'Dashboard',
+                result: 'changed',
+                diff: {
+                  regions: [{ pixelCount: 50 }],
+                  cluster_metadata: { clusterCount: 1 },
+                },
+              },
+            ],
+            comments: { build: [{ id: 'comment-1' }] },
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let payload = output.calls.find(call => call.method === 'data').args[0];
+      assert.deepStrictEqual(payload.screenshots, [
+        { id: 'ss-1', name: 'Dashboard' },
+      ]);
+      assert.deepStrictEqual(payload.comments, {
+        build: [{ id: 'comment-1' }],
+      });
+      assert.deepStrictEqual(payload.evidence[0].diff.regions, [
+        { pixelCount: 50 },
+      ]);
+      assert.deepStrictEqual(payload.evidence[0].diff.cluster_metadata, {
+        clusterCount: 1,
+      });
+    });
+
+    it('returns the full payload when agent JSON asks for full context', async () => {
+      let output = createMockOutput();
+      let context = {
+        resource: 'build_context',
+        build: { id: 'build-1' },
+        screenshots: [{ id: 'ss-1' }],
+      };
+
+      await contextBuildCommand(
+        'build-1',
+        { agent: true, full: true },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => context,
+          output,
+          exit: () => {},
+        }
+      );
+
+      let payload = output.calls.find(call => call.method === 'data').args[0];
+      assert.strictEqual(payload.resource, 'build_context');
+      assert.deepStrictEqual(payload.screenshots, [{ id: 'ss-1' }]);
+    });
+
+    it('resolves cloud current builds from the active run session', async () => {
+      let output = createMockOutput();
+      let capturedBuildId = null;
+
+      await contextBuildCommand(
+        'current',
+        { source: 'cloud', agent: true },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          readSession: () => ({
+            buildId: 'build-from-session',
+            source: 'session_file',
+          }),
+          getBuildContext: async (_client, buildId) => {
+            capturedBuildId = buildId;
+            return {
+              resource: 'build_context',
+              build: { id: buildId },
+              comparisons: [],
+            };
+          },
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedBuildId, 'build-from-session');
+      let payload = output.calls.find(call => call.method === 'data').args[0];
+      assert.strictEqual(payload.build.id, 'build-from-session');
     });
 
     it('uses local workspace context without requiring authentication', async () => {
@@ -802,6 +1037,47 @@ describe('commands/context', () => {
   });
 
   describe('contextReviewQueueCommand', () => {
+    it('uses cloud in auto mode when project scope is explicit', async () => {
+      let output = createMockOutput();
+      let capturedRuntimeOptions = null;
+
+      await contextReviewQueueCommand(
+        { org: 'acme', project: 'storybook', limit: 5 },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          resolveContextSource: runtimeOptions => {
+            capturedRuntimeOptions = runtimeOptions;
+            return 'cloud';
+          },
+          createLocalWorkspaceContextProvider: () => ({
+            isAvailable: () => true,
+            canHandle: () => true,
+          }),
+          createApiClient: () => ({}),
+          getReviewQueueContext: async () => ({
+            resource: 'review_queue_context',
+            source: 'cloud',
+            scope: {
+              organization: { slug: 'acme' },
+              project: { slug: 'storybook' },
+            },
+            summary: { total: 0, changed: 0, new: 0, builds: 0 },
+            comparisons: [],
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedRuntimeOptions.hasCloudScope, true);
+      let dataCall = output.calls.find(call => call.method === 'data');
+      assert.strictEqual(dataCall.args[0].source, 'cloud');
+    });
+
     it('passes review queue scope and pagination to the API helper', async () => {
       let output = createMockOutput();
       let capturedQuery = null;

--- a/tests/commands/project.test.js
+++ b/tests/commands/project.test.js
@@ -120,6 +120,20 @@ describe('commands/project', () => {
             call.args[0] === 'Linked vizzly/storybook'
         )
       );
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'hint' &&
+            call.args[0] === 'Active project: vizzly/storybook'
+        )
+      );
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'hint' &&
+            call.args[0] === 'Credential storage: keychain'
+        )
+      );
     });
 
     it('asks the user to login before linking', async () => {

--- a/tests/context/provider-resolver.test.js
+++ b/tests/context/provider-resolver.test.js
@@ -51,6 +51,25 @@ describe('context/provider-resolver', () => {
     assert.strictEqual(source, 'local');
   });
 
+  it('prefers cloud in auto mode when an explicit cloud scope is present', () => {
+    let source = resolveContextSource(
+      {
+        requestedSource: 'auto',
+        command: 'review-queue',
+        target: null,
+        hasCloudScope: true,
+      },
+      {
+        createLocalWorkspaceContextProvider: () => ({
+          isAvailable: () => true,
+          canHandle: () => true,
+        }),
+      }
+    );
+
+    assert.strictEqual(source, 'cloud');
+  });
+
   it('falls back to cloud in auto mode when the workspace cannot answer the query', () => {
     let source = resolveContextSource(
       { requestedSource: 'auto', command: 'similar', target: 'fp-dashboard' },

--- a/tests/utils/global-config.test.js
+++ b/tests/utils/global-config.test.js
@@ -6,11 +6,13 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   clearAuthTokens,
   clearGlobalConfig,
+  expandHomePath,
   getAccessToken,
   getAuthTokens,
   getGlobalConfigDir,
@@ -56,6 +58,30 @@ describe('utils/global-config', () => {
 
       // Restore
       process.env.VIZZLY_HOME = testDir;
+    });
+
+    it('expands shell-style home paths from dotenv files', () => {
+      process.env.VIZZLY_HOME = '$HOME/.vizzly.dev';
+      let dir = getGlobalConfigDir();
+
+      assert.strictEqual(dir.endsWith('/.vizzly.dev'), true);
+      assert.strictEqual(dir.includes('$HOME'), false);
+
+      process.env.VIZZLY_HOME = testDir;
+    });
+  });
+
+  describe('expandHomePath', () => {
+    it('expands tilde and HOME prefixes without changing other paths', () => {
+      assert.strictEqual(
+        expandHomePath('$HOME/.vizzly'),
+        join(homedir(), '.vizzly')
+      );
+      assert.strictEqual(
+        expandHomePath('~/.vizzly'),
+        join(homedir(), '.vizzly')
+      );
+      assert.strictEqual(expandHomePath('/tmp/vizzly'), '/tmp/vizzly');
     });
   });
 


### PR DESCRIPTION
## What Changed

- Fixed context source selection so explicit cloud scope and linked projects bias cloud in auto mode, while `--source local` stays local.
- Made `context build --agent --json` compact by default with stable build, baseline, status, evidence, and next-action fields.
- Added `--include screenshots,diffs,comments` and `--full` escape hatches for larger agent payloads.
- Polished project link and config output so the active project and credential storage are obvious without exposing tokens.
- Softened CLI/package/docs language away from repeated "UI context" phrasing.
- Added `npm run smoke:prod:pack`, which builds, packs, installs the tarball, verifies auth/project link/build/context against prod with isolated config, revokes the temporary token, and cleans up.

## Verification

- `npm run lint`
- `npm run build`
- `npm test`
- `npm run smoke:prod:pack`
