### PR TITLE
📝 Generate CLI release notes with Codex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,25 +77,80 @@ jobs:
           echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
       - name: Generate release notes
+        continue-on-error: true
+        uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          sandbox: workspace-write
+          safety-strategy: drop-sudo
+          prompt: |
+            Generate release notes for Vizzly CLI ${{ steps.version.outputs.new_version }}.
+
+            Context:
+            - Previous release tag: `${{ steps.prev_version.outputs.tag }}`
+            - New release tag: `${{ steps.version.outputs.new_version }}`
+            - Package version: `${{ steps.version.outputs.package_version }}`
+            - Package name: `@vizzly-testing/cli`
+
+            Instructions:
+            1. Use git commands to inspect commits and changed files for this release.
+               - If a previous release tag exists, inspect `${{ steps.prev_version.outputs.tag }}..HEAD`.
+               - If there is no previous release tag, inspect the latest 10 commits.
+            2. Read relevant diffs or files when commit messages are too vague.
+            3. Write concise, user-facing release notes. Keep it grounded in the real diff.
+            4. Use Keep a Changelog-style sections, but omit empty sections.
+            5. Prefer these headings when they apply: `### Added`, `### Changed`, `### Fixed`, `### Developer Experience`.
+            6. Do not invent features, fixes, migration steps, or breaking changes.
+            7. Do not include a raw list of commits or commands run.
+            8. Include a full changelog link at the bottom:
+               - If a previous release tag exists: `**Full Changelog**: https://github.com/vizzly-testing/cli/compare/${{ steps.prev_version.outputs.tag }}...${{ steps.version.outputs.new_version }}`
+               - Otherwise: `**Full Changelog**: https://github.com/vizzly-testing/cli/releases/tag/${{ steps.version.outputs.new_version }}`
+            9. Save the release notes to `RELEASE_NOTES.md`.
+
+            Use this format:
+
+            ## What's Changed
+
+            ### Added
+            - Short, concrete item grounded in the diff.
+
+            ### Changed
+            - Short, concrete item grounded in the diff.
+
+            ### Fixed
+            - Short, concrete item grounded in the diff.
+
+            **Full Changelog**: https://github.com/vizzly-testing/cli/compare/<previous-tag>...<new-tag>
+
+      - name: Read release notes
         id: release_notes
         run: |
-          if [ -n "${{ steps.prev_version.outputs.tag }}" ]; then
-            COMMITS=$(git log ${{ steps.prev_version.outputs.tag }}..HEAD --pretty=format:"- %s")
-            CHANGELOG_URL="https://github.com/vizzly-testing/cli/compare/${{ steps.prev_version.outputs.tag }}...${{ steps.version.outputs.new_version }}"
-          else
-            COMMITS=$(git log --pretty=format:"- %s" -10)
-            CHANGELOG_URL="https://github.com/vizzly-testing/cli/releases/tag/${{ steps.version.outputs.new_version }}"
+          if [ ! -s RELEASE_NOTES.md ]; then
+            if [ -n "${{ steps.prev_version.outputs.tag }}" ]; then
+              CHANGELOG_URL="https://github.com/vizzly-testing/cli/compare/${{ steps.prev_version.outputs.tag }}...${{ steps.version.outputs.new_version }}"
+            else
+              CHANGELOG_URL="https://github.com/vizzly-testing/cli/releases/tag/${{ steps.version.outputs.new_version }}"
+            fi
+
+            {
+              echo "## What's Changed"
+              echo
+              if [ -n "${{ steps.prev_version.outputs.tag }}" ]; then
+                git log ${{ steps.prev_version.outputs.tag }}..HEAD --pretty=format:"- %s"
+              else
+                git log --pretty=format:"- %s" -10
+              fi
+              echo
+              echo
+              echo "**Full Changelog**: $CHANGELOG_URL"
+            } > RELEASE_NOTES.md
           fi
 
           {
             echo 'notes<<RELEASE_EOF'
-            echo "## What's Changed"
-            echo
-            echo "$COMMITS"
-            echo
-            echo "**Full Changelog**: $CHANGELOG_URL"
+            cat RELEASE_NOTES.md
             echo 'RELEASE_EOF'
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Verify package version is unpublished
         run: |


### PR DESCRIPTION
## Summary

This PR updates the main CLI release workflow to use `openai/codex-action` for GitHub release notes.

The current release notes are technically correct, but they are just commit subjects. That works when every commit is perfectly written. It falls apart when the interesting part is in the diff: docs changes, CLI behavior tweaks, test/supporting work, or a PR that bundles a few related files together.

The new flow asks Codex to inspect the actual release diff and write concise Keep a Changelog-style notes. The prompt is intentionally restrained: no invented features, no marketing polish, no raw commit dump, and no command log. Just the user-facing changes that are actually in the release.

## What Changed

- Replaced the commit-list-only release note generation in `.github/workflows/release.yml` with `openai/codex-action`.
- Instructed Codex to inspect the tag-to-HEAD diff and read files when commit messages are not enough.
- Writes generated notes to `RELEASE_NOTES.md`, then passes that file into the GitHub Release body.
- Keeps a fallback path that generates the old commit-subject notes if Codex does not produce a file.

## Why

This gives us release notes that are still simple, but much more useful. The goal is not fancy copy. The goal is grounded notes that explain what changed in a way a user can scan quickly.

## Verification

Validated the workflow YAML locally and checked the diff for whitespace issues. `actionlint` is not installed locally, so this has not been run through actionlint.