### PR TITLE
✨ Align core SDK option contracts

### DIFF
--- a/clients/ember/bin/vizzly-testem-launcher.js
+++ b/clients/ember/bin/vizzly-testem-launcher.js
@@ -34,7 +34,7 @@ let browserType = args[0];
 let testUrl = args[args.length - 1];
 
 // Validate arguments
-if (!browserType || !testUrl || !testUrl.startsWith('http')) {
+if (!browserType || !testUrl?.startsWith('http')) {
   console.error('Usage: vizzly-testem-launcher <browser> <url>');
   console.error('  browser: chromium | firefox | webkit');
   console.error('  url: Test page URL (provided by Testem)');

--- a/clients/static-site/src/server.js
+++ b/clients/static-site/src/server.js
@@ -56,7 +56,7 @@ export async function startStaticServer(rootDir, port = 0) {
  * @returns {Promise<void>}
  */
 export async function stopStaticServer(serverInfo) {
-  if (!serverInfo || !serverInfo.server) {
+  if (!serverInfo?.server) {
     return;
   }
 

--- a/clients/storybook/src/server.js
+++ b/clients/storybook/src/server.js
@@ -56,7 +56,7 @@ export async function startStaticServer(rootDir, port = 0) {
  * @returns {Promise<void>}
  */
 export async function stopStaticServer(serverInfo) {
-  if (!serverInfo || !serverInfo.server) {
+  if (!serverInfo?.server) {
     return;
   }
 

--- a/examples/custom-plugin/package.json
+++ b/examples/custom-plugin/package.json
@@ -4,7 +4,9 @@
   "description": "Example Vizzly CLI plugin demonstrating the plugin API",
   "main": "plugin.js",
   "type": "module",
-  "vizzlyPlugin": "./plugin.js",
+  "vizzly": {
+    "plugin": "./plugin.js"
+  },
   "keywords": [
     "vizzly",
     "vizzly-plugin",
@@ -12,10 +14,7 @@
   ],
   "author": "Vizzly Team",
   "license": "MIT",
-  "dependencies": {
-    "glob": "^13.0.0"
-  },
   "peerDependencies": {
-    "@vizzly-testing/cli": ">=0.24.0"
+    "@vizzly-testing/cli": "^0.9.0"
   }
 }

--- a/examples/custom-plugin/package.json
+++ b/examples/custom-plugin/package.json
@@ -4,9 +4,7 @@
   "description": "Example Vizzly CLI plugin demonstrating the plugin API",
   "main": "plugin.js",
   "type": "module",
-  "vizzly": {
-    "plugin": "./plugin.js"
-  },
+  "vizzlyPlugin": "./plugin.js",
   "keywords": [
     "vizzly",
     "vizzly-plugin",
@@ -14,7 +12,10 @@
   ],
   "author": "Vizzly Team",
   "license": "MIT",
+  "dependencies": {
+    "glob": "^13.0.0"
+  },
   "peerDependencies": {
-    "@vizzly-testing/cli": "^0.9.0"
+    "@vizzly-testing/cli": ">=0.24.0"
   }
 }

--- a/examples/custom-plugin/plugin.js
+++ b/examples/custom-plugin/plugin.js
@@ -26,7 +26,9 @@ export default {
       .description('Say hello from the example plugin')
       .action(() => {
         output.info('Hello from the example plugin!');
-        output.info(`Config environment: ${config.build?.environment || 'not set'}`);
+        output.info(
+          `Config environment: ${config.build?.environment || 'not set'}`
+        );
       });
 
     // Example 2: Command with arguments and options
@@ -60,7 +62,9 @@ export default {
             output.success('git.detect is available');
             let gitInfo = await git.detect({ buildPrefix: 'Example' });
             output.info(`  Branch: ${gitInfo.branch}`);
-            output.info(`  Commit: ${gitInfo.commit?.slice(0, 7) || 'unknown'}`);
+            output.info(
+              `  Commit: ${gitInfo.commit?.slice(0, 7) || 'unknown'}`
+            );
             output.info(`  PR: ${gitInfo.prNumber || 'none'}`);
           } else {
             output.warn('git.detect not available (requires CLI v0.25.0+)');
@@ -85,7 +89,9 @@ export default {
           }
 
           output.info(`API URL: ${config.apiUrl || 'https://app.vizzly.dev'}`);
-          output.info(`API Token: ${config.apiKey ? '***' + config.apiKey.slice(-4) : 'Not set'}`);
+          output.info(
+            `API Token: ${config.apiKey ? `***${config.apiKey.slice(-4)}` : 'Not set'}`
+          );
         } catch (error) {
           output.error(`Failed to access services: ${error.message}`);
           process.exit(1);
@@ -99,20 +105,33 @@ export default {
       .action(async () => {
         try {
           let { glob } = await import('glob');
-          let screenshotsDir = config.upload?.screenshotsDir || './screenshots';
+          let screenshotsDirs = Array.isArray(config.upload?.screenshotsDir)
+            ? config.upload.screenshotsDir
+            : [config.upload?.screenshotsDir || './screenshots'];
 
-          output.info(`Looking for screenshots in: ${screenshotsDir}`);
+          output.info(
+            `Looking for screenshots in: ${screenshotsDirs.join(', ')}`
+          );
 
-          let files = await glob('**/*.{png,jpg,jpeg}', {
-            cwd: screenshotsDir,
-            absolute: false,
-          });
+          let fileGroups = await Promise.all(
+            screenshotsDirs.map(async screenshotsDir => {
+              let files = await glob('**/*.{png,jpg,jpeg}', {
+                cwd: screenshotsDir,
+                absolute: false,
+              });
+
+              return files.map(file => `${screenshotsDir}/${file}`);
+            })
+          );
+          let files = fileGroups.flat();
 
           if (files.length === 0) {
             output.warn('No screenshot files found');
           } else {
             output.info(`Found ${files.length} screenshot(s):`);
-            files.forEach(file => output.info(`  - ${file}`));
+            for (let file of files) {
+              output.info(`  - ${file}`);
+            }
           }
         } catch (error) {
           output.error(`Failed to list screenshots: ${error.message}`);

--- a/examples/custom-plugin/plugin.js
+++ b/examples/custom-plugin/plugin.js
@@ -26,9 +26,7 @@ export default {
       .description('Say hello from the example plugin')
       .action(() => {
         output.info('Hello from the example plugin!');
-        output.info(
-          `Config environment: ${config.build?.environment || 'not set'}`
-        );
+        output.info(`Config environment: ${config.build?.environment || 'not set'}`);
       });
 
     // Example 2: Command with arguments and options
@@ -62,9 +60,7 @@ export default {
             output.success('git.detect is available');
             let gitInfo = await git.detect({ buildPrefix: 'Example' });
             output.info(`  Branch: ${gitInfo.branch}`);
-            output.info(
-              `  Commit: ${gitInfo.commit?.slice(0, 7) || 'unknown'}`
-            );
+            output.info(`  Commit: ${gitInfo.commit?.slice(0, 7) || 'unknown'}`);
             output.info(`  PR: ${gitInfo.prNumber || 'none'}`);
           } else {
             output.warn('git.detect not available (requires CLI v0.25.0+)');
@@ -89,9 +85,7 @@ export default {
           }
 
           output.info(`API URL: ${config.apiUrl || 'https://app.vizzly.dev'}`);
-          output.info(
-            `API Token: ${config.apiKey ? `***${config.apiKey.slice(-4)}` : 'Not set'}`
-          );
+          output.info(`API Token: ${config.apiKey ? '***' + config.apiKey.slice(-4) : 'Not set'}`);
         } catch (error) {
           output.error(`Failed to access services: ${error.message}`);
           process.exit(1);
@@ -105,33 +99,20 @@ export default {
       .action(async () => {
         try {
           let { glob } = await import('glob');
-          let screenshotsDirs = Array.isArray(config.upload?.screenshotsDir)
-            ? config.upload.screenshotsDir
-            : [config.upload?.screenshotsDir || './screenshots'];
+          let screenshotsDir = config.upload?.screenshotsDir || './screenshots';
 
-          output.info(
-            `Looking for screenshots in: ${screenshotsDirs.join(', ')}`
-          );
+          output.info(`Looking for screenshots in: ${screenshotsDir}`);
 
-          let fileGroups = await Promise.all(
-            screenshotsDirs.map(async screenshotsDir => {
-              let files = await glob('**/*.{png,jpg,jpeg}', {
-                cwd: screenshotsDir,
-                absolute: false,
-              });
-
-              return files.map(file => `${screenshotsDir}/${file}`);
-            })
-          );
-          let files = fileGroups.flat();
+          let files = await glob('**/*.{png,jpg,jpeg}', {
+            cwd: screenshotsDir,
+            absolute: false,
+          });
 
           if (files.length === 0) {
             output.warn('No screenshot files found');
           } else {
             output.info(`Found ${files.length} screenshot(s):`);
-            for (let file of files) {
-              output.info(`  - ${file}`);
-            }
+            files.forEach(file => output.info(`  - ${file}`));
           }
         } catch (error) {
           output.error(`Failed to list screenshots: ${error.message}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,8 +404,11 @@ importers:
   examples/custom-plugin:
     dependencies:
       '@vizzly-testing/cli':
-        specifier: ^0.9.0
-        version: 0.9.1(typescript@6.0.3)
+        specifier: '>=0.24.0'
+        version: 0.30.0(typescript@6.0.3)
+      glob:
+        specifier: ^13.0.0
+        version: 13.0.6
 
   test-site:
     devDependencies:
@@ -1862,10 +1865,6 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
-  '@isaacs/cliui@9.0.0':
-    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
-    engines: {node: '>=18'}
-
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2858,11 +2857,6 @@ packages:
   '@vizzly-testing/cli@0.30.0':
     resolution: {integrity: sha512-vtF2ncb8NatRMBtY+0KKs8PFY7h5B86bymaWzyWWffIqzTcOC0ZCVI6ZMJ8qit6zx8Jh/EKdGHcieKJ5qrYa4A==}
     engines: {node: '>=22.0.0'}
-    hasBin: true
-
-  '@vizzly-testing/cli@0.9.1':
-    resolution: {integrity: sha512-nn2cDrXK86iU/DQZMdqIxzPChsac46TdsekgwpRIz16FQrlJy9LCZVWFY98LRUrbphGu4V+fxcIr5FFKSiDorg==}
-    engines: {node: '>=20.0.0'}
     hasBin: true
 
   '@vizzly-testing/honeydiff@0.10.3':
@@ -4909,12 +4903,6 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@11.1.0:
-    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
-    engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -5438,10 +5426,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jackspeak@4.2.3:
-    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
-    engines: {node: 20 || >=22}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -6084,10 +6068,6 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
-  odiff-bin@3.2.1:
-    resolution: {integrity: sha512-28y48d9vOf4DqHcn3U0RXL5PVO9gVNgrjzlO3Yu47NeDWnoxiIjlXRiXX5GYh0TU7qfUnWU7KGMtpl2BLJWpsA==}
-    hasBin: true
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -9790,8 +9770,6 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@isaacs/cliui@9.0.0': {}
-
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
@@ -10613,17 +10591,6 @@ snapshots:
       form-data: 4.0.5
       glob: 13.0.6
       zod: 4.4.3
-    transitivePeerDependencies:
-      - typescript
-
-  '@vizzly-testing/cli@0.9.1(typescript@6.0.3)':
-    dependencies:
-      commander: 14.0.3
-      cosmiconfig: 9.0.1(typescript@6.0.3)
-      dotenv: 17.4.2
-      form-data: 4.0.5
-      glob: 11.1.0
-      odiff-bin: 3.2.1
     transitivePeerDependencies:
       - typescript
 
@@ -13221,15 +13188,6 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.1.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.2.3
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.2
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -13764,10 +13722,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jackspeak@4.2.3:
-    dependencies:
-      '@isaacs/cliui': 9.0.0
 
   jake@10.9.4:
     dependencies:
@@ -14390,8 +14344,6 @@ snapshots:
       object-keys: 1.1.1
 
   obug@2.1.1: {}
-
-  odiff-bin@3.2.1: {}
 
   on-finished@2.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,11 +404,8 @@ importers:
   examples/custom-plugin:
     dependencies:
       '@vizzly-testing/cli':
-        specifier: '>=0.24.0'
-        version: 0.30.0(typescript@6.0.3)
-      glob:
-        specifier: ^13.0.0
-        version: 13.0.6
+        specifier: ^0.9.0
+        version: 0.9.1(typescript@6.0.3)
 
   test-site:
     devDependencies:
@@ -1865,6 +1862,10 @@ packages:
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
 
+  '@isaacs/cliui@9.0.0':
+    resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
+    engines: {node: '>=18'}
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2857,6 +2858,11 @@ packages:
   '@vizzly-testing/cli@0.30.0':
     resolution: {integrity: sha512-vtF2ncb8NatRMBtY+0KKs8PFY7h5B86bymaWzyWWffIqzTcOC0ZCVI6ZMJ8qit6zx8Jh/EKdGHcieKJ5qrYa4A==}
     engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  '@vizzly-testing/cli@0.9.1':
+    resolution: {integrity: sha512-nn2cDrXK86iU/DQZMdqIxzPChsac46TdsekgwpRIz16FQrlJy9LCZVWFY98LRUrbphGu4V+fxcIr5FFKSiDorg==}
+    engines: {node: '>=20.0.0'}
     hasBin: true
 
   '@vizzly-testing/honeydiff@0.10.3':
@@ -4903,6 +4909,12 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@11.1.0:
+    resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
+    engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -5426,6 +5438,10 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jackspeak@4.2.3:
+    resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
+    engines: {node: 20 || >=22}
 
   jake@10.9.4:
     resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
@@ -6068,6 +6084,10 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  odiff-bin@3.2.1:
+    resolution: {integrity: sha512-28y48d9vOf4DqHcn3U0RXL5PVO9gVNgrjzlO3Yu47NeDWnoxiIjlXRiXX5GYh0TU7qfUnWU7KGMtpl2BLJWpsA==}
+    hasBin: true
 
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
@@ -9770,6 +9790,8 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
+  '@isaacs/cliui@9.0.0': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.10
@@ -10591,6 +10613,17 @@ snapshots:
       form-data: 4.0.5
       glob: 13.0.6
       zod: 4.4.3
+    transitivePeerDependencies:
+      - typescript
+
+  '@vizzly-testing/cli@0.9.1(typescript@6.0.3)':
+    dependencies:
+      commander: 14.0.3
+      cosmiconfig: 9.0.1(typescript@6.0.3)
+      dotenv: 17.4.2
+      form-data: 4.0.5
+      glob: 11.1.0
+      odiff-bin: 3.2.1
     transitivePeerDependencies:
       - typescript
 
@@ -13188,6 +13221,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -13722,6 +13764,10 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jackspeak@4.2.3:
+    dependencies:
+      '@isaacs/cliui': 9.0.0
 
   jake@10.9.4:
     dependencies:
@@ -14344,6 +14390,8 @@ snapshots:
       object-keys: 1.1.1
 
   obug@2.1.1: {}
+
+  odiff-bin@3.2.1: {}
 
   on-finished@2.3.0:
     dependencies:

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -194,6 +194,7 @@ export function buildScreenshotCheckObject(sha256, name, metadata = {}) {
     browser: meta.browser || 'chrome',
     viewport_width: meta.viewport?.width || meta.viewport_width || 1920,
     viewport_height: meta.viewport?.height || meta.viewport_height || 1080,
+    properties: meta,
   };
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -279,6 +279,7 @@ const formatHelp = (cmd, helper) => {
 
 function extractGlobalOptionsFromArgv(argv, commandNames = null) {
   let configPath = null;
+  let tokenArg = null;
   let verboseMode = false;
   let logLevelArg = null;
   let jsonArg = null;
@@ -286,6 +287,12 @@ function extractGlobalOptionsFromArgv(argv, commandNames = null) {
   for (let i = 0; i < argv.length; i++) {
     if ((argv[i] === '-c' || argv[i] === '--config') && argv[i + 1]) {
       configPath = argv[i + 1];
+    }
+
+    if (argv[i] === '--token' && argv[i + 1]) {
+      tokenArg = argv[i + 1];
+    } else if (argv[i].startsWith('--token=')) {
+      tokenArg = argv[i].substring('--token='.length);
     }
 
     if (argv[i] === '-v' || argv[i] === '--verbose') {
@@ -310,7 +317,7 @@ function extractGlobalOptionsFromArgv(argv, commandNames = null) {
     }
   }
 
-  return { configPath, verboseMode, logLevelArg, jsonArg };
+  return { configPath, tokenArg, verboseMode, logLevelArg, jsonArg };
 }
 
 function normalizeJsonArgv(argv, commandNames) {
@@ -355,7 +362,7 @@ program
 
 // Load plugins before defining commands
 // We need to manually parse to get the config option early
-let { configPath, verboseMode, logLevelArg, jsonArg } =
+let { configPath, tokenArg, verboseMode, logLevelArg, jsonArg } =
   extractGlobalOptionsFromArgv(process.argv);
 
 // Configure output early
@@ -374,9 +381,9 @@ output.configure({
   json: jsonArg,
 });
 
-const config = await loadConfig(configPath, {});
-const services = createServices(config);
-const pluginServices = createPluginServices(services);
+let config = await loadConfig(configPath, { token: tokenArg });
+let services = createServices(config);
+let pluginServices = createPluginServices(services);
 
 let plugins = [];
 try {
@@ -424,7 +431,7 @@ program
 program
   .command('upload')
   .description('Upload screenshots to Vizzly')
-  .argument('<path>', 'Path to screenshots directory or file')
+  .argument('<path>', 'Path to screenshots directory')
   .option('-b, --build-name <name>', 'Build name for grouping')
   .option('-m, --metadata <json>', 'Additional metadata as JSON')
   .option('--batch-size <n>', 'Upload batch size', Number)
@@ -434,12 +441,17 @@ program
   .option('--message <msg>', 'Commit message')
   .option('--environment <env>', 'Environment name', 'test')
   .option('--threshold <number>', 'Comparison threshold', Number)
+  .option(
+    '--min-cluster-size <pixels>',
+    'Minimum changed-pixel cluster size',
+    Number
+  )
   .option('--token <token>', 'API token override')
   .option('--wait', 'Wait for build completion')
   .option('--upload-all', 'Upload all screenshots without SHA deduplication')
   .option('--parallel-id <id>', 'Unique identifier for parallel test execution')
   .action(async (path, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = program.opts();
 
     // Validate options
     const validationErrors = validateUploadOptions(path, options);
@@ -451,7 +463,10 @@ program
       process.exit(1);
     }
 
-    await uploadCommand(path, options, globalOptions);
+    let result = await uploadCommand(path, options, globalOptions);
+    if (result?.exitCode) {
+      process.exit(result.exitCode);
+    }
   });
 
 // TDD command with subcommands - local visual review with an interactive dashboard

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -227,17 +227,21 @@ function createSimpleClient(serverUrl, clientOptions = {}) {
         let image = isFilePath ? imageBuffer : imageBuffer.toString('base64');
         let type = isFilePath ? 'file-path' : 'base64';
 
+        let screenshotData = {
+          buildId: normalizedOptions.buildId ?? getBuildId(),
+          name,
+          image,
+          type,
+          properties: normalizedOptions.properties,
+        };
+        if (normalizedOptions.warnings.length > 0) {
+          screenshotData.warnings = normalizedOptions.warnings;
+        }
+
         let httpStart = Date.now();
         let { status, json } = await httpPost(
           `${serverUrl}/screenshot`,
-          {
-            buildId: normalizedOptions.buildId ?? getBuildId(),
-            name,
-            image,
-            type,
-            properties: normalizedOptions.properties,
-            warnings: normalizedOptions.warnings,
-          },
+          screenshotData,
           requestTimeout
         );
         let httpMs = Date.now() - httpStart;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -17,13 +17,19 @@ import { createScreenshotProperties } from '../utils/screenshot-options.js';
 
 // Internal client state
 let currentClient = null;
+let currentServerUrl = null;
 let isDisabled = false;
+let currentFailOnDiff = false;
 
 // Default timeout for screenshot requests (30 seconds)
 let DEFAULT_TIMEOUT_MS = 30000;
 
 // Log levels for client SDK output control
-export let LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+export let LOG_LEVELS = Object.freeze({ debug: 0, info: 1, warn: 2, error: 3 });
+
+function getEnvFailOnDiff(env = process.env) {
+  return env.VIZZLY_FAIL_ON_DIFF === 'true' || env.VIZZLY_FAIL_ON_DIFF === '1';
+}
 
 /**
  * Check if client should log at the given level
@@ -59,6 +65,7 @@ function isVizzlyDisabled() {
 function disableVizzly() {
   isDisabled = true;
   currentClient = null;
+  currentServerUrl = null;
 }
 
 /**
@@ -68,7 +75,11 @@ function disableVizzly() {
  * @returns {string|null} Server URL if found
  */
 export function autoDiscoverTddServer(startDir, deps = {}) {
-  let { exists = existsSync, readFile = readFileSync } = deps;
+  let {
+    exists = existsSync,
+    readFile = readFileSync,
+    env = process.env,
+  } = deps;
   try {
     // Look for .vizzly/server.json in current directory and parent directories
     let currentDir = startDir || process.cwd();
@@ -82,6 +93,8 @@ export function autoDiscoverTddServer(startDir, deps = {}) {
           let serverInfo = JSON.parse(readFile(serverJsonPath, 'utf8'));
           if (serverInfo.port) {
             let url = `http://localhost:${serverInfo.port}`;
+            currentFailOnDiff =
+              getEnvFailOnDiff(env) || Boolean(serverInfo.failOnDiff);
             return url;
           }
         } catch {
@@ -108,6 +121,7 @@ function getClient() {
 
   if (!currentClient) {
     let serverUrl = getServerUrl();
+    currentFailOnDiff = getEnvFailOnDiff();
 
     // Auto-detect local TDD server and enable Vizzly if TDD server is found
     if (!serverUrl) {
@@ -120,7 +134,10 @@ function getClient() {
 
     // If we have a server URL, create the client (regardless of initial enabled state)
     if (serverUrl) {
-      currentClient = createSimpleClient(serverUrl);
+      currentServerUrl = serverUrl;
+      currentClient = createSimpleClient(serverUrl, {
+        failOnDiff: currentFailOnDiff,
+      });
     }
   }
   return currentClient;
@@ -190,16 +207,19 @@ function httpPost(url, body, timeoutMs) {
  * Create a simple HTTP client for screenshots
  * @private
  */
-function createSimpleClient(serverUrl) {
+function createSimpleClient(serverUrl, clientOptions = {}) {
+  let { failOnDiff = false } = clientOptions;
+
   return {
     async screenshot(name, imageBuffer, options = {}) {
+      let requestTimeout = options.requestTimeout || DEFAULT_TIMEOUT_MS;
+
       try {
         // If it's a string, assume it's a file path and send directly
         // Otherwise it's a Buffer, so convert to base64
         let isFilePath = typeof imageBuffer === 'string';
         let image = isFilePath ? imageBuffer : imageBuffer.toString('base64');
         let type = isFilePath ? 'file-path' : 'base64';
-        let requestTimeout = options.requestTimeout || DEFAULT_TIMEOUT_MS;
 
         let properties = createScreenshotProperties(options);
 
@@ -207,7 +227,7 @@ function createSimpleClient(serverUrl) {
         let { status, json } = await httpPost(
           `${serverUrl}/screenshot`,
           {
-            buildId: getBuildId(),
+            buildId: options.buildId ?? getBuildId(),
             name,
             image,
             type,
@@ -230,6 +250,12 @@ function createSimpleClient(serverUrl) {
           if (status === 422 && json.tddMode && json.comparison) {
             let comp = json.comparison;
 
+            if (failOnDiff) {
+              throw new Error(
+                `Visual diff detected for "${comp.name}" (${comp.diffPercentage ?? 0}% difference)`
+              );
+            }
+
             // Return success so test continues and captures remaining screenshots
             // Visual diff details will be shown in the summary after tests complete
             return {
@@ -245,13 +271,23 @@ function createSimpleClient(serverUrl) {
           );
         }
 
+        if (
+          failOnDiff &&
+          json?.tddMode &&
+          ['diff', 'failed'].includes(json.status)
+        ) {
+          throw new Error(
+            `Visual diff detected for "${json.name || name}" (${json.diffPercentage ?? 0}% difference)`
+          );
+        }
+
         return json;
       } catch (error) {
         // Handle timeout
         if (error.message === 'Request timeout') {
           if (shouldLogClient('error')) {
             console.error(
-              `[vizzly] Screenshot timed out for "${name}" after ${DEFAULT_TIMEOUT_MS / 1000}s`
+              `[vizzly] Screenshot timed out for "${name}" after ${requestTimeout / 1000}s`
             );
           }
           disableVizzly();
@@ -339,7 +375,7 @@ function createSimpleClient(serverUrl) {
  * await vizzlyScreenshot('checkout-form', screenshot, {
  *   properties: {
  *     browser: 'chrome',
- *     viewport: '1920x1080'
+ *     viewport: { width: 1920, height: 1080 }
  *   },
  *   threshold: 5
  * });
@@ -398,10 +434,23 @@ export function isVizzlyReady() {
  * @param {boolean} [config.enabled] - Enable/disable screenshots
  */
 export function configure(config = {}) {
+  if ('failOnDiff' in config) {
+    currentFailOnDiff = config.failOnDiff === true;
+  } else if ('serverUrl' in config) {
+    currentFailOnDiff = getEnvFailOnDiff();
+  }
+
   if ('serverUrl' in config) {
+    currentServerUrl = config.serverUrl || null;
     currentClient = config.serverUrl
-      ? createSimpleClient(config.serverUrl)
+      ? createSimpleClient(config.serverUrl, {
+          failOnDiff: currentFailOnDiff,
+        })
       : null;
+  } else if ('failOnDiff' in config && currentClient && currentServerUrl) {
+    currentClient = createSimpleClient(currentServerUrl, {
+      failOnDiff: currentFailOnDiff,
+    });
   }
 
   if (typeof config.enabled === 'boolean') {
@@ -430,10 +479,11 @@ export function getVizzlyInfo() {
   let client = getClient();
   return {
     enabled: !isVizzlyDisabled(),
-    serverUrl: getServerUrl(),
+    serverUrl: currentServerUrl || getServerUrl() || null,
     ready: !isVizzlyDisabled() && client !== null,
-    buildId: getBuildId(),
+    buildId: getBuildId() || null,
     tddMode: isTddMode(),
     disabled: isVizzlyDisabled(),
+    failOnDiff: currentFailOnDiff,
   };
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,7 @@ import {
   isTddMode,
   setVizzlyEnabled,
 } from '../utils/environment-config.js';
-import { createScreenshotProperties } from '../utils/screenshot-options.js';
+import { normalizeScreenshotOptions } from '../utils/screenshot-options.js';
 
 // Internal client state
 let currentClient = null;
@@ -212,7 +212,13 @@ function createSimpleClient(serverUrl, clientOptions = {}) {
 
   return {
     async screenshot(name, imageBuffer, options = {}) {
-      let requestTimeout = options.requestTimeout || DEFAULT_TIMEOUT_MS;
+      let normalizedOptions = normalizeScreenshotOptions(options);
+      let requestTimeout =
+        normalizedOptions.requestTimeout || DEFAULT_TIMEOUT_MS;
+
+      for (let warning of normalizedOptions.warnings) {
+        console.warn(`[vizzly] ${warning.message}`);
+      }
 
       try {
         // If it's a string, assume it's a file path and send directly
@@ -221,17 +227,16 @@ function createSimpleClient(serverUrl, clientOptions = {}) {
         let image = isFilePath ? imageBuffer : imageBuffer.toString('base64');
         let type = isFilePath ? 'file-path' : 'base64';
 
-        let properties = createScreenshotProperties(options);
-
         let httpStart = Date.now();
         let { status, json } = await httpPost(
           `${serverUrl}/screenshot`,
           {
-            buildId: options.buildId ?? getBuildId(),
+            buildId: normalizedOptions.buildId ?? getBuildId(),
             name,
             image,
             type,
-            properties,
+            properties: normalizedOptions.properties,
+            warnings: normalizedOptions.warnings,
           },
           requestTimeout
         );

--- a/src/commands/api.js
+++ b/src/commands/api.js
@@ -84,7 +84,7 @@ export function appendApiQuery(endpoint, queryOption) {
   return endpoint + (endpoint.includes('?') ? '&' : '?') + queryString;
 }
 
-export function validateApiRequest({ endpoint, method }) {
+export function validateApiRequest({ endpoint, method, hasData = false }) {
   let errors = [];
 
   if (method !== 'GET' && method !== 'POST') {
@@ -100,13 +100,21 @@ export function validateApiRequest({ endpoint, method }) {
     );
   }
 
+  if (hasData && method !== 'POST') {
+    errors.push('Request data requires --method POST.');
+  }
+
   return errors;
 }
 
 export function buildApiRequest({ endpoint, options = {} }) {
   let normalizedEndpoint = normalizeApiEndpoint(endpoint);
   let method = normalizeApiMethod(options.method || 'GET');
-  let errors = validateApiRequest({ endpoint: normalizedEndpoint, method });
+  let errors = validateApiRequest({
+    endpoint: normalizedEndpoint,
+    method,
+    hasData: options.data !== undefined,
+  });
 
   if (errors.length > 0) {
     return { errors, method, normalizedEndpoint, requestOptions: null };
@@ -265,7 +273,13 @@ export function validateApiOptions(endpoint, options = {}) {
 
   let normalizedEndpoint = normalizeApiEndpoint(endpoint);
   let method = normalizeApiMethod(options.method || 'GET');
-  errors.push(...validateApiRequest({ endpoint: normalizedEndpoint, method }));
+  errors.push(
+    ...validateApiRequest({
+      endpoint: normalizedEndpoint,
+      method,
+      hasData: options.data !== undefined,
+    })
+  );
 
   return errors;
 }

--- a/src/commands/preview.js
+++ b/src/commands/preview.js
@@ -325,6 +325,7 @@ export async function previewCommand(
     formatSessionAge = defaultFormatSessionAge,
     detectBranch = defaultDetectBranch,
     openBrowser = defaultOpenBrowser,
+    createZipWithSystem: createZip = createZipWithSystem,
     output = defaultOutput,
     exit = code => process.exit(code),
   } = deps;
@@ -349,16 +350,18 @@ export async function previewCommand(
       return { success: false, reason: 'no-api-key' };
     }
 
+    let uploadPath = options.base ? resolve(path, options.base) : path;
+
     // Validate path exists and is a directory
-    if (!existsSync(path)) {
-      output.error(`Path does not exist: ${path}`);
+    if (!existsSync(uploadPath)) {
+      output.error(`Path does not exist: ${uploadPath}`);
       exit(1);
       return { success: false, reason: 'path-not-found' };
     }
 
-    let pathStat = statSync(path);
+    let pathStat = statSync(uploadPath);
     if (!pathStat.isDirectory()) {
-      output.error(`Path is not a directory: ${path}`);
+      output.error(`Path is not a directory: ${uploadPath}`);
       exit(1);
       return { success: false, reason: 'not-a-directory' };
     }
@@ -513,7 +516,7 @@ export async function previewCommand(
       count: fileCount,
       totalSize,
       files,
-    } = await countFiles(path, {
+    } = await countFiles(uploadPath, {
       collectPaths: options.dryRun,
       excludedDirs,
       excludedFiles,
@@ -521,7 +524,7 @@ export async function previewCommand(
 
     if (fileCount === 0) {
       output.stopSpinner();
-      output.error(`No files found in ${path}`);
+      output.error(`No files found in ${uploadPath}`);
       exit(1);
       return { success: false, reason: 'no-files' };
     }
@@ -535,7 +538,7 @@ export async function previewCommand(
       if (globalOptions.json) {
         output.data({
           dryRun: true,
-          path: resolve(path),
+          path: resolve(uploadPath),
           fileCount,
           totalSize,
           excludedDirs,
@@ -548,7 +551,7 @@ export async function previewCommand(
         );
         output.blank();
         output.print(
-          `  ${colors.brand.textTertiary('Source')}      ${resolve(path)}`
+          `  ${colors.brand.textTertiary('Source')}      ${resolve(uploadPath)}`
         );
         output.print(
           `  ${colors.brand.textTertiary('Files')}       ${fileCount}`
@@ -614,7 +617,7 @@ export async function previewCommand(
 
     let zipBuffer;
     try {
-      await createZipWithSystem(path, zipPath, exclusions);
+      await createZip(uploadPath, zipPath, exclusions);
       zipBuffer = await readFile(zipPath);
     } catch (zipError) {
       output.stopSpinner();
@@ -644,10 +647,10 @@ export async function previewCommand(
         success: true,
         buildId,
         previewUrl: result.previewUrl,
-        files: result.uploaded || fileCount,
+        files: result.uploaded ?? fileCount,
         bytes: totalSize,
         compressedBytes: zipBuffer.length,
-        compressionRatio,
+        compressionRatio: `${compressionPercent}%`,
         newBytes: result.newBytes,
         reusedBlobs: result.reusedBlobs || 0,
         deduplicationRatio: result.deduplicationRatio,

--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -72,7 +72,8 @@ export async function projectLinkCommand(
 
   try {
     let config = await loadConfig(globalOptions.config, globalOptions);
-    let userToken = config.userToken || (await getAccessToken());
+    let userToken =
+      config.userToken || globalOptions.token || (await getAccessToken());
 
     if (!userToken) {
       output.error('Login required before linking a project');

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -11,6 +11,7 @@ import {
   getBuild as defaultGetBuild,
   getTokenContext as defaultGetTokenContext,
 } from '../api/index.js';
+import { CONFIG_DEFAULTS } from '../config/core.js';
 import { VizzlyError } from '../errors/vizzly-error.js';
 import { createServerManager as defaultCreateServerManager } from '../server-manager/index.js';
 import { createBuildObject as defaultCreateBuildObject } from '../services/build-manager.js';
@@ -212,10 +213,17 @@ export async function runCommand(
     }
 
     // Collect git metadata and build info
-    let branch = await detectBranch(options.branch);
-    let commit = await detectCommit(options.commit);
-    let message = options.message || (await detectCommitMessage());
-    let buildName = await generateBuildNameWithGit(options.buildName);
+    let configuredBuildName =
+      config.build.name && config.build.name !== CONFIG_DEFAULTS.build.name
+        ? config.build.name
+        : undefined;
+    let branch = await detectBranch(options.branch || config.build.branch);
+    let commit = await detectCommit(options.commit || config.build.commit);
+    let message =
+      options.message || config.build.message || (await detectCommitMessage());
+    let buildName = await generateBuildNameWithGit(
+      options.buildName || configuredBuildName
+    );
     let pullRequestNumber = detectPullRequestNumber();
 
     if (globalOptions.verbose) {
@@ -347,7 +355,7 @@ export async function runCommand(
       }
 
       // JSON output mode - output structured data and exit
-      if (globalOptions.json) {
+      if (globalOptions.json && !runOptions.wait) {
         let executionTimeMs = Date.now() - startTime;
         let displayUrl = await resolveBuildDisplayUrl({
           result,
@@ -533,9 +541,19 @@ export async function runCommand(
     // Don't fail CI for Vizzly infrastructure issues (5xx errors)
     let status = error.context?.status;
     if (status >= 500) {
-      output.warn(
-        'Vizzly API unavailable - visual tests skipped. Your tests still ran.'
-      );
+      if (globalOptions.json) {
+        output.data({
+          buildId: null,
+          status: 'skipped',
+          message: 'Vizzly API unavailable - visual tests skipped',
+          executionTimeMs: Date.now() - (startTime || Date.now()),
+        });
+      } else {
+        output.warn(
+          'Vizzly API unavailable - visual tests skipped. Your tests still ran.'
+        );
+      }
+      output.cleanup();
       output.debug('api', 'API error details:', { error: error.message });
       return { success: true, result: { skipped: true } };
     }

--- a/src/commands/tdd-daemon.js
+++ b/src/commands/tdd-daemon.js
@@ -53,16 +53,22 @@ export function cleanupLocalDaemonFiles(directory = process.cwd(), deps = {}) {
   };
 }
 
-export function buildLegacyServerInfo({ pid, port, now = Date.now }) {
+export function buildLegacyServerInfo({
+  pid,
+  port,
+  failOnDiff = false,
+  now = Date.now,
+}) {
   return {
     pid,
     port: port.toString(),
     startTime: now(),
+    failOnDiff,
   };
 }
 
 export function writeLegacyGlobalServerFile(
-  { pid, port },
+  { pid, port, failOnDiff = false },
   {
     home = homedir,
     exists = existsSync,
@@ -77,7 +83,7 @@ export function writeLegacyGlobalServerFile(
   }
 
   let globalServerFile = join(globalVizzlyDir, 'server.json');
-  let serverInfo = buildLegacyServerInfo({ pid, port, now });
+  let serverInfo = buildLegacyServerInfo({ pid, port, failOnDiff, now });
   writeFile(globalServerFile, JSON.stringify(serverInfo, null, 2));
   return { path: globalServerFile, serverInfo };
 }
@@ -443,7 +449,11 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
 
     // Also write legacy server.json for SDK discovery (backwards compatibility)
     try {
-      writeLegacyGlobalServerFile({ pid: child.pid, port });
+      writeLegacyGlobalServerFile({
+        pid: child.pid,
+        port,
+        failOnDiff: options.failOnDiff || false,
+      });
     } catch {
       // Non-fatal, SDK can still use health check
     }

--- a/src/commands/tdd.js
+++ b/src/commands/tdd.js
@@ -10,6 +10,7 @@ import {
   finalizeBuild as defaultFinalizeApiBuild,
   getBuild as defaultGetBuild,
 } from '../api/index.js';
+import { CONFIG_DEFAULTS } from '../config/core.js';
 import { VizzlyError } from '../errors/vizzly-error.js';
 import { createServerManager as defaultCreateServerManager } from '../server-manager/index.js';
 import { createAuthService as defaultCreateAuthService } from '../services/auth-service.js';
@@ -24,6 +25,9 @@ import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import {
   detectBranch as defaultDetectBranch,
   detectCommit as defaultDetectCommit,
+  detectCommitMessage as defaultDetectCommitMessage,
+  detectPullRequestNumber as defaultDetectPullRequestNumber,
+  generateBuildNameWithGit as defaultGenerateBuildNameWithGit,
 } from '../utils/git.js';
 import * as defaultOutput from '../utils/output.js';
 
@@ -60,6 +64,9 @@ export async function tddCommand(
     runTests = defaultRunTests,
     detectBranch = defaultDetectBranch,
     detectCommit = defaultDetectCommit,
+    detectCommitMessage = defaultDetectCommitMessage,
+    detectPullRequestNumber = defaultDetectPullRequestNumber,
+    generateBuildNameWithGit = defaultGenerateBuildNameWithGit,
     spawn = defaultSpawn,
     output = defaultOutput,
   } = deps;
@@ -94,7 +101,11 @@ export async function tddCommand(
     let config = await loadConfig(globalOptions.config, allOptions);
 
     // Dev mode works locally by default - only needs token for baseline download
-    let needsToken = options.baselineBuild || options.baselineComparison;
+    let needsToken =
+      options.baselineBuild ||
+      options.baselineComparison ||
+      config.baselineBuildId ||
+      config.baselineComparisonId;
 
     if (!config.apiKey && needsToken) {
       throw new Error(
@@ -106,8 +117,18 @@ export async function tddCommand(
     config.allowNoToken = true;
 
     // Collect git metadata
-    let branch = await detectBranch(options.branch);
-    let commit = await detectCommit(options.commit);
+    let configuredBuildName =
+      config.build.name && config.build.name !== CONFIG_DEFAULTS.build.name
+        ? config.build.name
+        : undefined;
+    let branch = await detectBranch(options.branch || config.build.branch);
+    let commit = await detectCommit(options.commit || config.build.commit);
+    let message =
+      options.message || config.build.message || (await detectCommitMessage());
+    let buildName = await generateBuildNameWithGit(
+      options.buildName || configuredBuildName
+    );
+    let pullRequestNumber = detectPullRequestNumber();
 
     // Show header (skip in daemon mode)
     if (!options.daemon) {
@@ -153,9 +174,21 @@ export async function tddCommand(
       tdd: true,
       daemon: options.daemon || false,
       setBaseline: options.setBaseline || false,
+      failOnDiff: options.failOnDiff || false,
+      name: buildName,
+      buildName,
       branch,
       commit,
+      message,
       environment: config.build.environment,
+      pullRequestNumber,
+      parallelId: config.parallelId,
+      metadata: {
+        comparison: {
+          threshold: config.comparison.threshold,
+          minClusterSize: config.comparison.minClusterSize,
+        },
+      },
       threshold: config.comparison.threshold,
       minClusterSize: config.comparison.minClusterSize,
       allowNoToken: config.allowNoToken || false,

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -3,6 +3,7 @@ import {
   finalizeBuild as defaultFinalizeBuild,
   getTokenContext as defaultGetTokenContext,
 } from '../api/index.js';
+import { CONFIG_DEFAULTS } from '../config/core.js';
 import { createUploader as defaultCreateUploader } from '../uploader/index.js';
 import { getAppBaseUrl } from '../utils/api-url.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
@@ -93,13 +94,13 @@ export async function uploadCommand(
 
   let buildId = null;
   let config = null;
-  const uploadStartTime = Date.now();
+  let uploadStartTime = Date.now();
 
   try {
     output.info('Starting upload process...');
 
     // Load configuration with CLI overrides
-    const allOptions = { ...globalOptions, ...options };
+    let allOptions = { ...globalOptions, ...options };
     config = await loadConfig(globalOptions.config, allOptions);
 
     // Validate API token
@@ -112,11 +113,18 @@ export async function uploadCommand(
     }
 
     // Collect git metadata if not provided
-    const branch = await detectBranch(options.branch);
-    const commit = await detectCommit(options.commit);
-    const message = options.message || (await detectCommitMessage());
-    const buildName = await generateBuildNameWithGit(options.buildName);
-    const pullRequestNumber = detectPullRequestNumber();
+    let configuredBuildName =
+      config.build.name && config.build.name !== CONFIG_DEFAULTS.build.name
+        ? config.build.name
+        : undefined;
+    let branch = await detectBranch(options.branch || config.build.branch);
+    let commit = await detectCommit(options.commit || config.build.commit);
+    let message =
+      options.message || config.build.message || (await detectCommitMessage());
+    let buildName = await generateBuildNameWithGit(
+      options.buildName || configuredBuildName
+    );
+    let pullRequestNumber = detectPullRequestNumber();
 
     output.info(`Uploading screenshots from: ${screenshotsPath}`);
     if (globalOptions.verbose) {
@@ -134,7 +142,7 @@ export async function uploadCommand(
     let uploader = createUploader({ ...config, command: 'upload' });
 
     // Prepare upload options with progress callback
-    const uploadOptions = {
+    let uploadOptions = {
       screenshotsDir: screenshotsPath,
       buildName,
       branch,
@@ -142,12 +150,13 @@ export async function uploadCommand(
       message,
       environment: config.build.environment,
       threshold: config.comparison.threshold,
+      minClusterSize: config.comparison.minClusterSize,
       uploadAll: options.uploadAll || false,
       metadata: options.metadata ? JSON.parse(options.metadata) : {},
       pullRequestNumber,
       parallelId: config.parallelId,
       onProgress: progressData => {
-        const {
+        let {
           message: progressMessage,
           current,
           total,
@@ -175,7 +184,7 @@ export async function uploadCommand(
 
     // Start upload
     output.progress('Starting upload...');
-    const result = await uploader.upload(uploadOptions);
+    let result = await uploader.upload(uploadOptions);
     buildId = result.buildId; // Ensure we have the buildId
 
     // Write session for subsequent commands (like preview)
@@ -305,7 +314,8 @@ export async function uploadCommand(
           executionTimeMs,
         });
         output.cleanup();
-        return { success: buildResult.failedComparisons === 0, result };
+        let success = buildResult.failedComparisons === 0;
+        return { success, exitCode: success ? 0 : 1, result };
       }
 
       output.complete('Build processing completed');
@@ -334,6 +344,11 @@ export async function uploadCommand(
         ));
       output.blank();
       output.labelValue('View', output.link('Results', waitBuildUrl));
+
+      if (buildResult.failedComparisons > 0) {
+        output.cleanup();
+        return { success: false, exitCode: 1, result };
+      }
     }
 
     output.cleanup();
@@ -349,13 +364,12 @@ export async function uploadCommand(
           message: 'Vizzly API unavailable - upload skipped',
           executionTimeMs: Date.now() - uploadStartTime,
         });
-        output.cleanup();
       } else {
         output.warn(
           'Vizzly API unavailable - upload skipped. Your tests still ran.'
         );
-        output.cleanup();
       }
+      output.cleanup();
       return { success: true, result: { skipped: true } };
     }
 
@@ -428,6 +442,13 @@ export function validateUploadOptions(screenshotsPath, options) {
       errors.push(
         'Threshold must be a non-negative number (CIEDE2000 Delta E)'
       );
+    }
+  }
+
+  if (options.minClusterSize !== undefined) {
+    let minClusterSize = Number(options.minClusterSize);
+    if (!Number.isInteger(minClusterSize) || minClusterSize < 1) {
+      errors.push('Min cluster size must be a positive integer');
     }
   }
 

--- a/src/reporter/src/components/comparison/fullscreen-viewer.jsx
+++ b/src/reporter/src/components/comparison/fullscreen-viewer.jsx
@@ -17,6 +17,7 @@ import {
   ComputerDesktopIcon,
   CubeTransparentIcon,
   DocumentMagnifyingGlassIcon,
+  ExclamationTriangleIcon,
   InformationCircleIcon,
   ListBulletIcon,
   MapPinIcon,
@@ -742,6 +743,21 @@ function FullscreenViewerInner({
               </Badge>
             </div>
           </InspectorPanel.Section>
+
+          {comparison.warnings?.length > 0 && (
+            <InspectorPanel.Section
+              title="Warnings"
+              icon={ExclamationTriangleIcon}
+            >
+              {comparison.warnings.map(warning => (
+                <InspectorPanel.Row
+                  key={`${warning.code}-${warning.option}`}
+                  label={warning.option || 'Warning'}
+                  value={warning.message}
+                />
+              ))}
+            </InspectorPanel.Section>
+          )}
 
           {/* Screenshot details */}
           <InspectorPanel.Section title="Screenshot" icon={ComputerDesktopIcon}>

--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -340,8 +340,10 @@ export class VizzlySDK extends EventEmitter {
       image: imageBase64,
       type: 'base64',
       properties: normalizedOptions.properties,
-      warnings: normalizedOptions.warnings,
     };
+    if (normalizedOptions.warnings.length > 0) {
+      screenshotData.warnings = normalizedOptions.warnings;
+    }
 
     // POST to the local screenshot server
     let serverUrl = `http://localhost:${this.config.server?.port || 3000}`;

--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -392,13 +392,18 @@ export class VizzlySDK extends EventEmitter {
 
     let uploadOptions = {
       screenshotsDir,
-      buildName: options.buildName || this.config.buildName,
-      branch: options.branch || this.config.branch,
-      commit: options.commit || this.config.commit,
-      message: options.message || this.config.message,
+      buildName: options.buildName || this.config.build?.name,
+      branch: options.branch || this.config.build?.branch,
+      commit: options.commit || this.config.build?.commit,
+      message: options.message || this.config.build?.message,
       environment:
-        options.environment || this.config.environment || 'production',
-      threshold: options.threshold ?? this.config.threshold,
+        options.environment || this.config.build?.environment || 'production',
+      threshold: options.threshold ?? this.config.comparison?.threshold,
+      minClusterSize:
+        options.minClusterSize ?? this.config.comparison?.minClusterSize,
+      metadata: options.metadata || {},
+      pullRequestNumber: options.pullRequestNumber,
+      parallelId: options.parallelId || this.config.parallelId,
       onProgress: progress => {
         this.emit('upload:progress', progress);
         if (options.onProgress) {

--- a/src/sdk/index.js
+++ b/src/sdk/index.js
@@ -23,7 +23,7 @@ import { createUploader } from '../uploader/index.js';
 import { loadConfig } from '../utils/config-loader.js';
 import { resolveImageBuffer } from '../utils/file-helpers.js';
 import * as output from '../utils/output.js';
-import { createScreenshotProperties } from '../utils/screenshot-options.js';
+import { normalizeScreenshotOptions } from '../utils/screenshot-options.js';
 
 /**
  * Create a new Vizzly instance with custom configuration
@@ -319,8 +319,16 @@ export class VizzlySDK extends EventEmitter {
     // Resolve Buffer or file path using shared utility
     let buffer = resolveImageBuffer(imageBuffer, 'screenshot');
 
+    let normalizedOptions = normalizeScreenshotOptions(options);
+    for (let warning of normalizedOptions.warnings) {
+      output.warn(warning.message, {
+        code: warning.code,
+        option: warning.option,
+      });
+    }
+
     // Generate or use provided build ID
-    let buildId = options.buildId || this.currentBuildId || 'default';
+    let buildId = normalizedOptions.buildId || this.currentBuildId || 'default';
     this.currentBuildId = buildId;
 
     // Convert Buffer to base64 for JSON transport
@@ -331,7 +339,8 @@ export class VizzlySDK extends EventEmitter {
       name,
       image: imageBase64,
       type: 'base64',
-      properties: createScreenshotProperties(options),
+      properties: normalizedOptions.properties,
+      warnings: normalizedOptions.warnings,
     };
 
     // POST to the local screenshot server

--- a/src/server/handlers/api-handler.js
+++ b/src/server/handlers/api-handler.js
@@ -54,7 +54,8 @@ export const createApiHandler = (
     name,
     image,
     properties = {},
-    type
+    type,
+    warnings = []
   ) => {
     let handlerStart = Date.now();
     output.debug('upload', `${name} received`, {
@@ -187,6 +188,7 @@ export const createApiHandler = (
         success: true,
         name,
         count: screenshotCount,
+        warnings,
       },
     };
   };

--- a/src/server/handlers/tdd-handler.js
+++ b/src/server/handlers/tdd-handler.js
@@ -377,7 +377,8 @@ export const createTddHandler = (
     name,
     image,
     properties = {},
-    type
+    type,
+    warnings = []
   ) => {
     let handlerStart = Date.now();
     output.debug('tdd', `${name} received`);
@@ -532,6 +533,7 @@ export const createTddHandler = (
       aaPercentage: comparison.aaPercentage,
       heightDiff: comparison.heightDiff,
       error: comparison.error,
+      warnings,
       originalName: name,
       timestamp: Date.now(),
       // Boolean hints so UI can show toggle buttons without fetching heavy data
@@ -575,6 +577,7 @@ export const createTddHandler = (
           diff: comparison.diff,
           diffPercentage: comparison.diffPercentage,
           threshold: comparison.threshold,
+          warnings,
           tddMode: true,
         },
       };
@@ -589,6 +592,7 @@ export const createTddHandler = (
           message: `Baseline updated for '${name}'`,
           baseline: comparison.baseline,
           current: comparison.current,
+          warnings,
           tddMode: true,
         },
       };
@@ -618,6 +622,7 @@ export const createTddHandler = (
         name: comparison.name,
         baseline: comparison.baseline,
         current: comparison.current,
+        warnings,
         tddMode: true,
       },
     };

--- a/src/server/routers/screenshot.js
+++ b/src/server/routers/screenshot.js
@@ -24,7 +24,7 @@ export function createScreenshotRouter({ screenshotHandler, defaultBuildId }) {
     if (pathname === '/screenshot') {
       try {
         const body = await parseJsonBody(req);
-        const { buildId, name, properties, image, type } = body;
+        const { buildId, name, properties, image, type, warnings } = body;
 
         if (!name || !image) {
           sendError(res, 400, 'name and image are required');
@@ -39,7 +39,8 @@ export function createScreenshotRouter({ screenshotHandler, defaultBuildId }) {
           name,
           image,
           properties,
-          type
+          type,
+          warnings
         );
 
         sendJson(res, result.statusCode, result.body);

--- a/src/server/routers/screenshot.js
+++ b/src/server/routers/screenshot.js
@@ -57,9 +57,15 @@ export function createScreenshotRouter({ screenshotHandler, defaultBuildId }) {
     // Flush endpoint - signals test completion and prints summary
     if (pathname === '/flush') {
       try {
-        if (screenshotHandler.getResults) {
+        if (screenshotHandler.flush) {
+          let stats = await screenshotHandler.flush();
+          sendJson(res, 200, {
+            success: true,
+            ...stats,
+          });
+        } else if (screenshotHandler.getResults) {
           // This triggers printResults() which outputs the summary
-          const results = await screenshotHandler.getResults();
+          let results = await screenshotHandler.getResults();
           sendJson(res, 200, {
             success: true,
             summary: {

--- a/src/services/build-manager.js
+++ b/src/services/build-manager.js
@@ -20,9 +20,12 @@ import { randomUUID } from 'node:crypto';
 export function createBuildObject(buildOptions, deps = {}) {
   let {
     name,
+    buildName,
     branch,
     commit,
+    message,
     environment = 'test',
+    parallelId,
     metadata = {},
   } = buildOptions;
   let randomId = deps.randomId || randomUUID;
@@ -31,10 +34,12 @@ export function createBuildObject(buildOptions, deps = {}) {
 
   return {
     id: `build-${randomId()}`,
-    name: name || `build-${timestamp()}`,
+    name: name || buildName || `build-${timestamp()}`,
     branch,
     commit,
+    message,
     environment,
+    parallelId,
     metadata,
     status: 'pending',
     createdAt: now(),

--- a/src/test-runner/core.js
+++ b/src/test-runner/core.js
@@ -14,6 +14,7 @@
  * @param {number} options.port - Server port
  * @param {string} options.buildId - Build ID
  * @param {boolean} [options.setBaseline] - Whether to set baseline
+ * @param {boolean} [options.failOnDiff] - Whether visual diffs should fail tests
  * @param {Object} [options.baseEnv] - Base environment (defaults to process.env)
  * @returns {Object} Environment variables object
  */
@@ -21,6 +22,7 @@ export function buildTestEnv({
   port,
   buildId,
   setBaseline = false,
+  failOnDiff = false,
   baseEnv = process.env,
 }) {
   return {
@@ -29,6 +31,7 @@ export function buildTestEnv({
     VIZZLY_BUILD_ID: buildId,
     VIZZLY_ENABLED: 'true',
     VIZZLY_SET_BASELINE: setBaseline ? 'true' : 'false',
+    VIZZLY_FAIL_ON_DIFF: failOnDiff ? 'true' : 'false',
   };
 }
 

--- a/src/test-runner/operations.js
+++ b/src/test-runner/operations.js
@@ -313,6 +313,7 @@ export async function runTests({ runOptions, config, deps }) {
       port: config.server?.port,
       buildId,
       setBaseline,
+      failOnDiff: runOptions.failOnDiff || false,
     });
 
     try {

--- a/src/types/client.d.ts
+++ b/src/types/client.d.ts
@@ -24,6 +24,7 @@ export function autoDiscoverTddServer(
   deps?: {
     exists?: (path: string) => boolean;
     readFile?: (path: string, encoding: BufferEncoding) => string | Buffer;
+    env?: Record<string, string | undefined>;
   }
 ): string | null;
 
@@ -32,7 +33,14 @@ export function autoDiscoverTddServer(
  */
 export interface ScreenshotResult {
   success: boolean;
-  status?: 'passed' | 'failed' | 'new';
+  status?:
+    | 'passed'
+    | 'failed'
+    | 'new'
+    | 'match'
+    | 'diff'
+    | 'baseline-updated'
+    | 'error';
   name?: string;
   diffPercentage?: number;
   [key: string]: unknown;
@@ -59,10 +67,16 @@ export interface ScreenshotResult {
  * @example
  * // With properties and comparison settings
  * await vizzlyScreenshot('checkout-form', screenshot, {
- *   properties: { browser: 'chrome', viewport: '1920x1080' },
+ *   properties: { browser: 'chrome', viewport: { width: 1920, height: 1080 } },
  *   threshold: 5,
- *   minClusterSize: 10
+ *   minClusterSize: 10,
+ *   fullPage: true,
+ *   requestTimeout: 5000
  * });
+ *
+ * Top-level `browser`, `viewport`, `threshold`, `minClusterSize`, and
+ * `fullPage` values are normalized into screenshot metadata. `requestTimeout`
+ * stays on the client request, and `buildId` only tags the upload request.
  */
 export function vizzlyScreenshot(
   name: string,
@@ -72,6 +86,10 @@ export function vizzlyScreenshot(
     threshold?: number;
     minClusterSize?: number;
     fullPage?: boolean;
+    /** Transport-only build ID used to route the request. */
+    buildId?: string;
+    /** Client-side HTTP timeout in milliseconds; not stored as metadata. */
+    requestTimeout?: number;
     [key: string]: unknown;
   }
 ): Promise<ScreenshotResult | null>;
@@ -81,7 +99,15 @@ export function vizzlyScreenshot(
  */
 export interface FlushResult {
   success: boolean;
-  summary: {
+  uploaded?: number;
+  flushed?: boolean;
+  total?: number;
+  passed?: number;
+  failed?: number;
+  new?: number;
+  errors?: number;
+  message?: string;
+  summary?: {
     total: number;
     passed: number;
     failed: number;
@@ -124,6 +150,7 @@ export function isVizzlyReady(): boolean;
 export function configure(config?: {
   serverUrl?: string;
   enabled?: boolean;
+  failOnDiff?: boolean;
 }): void;
 
 /**
@@ -145,4 +172,5 @@ export function getVizzlyInfo(): {
   buildId: string | null;
   tddMode: boolean;
   disabled: boolean;
+  failOnDiff: boolean;
 };

--- a/src/types/client.d.ts
+++ b/src/types/client.d.ts
@@ -74,9 +74,9 @@ export interface ScreenshotResult {
  *   requestTimeout: 5000
  * });
  *
- * Top-level `browser`, `viewport`, `threshold`, `minClusterSize`, and
- * `fullPage` values are normalized into screenshot metadata. `requestTimeout`
- * stays on the client request, and `buildId` only tags the upload request.
+ * `properties` is the user metadata bag. Comparison options are normalized
+ * into the server metadata payload, while `requestTimeout` stays on the
+ * client request and `buildId` only routes the screenshot to a build.
  */
 export function vizzlyScreenshot(
   name: string,
@@ -90,7 +90,6 @@ export function vizzlyScreenshot(
     buildId?: string;
     /** Client-side HTTP timeout in milliseconds; not stored as metadata. */
     requestTimeout?: number;
-    [key: string]: unknown;
   }
 ): Promise<ScreenshotResult | null>;
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -82,7 +82,6 @@ export interface ScreenshotOptions {
   buildId?: string;
   /** Client-side HTTP timeout in milliseconds; not stored as metadata. */
   requestTimeout?: number;
-  [key: string]: unknown;
 }
 
 export interface ScreenshotResult {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -24,7 +24,9 @@ export interface BuildConfig {
 
 export interface UploadConfig {
   screenshotsDir?: string | string[];
+  /** Batch size used when uploading screenshots. */
   batchSize?: number;
+  /** Timeout in milliseconds for waiting on build processing after upload. */
   timeout?: number;
 }
 
@@ -76,13 +78,23 @@ export interface ScreenshotOptions {
   threshold?: number;
   minClusterSize?: number;
   fullPage?: boolean;
+  /** Transport-only build ID used to route the request. */
   buildId?: string;
+  /** Client-side HTTP timeout in milliseconds; not stored as metadata. */
+  requestTimeout?: number;
   [key: string]: unknown;
 }
 
 export interface ScreenshotResult {
   success: boolean;
-  status?: 'passed' | 'failed' | 'new';
+  status?:
+    | 'passed'
+    | 'failed'
+    | 'new'
+    | 'match'
+    | 'diff'
+    | 'baseline-updated'
+    | 'error';
   name?: string;
   diffPercentage?: number;
   [key: string]: unknown;
@@ -95,7 +107,13 @@ export interface ScreenshotResult {
 export interface ComparisonResult {
   id: string;
   name: string;
-  status: 'passed' | 'failed' | 'new' | 'error' | 'baseline-updated';
+  status:
+    | 'passed'
+    | 'failed'
+    | 'new'
+    | 'error'
+    | 'baseline-created'
+    | 'baseline-updated';
   baseline: string;
   current: string;
   diff: string | null;
@@ -150,7 +168,9 @@ export interface UploadOptions {
   message?: string;
   environment?: string;
   threshold?: number;
-  pullRequestNumber?: string;
+  minClusterSize?: number;
+  metadata?: Record<string, unknown>;
+  pullRequestNumber?: string | number;
   parallelId?: string;
   onProgress?: (progress: UploadProgress) => void;
 }
@@ -186,8 +206,10 @@ export interface BuildResult {
   status: 'completed' | 'failed' | 'pending';
   build: unknown;
   comparisons?: number;
+  totalComparisons: number;
   passedComparisons?: number;
   failedComparisons?: number;
+  newComparisons: number;
   url?: string;
 }
 
@@ -487,15 +509,19 @@ export interface BuildOptions {
   buildName?: string;
   branch?: string;
   commit?: string;
+  commit_sha?: string;
   message?: string;
+  commit_message?: string;
   environment?: string;
   threshold?: number;
   eager?: boolean;
   allowNoToken?: boolean;
   wait?: boolean;
   uploadAll?: boolean;
-  pullRequestNumber?: string;
+  pullRequestNumber?: string | number;
+  github_pull_request_number?: string | number;
   parallelId?: string;
+  parallel_id?: string;
 }
 
 /**
@@ -565,6 +591,8 @@ export function vizzlyScreenshot(
     threshold?: number;
     minClusterSize?: number;
     fullPage?: boolean;
+    requestTimeout?: number;
+    buildId?: string;
     [key: string]: unknown;
   }
 ): Promise<ScreenshotResult | null>;
@@ -573,6 +601,7 @@ export function vizzlyScreenshot(
 export function configure(config?: {
   serverUrl?: string;
   enabled?: boolean;
+  failOnDiff?: boolean;
 }): void;
 
 /** Enable or disable screenshot capture */

--- a/src/uploader/core.js
+++ b/src/uploader/core.js
@@ -101,6 +101,25 @@ export function extractBrowserFromFilename(filename) {
 // Build Info Construction
 // ============================================================================
 
+function buildUploadMetadata(options) {
+  let metadata = { ...(options.metadata || {}) };
+  let comparison = { ...(metadata.comparison || {}) };
+
+  if (options.threshold !== undefined) {
+    comparison.threshold = options.threshold;
+  }
+
+  if (options.minClusterSize !== undefined) {
+    comparison.minClusterSize = options.minClusterSize;
+  }
+
+  if (Object.keys(comparison).length > 0) {
+    metadata.comparison = comparison;
+  }
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 /**
  * Build API build info payload
  * @param {Object} options - Upload options
@@ -108,7 +127,7 @@ export function extractBrowserFromFilename(filename) {
  * @returns {Object} Build info payload
  */
 export function buildBuildInfo(options, defaultBranch = 'main') {
-  return {
+  let buildInfo = {
     name: options.buildName || `Upload ${new Date().toISOString()}`,
     branch: options.branch || defaultBranch || 'main',
     commit_sha: options.commit,
@@ -118,6 +137,13 @@ export function buildBuildInfo(options, defaultBranch = 'main') {
     github_pull_request_number: options.pullRequestNumber,
     parallel_id: options.parallelId,
   };
+
+  let metadata = buildUploadMetadata(options);
+  if (metadata) {
+    buildInfo.metadata = metadata;
+  }
+
+  return buildInfo;
 }
 
 // ============================================================================
@@ -288,18 +314,52 @@ export function buildUploadResult({ buildId, url, total, uploaded, skipped }) {
  * @returns {Object} Wait result
  */
 export function buildWaitResult(build) {
+  let totalComparisons = build.comparisonsTotal ?? build.total_comparisons ?? 0;
+  let passedComparisons =
+    build.comparisonsPassed ??
+    build.passed_comparisons ??
+    build.identicalComparisons ??
+    build.identical_comparisons ??
+    0;
+  let failedComparisons =
+    build.comparisonsFailed ??
+    build.failed_comparisons ??
+    build.changedComparisons ??
+    build.changed_comparisons ??
+    0;
+  let newComparisons =
+    build.comparisonsNew ?? build.newComparisons ?? build.new_comparisons ?? 0;
+  let identicalComparisons =
+    build.identicalComparisons ??
+    build.identical_comparisons ??
+    passedComparisons;
+  let approvalStatus =
+    build.approvalStatus ?? build.approval_status ?? 'pending';
+  let hasComparisonCounts =
+    build.comparisonsTotal !== undefined ||
+    build.total_comparisons !== undefined ||
+    build.comparisonsPassed !== undefined ||
+    build.passed_comparisons !== undefined ||
+    build.comparisonsFailed !== undefined ||
+    build.failed_comparisons !== undefined ||
+    build.comparisonsNew !== undefined ||
+    build.new_comparisons !== undefined ||
+    build.identicalComparisons !== undefined ||
+    build.identical_comparisons !== undefined;
+
   let result = {
     status: 'completed',
     build,
+    passedComparisons,
+    failedComparisons,
+    newComparisons,
+    identicalComparisons,
+    approvalStatus,
+    totalComparisons,
   };
 
-  if (typeof build.comparisonsTotal === 'number') {
-    result.comparisons = build.comparisonsTotal;
-    result.passedComparisons = build.comparisonsPassed || 0;
-    result.failedComparisons = build.comparisonsFailed || 0;
-  } else {
-    result.passedComparisons = 0;
-    result.failedComparisons = 0;
+  if (hasComparisonCounts) {
+    result.comparisons = totalComparisons;
   }
 
   if (build.url) {

--- a/src/uploader/operations.js
+++ b/src/uploader/operations.js
@@ -403,14 +403,22 @@ export async function upload({
     let build = await createBuild(client, buildInfo);
     let buildId = build.id;
 
-    // Check existing files
-    let { toUpload, existing, screenshots } = await checkExistingFiles({
-      fileMetadata,
-      client,
-      signal,
-      buildId,
-      deps: { checkShas, createError, output },
-    });
+    let toUpload = fileMetadata;
+    let existing = [];
+    let screenshots = [];
+
+    if (!uploadOptions.uploadAll) {
+      let existingResult = await checkExistingFiles({
+        fileMetadata,
+        client,
+        signal,
+        buildId,
+        deps: { checkShas, createError, output },
+      });
+      toUpload = existingResult.toUpload;
+      existing = existingResult.existing;
+      screenshots = existingResult.screenshots;
+    }
 
     onProgress(
       buildDeduplicationProgress(toUpload.length, existing.length, files.length)

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -6,7 +6,9 @@ import {
   getApiToken,
   getApiUrl,
   getBuildName,
+  getMinClusterSize,
   getParallelId,
+  getThreshold,
 } from './environment-config.js';
 import { getAccessToken } from './global-config.js';
 import * as output from './output.js';
@@ -33,10 +35,12 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
   mergeConfig(config, validatedFileConfig);
 
   // 3. Override with environment variables (higher priority than fallbacks)
-  const envApiKey = getApiToken();
-  const envApiUrl = getApiUrl();
-  const envBuildName = getBuildName();
-  const envParallelId = getParallelId();
+  let envApiKey = getApiToken();
+  let envApiUrl = getApiUrl();
+  let envBuildName = getBuildName();
+  let envParallelId = getParallelId();
+  let envThreshold = getThreshold();
+  let envMinClusterSize = getMinClusterSize();
 
   if (envApiKey) {
     config.apiKey = envApiKey;
@@ -48,6 +52,10 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
     output.debug('config', 'using build name from environment');
   }
   if (envParallelId) config.parallelId = envParallelId;
+  if (envThreshold !== undefined) config.comparison.threshold = envThreshold;
+  if (envMinClusterSize !== undefined) {
+    config.comparison.minClusterSize = envMinClusterSize;
+  }
 
   // 4. Apply CLI overrides (highest priority)
   if (cliOverrides.token) {
@@ -120,7 +128,7 @@ function applyCLIOverrides(config, cliOverrides = {}) {
 
   // Comparison overrides
   if (cliOverrides.threshold !== undefined)
-    config.comparison.threshold = cliOverrides.threshold;
+    config.comparison.threshold = Number(cliOverrides.threshold);
   if (cliOverrides.minClusterSize !== undefined) {
     config.comparison.minClusterSize = Number(cliOverrides.minClusterSize);
   }

--- a/src/utils/context.js
+++ b/src/utils/context.js
@@ -12,6 +12,48 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+function getGlobalConfigPath() {
+  return join(
+    process.env.VIZZLY_HOME || join(homedir(), '.vizzly'),
+    'config.json'
+  );
+}
+
+function readJsonFile(path) {
+  try {
+    if (existsSync(path)) {
+      return JSON.parse(readFileSync(path, 'utf8'));
+    }
+  } catch {
+    // Optional context should never block the command that is rendering it.
+  }
+
+  return null;
+}
+
+function readGlobalConfig() {
+  return readJsonFile(getGlobalConfigPath()) || {};
+}
+
+function readBaselineInfo(cwd) {
+  let path = join(cwd, '.vizzly', 'baselines');
+  let metadata = readJsonFile(join(path, 'metadata.json'));
+
+  return {
+    count: metadata?.screenshots?.length || 0,
+    path: metadata ? path : null,
+  };
+}
+
+function readServerInfo(cwd) {
+  let serverInfo = readJsonFile(join(cwd, '.vizzly', 'server.json'));
+
+  return {
+    running: !!serverInfo,
+    port: serverInfo ? serverInfo.port : null,
+  };
+}
+
 /**
  * Get dynamic context about the current Vizzly state
  * Returns an array of context items with type, label, and value
@@ -23,49 +65,13 @@ export function getContext() {
 
   try {
     let cwd = process.cwd();
-    let globalConfigPath = join(
-      process.env.VIZZLY_HOME || join(homedir(), '.vizzly'),
-      'config.json'
-    );
-
-    // Load global config once
-    let globalConfig = {};
-    try {
-      if (existsSync(globalConfigPath)) {
-        globalConfig = JSON.parse(readFileSync(globalConfigPath, 'utf8'));
-      }
-    } catch {
-      // Ignore
-    }
+    let globalConfig = readGlobalConfig();
 
     // Check for vizzly.config.js (project config)
     let hasProjectConfig = existsSync(join(cwd, 'vizzly.config.js'));
 
-    // Check for .vizzly directory (TDD baselines)
-    let baselineCount = 0;
-    try {
-      let metaPath = join(cwd, '.vizzly', 'baselines', 'metadata.json');
-      if (existsSync(metaPath)) {
-        let meta = JSON.parse(readFileSync(metaPath, 'utf8'));
-        baselineCount = meta.screenshots?.length || 0;
-      }
-    } catch {
-      // Ignore
-    }
-
-    // Check for TDD server running
-    let serverRunning = false;
-    let serverPort = null;
-    try {
-      let serverFile = join(cwd, '.vizzly', 'server.json');
-      if (existsSync(serverFile)) {
-        let serverInfo = JSON.parse(readFileSync(serverFile, 'utf8'));
-        serverPort = serverInfo.port;
-        serverRunning = true;
-      }
-    } catch {
-      // Ignore
-    }
+    let baselineInfo = readBaselineInfo(cwd);
+    let serverInfo = readServerInfo(cwd);
 
     // Check for OAuth login (from vizzly login)
     let isLoggedIn = !!globalConfig.auth?.accessToken;
@@ -76,11 +82,11 @@ export function getContext() {
     let hasEnvToken = !!process.env.VIZZLY_TOKEN;
 
     // Build context items - prioritize most useful info
-    if (serverRunning) {
+    if (serverInfo.running) {
       items.push({
         type: 'success',
         label: 'TDD Server',
-        value: `running on :${serverPort}`,
+        value: `running on :${serverInfo.port}`,
       });
     }
 
@@ -100,15 +106,15 @@ export function getContext() {
       });
     }
 
-    if (baselineCount > 0) {
+    if (baselineInfo.count > 0) {
       items.push({
         type: 'success',
         label: 'Baselines',
-        value: `${baselineCount} screenshots`,
+        value: `${baselineInfo.count} screenshots`,
       });
     }
 
-    if (!hasProjectConfig && !serverRunning && baselineCount === 0) {
+    if (!hasProjectConfig && !serverInfo.running && baselineInfo.count === 0) {
       // Only show "no config" hint if there's nothing else useful
       items.push({
         type: 'info',
@@ -131,10 +137,6 @@ export function getContext() {
  */
 export function getDetailedContext() {
   let cwd = process.cwd();
-  let globalConfigPath = join(
-    process.env.VIZZLY_HOME || join(homedir(), '.vizzly'),
-    'config.json'
-  );
 
   let context = {
     tddServer: {
@@ -156,42 +158,18 @@ export function getDetailedContext() {
   };
 
   try {
-    // Load global config
-    let globalConfig = {};
-    try {
-      if (existsSync(globalConfigPath)) {
-        globalConfig = JSON.parse(readFileSync(globalConfigPath, 'utf8'));
-      }
-    } catch {
-      // Ignore
-    }
+    let globalConfig = readGlobalConfig();
 
     // Check for vizzly.config.js
     context.project.hasConfig = existsSync(join(cwd, 'vizzly.config.js'));
 
-    // Check for baselines
-    try {
-      let metaPath = join(cwd, '.vizzly', 'baselines', 'metadata.json');
-      if (existsSync(metaPath)) {
-        let meta = JSON.parse(readFileSync(metaPath, 'utf8'));
-        context.baselines.count = meta.screenshots?.length || 0;
-        context.baselines.path = join(cwd, '.vizzly', 'baselines');
-      }
-    } catch {
-      // Ignore
-    }
+    let baselineInfo = readBaselineInfo(cwd);
+    context.baselines.count = baselineInfo.count;
+    context.baselines.path = baselineInfo.path;
 
-    // Check for TDD server
-    try {
-      let serverFile = join(cwd, '.vizzly', 'server.json');
-      if (existsSync(serverFile)) {
-        let serverInfo = JSON.parse(readFileSync(serverFile, 'utf8'));
-        context.tddServer.running = true;
-        context.tddServer.port = serverInfo.port;
-      }
-    } catch {
-      // Ignore
-    }
+    let serverInfo = readServerInfo(cwd);
+    context.tddServer.running = serverInfo.running;
+    context.tddServer.port = serverInfo.port;
 
     // Check auth status
     context.auth.loggedIn = !!globalConfig.auth?.accessToken;

--- a/src/utils/environment-config.js
+++ b/src/utils/environment-config.js
@@ -86,6 +86,24 @@ export function getBuildName() {
 }
 
 /**
+ * Get comparison threshold from environment
+ * @returns {number|undefined} Threshold value when set
+ */
+export function getThreshold() {
+  if (process.env.VIZZLY_THRESHOLD === undefined) return undefined;
+  return Number(process.env.VIZZLY_THRESHOLD);
+}
+
+/**
+ * Get minimum changed cluster size from environment
+ * @returns {number|undefined} Minimum cluster size when set
+ */
+export function getMinClusterSize() {
+  if (process.env.VIZZLY_MIN_CLUSTER_SIZE === undefined) return undefined;
+  return Number(process.env.VIZZLY_MIN_CLUSTER_SIZE);
+}
+
+/**
  * Check if TDD mode is enabled
  * @returns {boolean} Whether TDD mode is enabled
  */
@@ -117,6 +135,8 @@ export function getAllEnvironmentConfig() {
     buildId: getBuildId(),
     buildName: getBuildName(),
     parallelId: getParallelId(),
+    threshold: getThreshold(),
+    minClusterSize: getMinClusterSize(),
     tddMode: isTddMode(),
   };
 }

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -288,7 +288,7 @@ export function success(message, data = {}) {
   if (config.silent) return;
 
   if (config.json) {
-    console.log(JSON.stringify({ status: 'success', message, ...data }));
+    console.error(JSON.stringify({ status: 'success', message, ...data }));
   } else {
     console.error('');
     console.error(colors.success('✓'), message);
@@ -305,7 +305,7 @@ export function result(message) {
   const elapsed = getElapsedTime();
 
   if (config.json) {
-    console.log(JSON.stringify({ status: 'complete', message, elapsed }));
+    console.error(JSON.stringify({ status: 'complete', message, elapsed }));
   } else {
     console.error('');
     console.error(
@@ -323,7 +323,7 @@ export function info(message, data = {}) {
   if (!shouldLog('info')) return;
 
   if (config.json) {
-    console.log(JSON.stringify({ status: 'info', message, ...data }));
+    console.error(JSON.stringify({ status: 'info', message, ...data }));
   } else {
     console.log(colors.info('ℹ'), message);
   }
@@ -508,7 +508,7 @@ export function progress(message, current = 0, total = 0) {
   if (config.silent) return;
 
   if (config.json) {
-    console.log(
+    console.error(
       JSON.stringify({
         status: 'progress',
         message,
@@ -943,7 +943,7 @@ export function complete(message, options = {}) {
   let detailStr = detail ? ` ${colors.brand.textMuted(detail)}` : '';
 
   if (config.json) {
-    console.log(JSON.stringify({ status: 'complete', message, detail }));
+    console.error(JSON.stringify({ status: 'complete', message, detail }));
   } else {
     console.log(`  ${colors.brand.success('✓')} ${message}${detailStr}`);
   }

--- a/src/utils/screenshot-options.js
+++ b/src/utils/screenshot-options.js
@@ -1,22 +1,74 @@
 /**
+ * Screenshot option names that are part of the SDK/config contract, not the
+ * user's arbitrary metadata bag.
+ */
+export let RESERVED_PROPERTY_OPTIONS = Object.freeze({
+  threshold: {
+    message:
+      'Move "threshold" out of properties; properties is only for user metadata.',
+  },
+  minClusterSize: {
+    message:
+      'Move "minClusterSize" out of properties; properties is only for user metadata.',
+  },
+  fullPage: {
+    message:
+      'Move "fullPage" out of properties; properties is only for user metadata.',
+  },
+  buildId: {
+    message:
+      'Move "buildId" out of properties; properties is only for user metadata.',
+  },
+  requestTimeout: {
+    message:
+      'Move "requestTimeout" out of properties; properties is only for user metadata.',
+  },
+});
+
+function createReservedPropertyWarning(option) {
+  return {
+    code: 'reserved-property-option',
+    option,
+    message: RESERVED_PROPERTY_OPTIONS[option].message,
+  };
+}
+
+/**
  * Normalize screenshot SDK options into the properties payload consumed by the
  * local TDD server and cloud-compatible comparison path.
  */
-export function createScreenshotProperties(options = {}) {
+export function normalizeScreenshotOptions(options = {}) {
   let {
-    buildId: _buildId,
+    buildId,
     properties = {},
-    requestTimeout: _requestTimeout,
+    requestTimeout,
     threshold,
     minClusterSize,
     fullPage,
-    ...topLevelProperties
   } = options;
 
-  let normalizedProperties = {
-    ...properties,
-    ...topLevelProperties,
-  };
+  let warnings = [];
+  let normalizedProperties = {};
+
+  for (let [key, value] of Object.entries(properties || {})) {
+    if (RESERVED_PROPERTY_OPTIONS[key]) {
+      warnings.push(createReservedPropertyWarning(key));
+
+      if (key === 'threshold' && threshold === undefined) threshold = value;
+      if (key === 'minClusterSize' && minClusterSize === undefined) {
+        minClusterSize = value;
+      }
+      if (key === 'fullPage' && fullPage === undefined) fullPage = value;
+      if (key === 'buildId' && buildId === undefined) buildId = value;
+      if (key === 'requestTimeout' && requestTimeout === undefined) {
+        requestTimeout = value;
+      }
+
+      continue;
+    }
+
+    normalizedProperties[key] = value;
+  }
 
   if (threshold !== undefined) {
     normalizedProperties.threshold = threshold;
@@ -30,5 +82,14 @@ export function createScreenshotProperties(options = {}) {
     normalizedProperties.fullPage = fullPage;
   }
 
-  return normalizedProperties;
+  return {
+    buildId,
+    requestTimeout,
+    properties: normalizedProperties,
+    warnings,
+  };
+}
+
+export function createScreenshotProperties(options = {}) {
+  return normalizeScreenshotOptions(options).properties;
 }

--- a/src/utils/screenshot-options.js
+++ b/src/utils/screenshot-options.js
@@ -14,8 +14,8 @@ export function createScreenshotProperties(options = {}) {
   } = options;
 
   let normalizedProperties = {
-    ...topLevelProperties,
     ...properties,
+    ...topLevelProperties,
   };
 
   if (threshold !== undefined) {

--- a/test-d/client.test-d.ts
+++ b/test-d/client.test-d.ts
@@ -47,14 +47,6 @@ expectType<Promise<ScreenshotResult | null>>(
   })
 );
 
-// Should accept top-level screenshot properties
-expectType<Promise<ScreenshotResult | null>>(
-  vizzlyScreenshot('test', Buffer.from('test'), {
-    browser: 'chrome',
-    viewport: { width: 1920, height: 1080 },
-  })
-);
-
 // Should accept partial options
 expectType<Promise<ScreenshotResult | null>>(
   vizzlyScreenshot('test', Buffer.from('test'), { threshold: 10 })
@@ -70,6 +62,9 @@ expectError(vizzlyScreenshot('test', 123));
 expectError(vizzlyScreenshot('test', Buffer.from('test'), { threshold: 'high' }));
 expectError(
   vizzlyScreenshot('test', Buffer.from('test'), { requestTimeout: 'fast' })
+);
+expectError(
+  vizzlyScreenshot('test', Buffer.from('test'), { browser: 'chrome' })
 );
 
 // ============================================================================

--- a/test-d/client.test-d.ts
+++ b/test-d/client.test-d.ts
@@ -15,6 +15,12 @@ import {
 } from '../src/types/client';
 import type { ScreenshotResult } from '../src/types/client';
 
+let screenshotResult: ScreenshotResult = {
+  success: true,
+  status: 'diff',
+};
+expectType<ScreenshotResult>(screenshotResult);
+
 // ============================================================================
 // vizzlyScreenshot
 // ============================================================================
@@ -32,9 +38,12 @@ expectType<Promise<ScreenshotResult | null>>(
 // Should accept options object
 expectType<Promise<ScreenshotResult | null>>(
   vizzlyScreenshot('test', Buffer.from('test'), {
-    properties: { browser: 'chrome' },
+    properties: { browser: 'chrome', viewport: { width: 1920, height: 1080 } },
     threshold: 5,
+    minClusterSize: 2,
     fullPage: true,
+    requestTimeout: 5000,
+    buildId: 'build-123',
   })
 );
 
@@ -42,7 +51,7 @@ expectType<Promise<ScreenshotResult | null>>(
 expectType<Promise<ScreenshotResult | null>>(
   vizzlyScreenshot('test', Buffer.from('test'), {
     browser: 'chrome',
-    viewport: '1920x1080',
+    viewport: { width: 1920, height: 1080 },
   })
 );
 
@@ -59,6 +68,9 @@ expectError(vizzlyScreenshot('test', 123));
 
 // Should error on wrong options type
 expectError(vizzlyScreenshot('test', Buffer.from('test'), { threshold: 'high' }));
+expectError(
+  vizzlyScreenshot('test', Buffer.from('test'), { requestTimeout: 'fast' })
+);
 
 // ============================================================================
 // vizzlyFlush
@@ -67,6 +79,14 @@ expectError(vizzlyScreenshot('test', Buffer.from('test'), { threshold: 'high' })
 // Should return Promise<FlushResult | null>
 import type { FlushResult } from '../src/types/client';
 expectType<Promise<FlushResult | null>>(vizzlyFlush());
+let flushResult: FlushResult = {
+  success: true,
+  uploaded: 2,
+  failed: 1,
+  total: 3,
+};
+expectType<number | undefined>(flushResult.uploaded);
+expectType<string | undefined>(flushResult.message);
 
 // ============================================================================
 // isVizzlyReady
@@ -88,9 +108,15 @@ configure({ serverUrl: 'http://localhost:3000' });
 
 // Should accept enabled
 configure({ enabled: true });
+configure({ failOnDiff: true });
 
 // Should accept both
-configure({ serverUrl: 'http://localhost:3000', enabled: false });
+configure({
+  serverUrl: 'http://localhost:3000',
+  enabled: false,
+  failOnDiff: false,
+});
+expectError(configure({ failOnDiff: 'yes' }));
 
 // ============================================================================
 // setEnabled
@@ -116,6 +142,7 @@ expectType<boolean>(info.ready);
 expectType<string | null>(info.buildId);
 expectType<boolean>(info.tddMode);
 expectType<boolean>(info.disabled);
+expectType<boolean>(info.failOnDiff);
 
 // ============================================================================
 // Public helper exports
@@ -134,5 +161,6 @@ expectType<string | null>(
   autoDiscoverTddServer('/workspace/project', {
     exists: path => path.endsWith('server.json'),
     readFile: () => JSON.stringify({ port: 47392 }),
+    env: { VIZZLY_FAIL_ON_DIFF: 'true' },
   })
 );

--- a/test-d/main.test-d.ts
+++ b/test-d/main.test-d.ts
@@ -1,7 +1,7 @@
 /**
  * Type tests for @vizzly-testing/cli (main entry point)
  */
-import { expectType, expectError } from 'tsd';
+import { expectAssignable, expectType, expectError } from 'tsd';
 import {
   // SDK
   createVizzly,
@@ -45,6 +45,7 @@ import {
   PluginServices,
   Uploader,
   TddService,
+  BuildOptions,
 } from '../src/types/index';
 
 // ============================================================================
@@ -61,6 +62,10 @@ async function testCreateVizzlyType() {
 expectType<Promise<ScreenshotResult | null>>(
   vizzlyScreenshot('test', Buffer.from('test'))
 );
+expectAssignable<ScreenshotResult>({
+  success: true,
+  status: 'baseline-updated',
+});
 configure({});
 setEnabled(true);
 
@@ -175,12 +180,32 @@ async function testComparisonResult() {
 
   expectType<string>(result.id);
   expectType<string>(result.name);
-  expectType<'passed' | 'failed' | 'new' | 'error' | 'baseline-updated'>(result.status);
+  expectType<
+    | 'passed'
+    | 'failed'
+    | 'new'
+    | 'error'
+    | 'baseline-created'
+    | 'baseline-updated'
+  >(result.status);
   expectType<string>(result.baseline);
   expectType<string>(result.current);
   expectType<string | null>(result.diff);
   expectType<Record<string, unknown>>(result.properties);
   expectType<string>(result.signature);
+}
+
+function testBuildOptionAliases() {
+  let options: BuildOptions = {
+    buildName: 'Build',
+    branch: 'main',
+    commit_sha: 'abc123',
+    commit_message: 'Message',
+    github_pull_request_number: 42,
+    parallel_id: 'parallel-1',
+  };
+
+  expectType<BuildOptions>(options);
 }
 
 // ============================================================================

--- a/tests/api/core.test.js
+++ b/tests/api/core.test.js
@@ -425,6 +425,7 @@ describe('api/core', () => {
         browser: 'chrome',
         viewport_width: 1920,
         viewport_height: 1080,
+        properties: {},
       });
     });
 
@@ -437,6 +438,10 @@ describe('api/core', () => {
       assert.strictEqual(result.browser, 'firefox');
       assert.strictEqual(result.viewport_width, 1280);
       assert.strictEqual(result.viewport_height, 720);
+      assert.deepStrictEqual(result.properties, {
+        browser: 'firefox',
+        viewport: { width: 1280, height: 720 },
+      });
     });
 
     it('uses flat viewport_width/height from metadata', () => {
@@ -453,6 +458,7 @@ describe('api/core', () => {
       let result = buildScreenshotCheckObject('sha123', 'homepage', null);
 
       assert.strictEqual(result.browser, 'chrome');
+      assert.deepStrictEqual(result.properties, {});
     });
   });
 

--- a/tests/cli/json-output.test.js
+++ b/tests/cli/json-output.test.js
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseJSONOutput, runCLI } from '../helpers/cli-runner.js';
+
+describe('cli json output', () => {
+  it('wraps command payloads in the standard data envelope', async () => {
+    let result = await runCLI(['--json', 'config', 'server.port']);
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, '');
+
+    let messages = parseJSONOutput(result.stdout);
+    assert.deepEqual(messages, [
+      {
+        status: 'data',
+        data: {
+          key: 'server.port',
+          value: 47392,
+        },
+      },
+    ]);
+  });
+
+  it('selects json fields from the command payload before wrapping', async () => {
+    let result = await runCLI(['--json', 'key', 'config', 'server.port']);
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, '');
+
+    let messages = parseJSONOutput(result.stdout);
+    assert.deepEqual(messages, [
+      {
+        status: 'data',
+        data: {
+          key: 'server.port',
+        },
+      },
+    ]);
+  });
+
+  it('uses the same envelope for TDD subcommands with empty payloads', async () => {
+    let result = await runCLI(['--json', 'tdd', 'list']);
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stderr, '');
+
+    let messages = parseJSONOutput(result.stdout);
+    assert.deepEqual(messages, [
+      {
+        status: 'data',
+        data: {
+          servers: [],
+        },
+      },
+    ]);
+  });
+});

--- a/tests/cli/plugin-token.test.js
+++ b/tests/cli/plugin-token.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+describe('cli plugin registration', () => {
+  let workspace;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'vizzly-plugin-token-'));
+    await writeFile(
+      join(workspace, 'capture-plugin.js'),
+      `import { writeFileSync } from 'node:fs';
+
+export default {
+  name: 'capture-plugin',
+  version: '1.0.0',
+  register(_program, { config }) {
+    writeFileSync(
+      process.env.VIZZLY_PLUGIN_CAPTURE_PATH,
+      JSON.stringify({ apiKey: config.apiKey })
+    );
+  },
+};
+`
+    );
+    await writeFile(
+      join(workspace, 'vizzly.config.js'),
+      `export default {
+  plugins: ['./capture-plugin.js'],
+};
+`
+    );
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  it('passes --token to plugins registered before command parsing', async () => {
+    let capturePath = join(workspace, 'capture.json');
+    let result = await runCLI(['--token', 'cli-token', '--help'], {
+      cwd: workspace,
+      env: { VIZZLY_PLUGIN_CAPTURE_PATH: capturePath },
+    });
+
+    assert.equal(result.code, 0);
+    assert.deepEqual(JSON.parse(await readFile(capturePath, 'utf8')), {
+      apiKey: 'cli-token',
+    });
+  });
+
+  it('passes --token=value to plugins registered before command parsing', async () => {
+    let capturePath = join(workspace, 'capture-equals.json');
+    let result = await runCLI(['--token=equals-token', '--help'], {
+      cwd: workspace,
+      env: { VIZZLY_PLUGIN_CAPTURE_PATH: capturePath },
+    });
+
+    assert.equal(result.code, 0);
+    assert.deepEqual(JSON.parse(await readFile(capturePath, 'utf8')), {
+      apiKey: 'equals-token',
+    });
+  });
+});

--- a/tests/commands/api.test.js
+++ b/tests/commands/api.test.js
@@ -174,6 +174,14 @@ describe('commands/api', () => {
           'Method DELETE not allowed. Use GET for queries or POST for approve/reject/comment.',
         ]
       );
+      assert.deepStrictEqual(
+        validateApiRequest({
+          endpoint: '/api/sdk/builds',
+          method: 'GET',
+          hasData: true,
+        }),
+        ['Request data requires --method POST.']
+      );
     });
   });
 
@@ -195,6 +203,10 @@ describe('commands/api', () => {
         [
           'Method PATCH not allowed. Use GET for queries or POST for approve/reject/comment.',
         ]
+      );
+      assert.deepStrictEqual(
+        validateApiOptions('/api/sdk/builds', { data: '{"ignored":true}' }),
+        ['Request data requires --method POST.']
       );
     });
   });
@@ -311,6 +323,42 @@ describe('commands/api', () => {
       assert.strictEqual(createdClient, false);
       assert.ok(output.calls.some(call => call.method === 'error'));
       assert.ok(output.calls.some(call => call.method === 'cleanup'));
+    });
+
+    it('blocks request data on GET before creating a client', async () => {
+      let output = createMockOutput();
+      let exitCode = null;
+      let createdClient = false;
+
+      await apiCommand(
+        '/api/sdk/builds',
+        { data: '{"silently":"dropped"}' },
+        {},
+        {
+          loadConfig: async () => ({
+            apiKey: 'token-123',
+            apiUrl: 'https://api.example.test',
+          }),
+          createApiClient: () => {
+            createdClient = true;
+            return {};
+          },
+          output,
+          exit: code => {
+            exitCode = code;
+          },
+        }
+      );
+
+      assert.strictEqual(exitCode, 1);
+      assert.strictEqual(createdClient, false);
+      assert.ok(
+        output.calls.some(
+          call =>
+            call.method === 'error' &&
+            call.args[0] === 'Request data requires --method POST.'
+        )
+      );
     });
 
     it('returns JSON failure details using normalized endpoint and method', async () => {

--- a/tests/commands/preview.test.js
+++ b/tests/commands/preview.test.js
@@ -423,6 +423,40 @@ describe('previewCommand', () => {
     assert.strictEqual(dataCall.args[0].buildId, 'build-123');
   });
 
+  it('reports zero uploaded files in JSON when the API returns uploaded: 0', async () => {
+    let output = createMockOutput();
+
+    await previewCommand(
+      distDir,
+      { build: 'build-123' },
+      { json: true },
+      {
+        loadConfig: async () => ({
+          apiKey: 'test-token',
+          apiUrl: 'https://api.test',
+        }),
+        createApiClient: () => ({}),
+        getBuild: async () => ({ project: { isPublic: true } }),
+        createZipWithSystem: async (_sourceDir, outputPath) => {
+          writeFileSync(outputPath, 'zip');
+        },
+        uploadPreviewZip: async () => ({
+          previewUrl: 'https://preview.test',
+          uploaded: 0,
+          totalBytes: 3,
+          newBytes: 0,
+          deduplicationRatio: 1,
+        }),
+        output,
+        exit: () => {},
+      }
+    );
+
+    let dataCall = output.calls.find(c => c.method === 'data');
+    assert.strictEqual(dataCall.args[0].files, 0);
+    assert.match(dataCall.args[0].compressionRatio, /^\d+%$/);
+  });
+
   it('opens browser when --open flag is set', async () => {
     let output = createMockOutput();
     let openedUrl = null;
@@ -507,6 +541,34 @@ describe('previewCommand', () => {
     assert.ok(dataCall.args[0].files.length > 0);
     assert.ok(Array.isArray(dataCall.args[0].excludedDirs));
     assert.ok(Array.isArray(dataCall.args[0].excludedFiles));
+  });
+
+  it('uses --base as the upload root in dry-run mode', async () => {
+    mkdirSync(join(distDir, 'public'));
+    writeFileSync(join(distDir, 'public', 'index.html'), '<html></html>');
+    let output = createMockOutput();
+
+    let result = await previewCommand(
+      distDir,
+      { dryRun: true, build: 'build-123', base: 'public' },
+      { json: true },
+      {
+        loadConfig: async () => ({
+          apiKey: null,
+          apiUrl: 'https://api.test',
+        }),
+        output,
+        exit: () => {},
+      }
+    );
+
+    let dataCall = output.calls.find(c => c.method === 'data');
+    assert.strictEqual(result.fileCount, 1);
+    assert.strictEqual(dataCall.args[0].path, join(distDir, 'public'));
+    assert.deepStrictEqual(
+      dataCall.args[0].files.map(file => file.path),
+      ['index.html']
+    );
   });
 
   it('excludes files matching --exclude patterns', async () => {

--- a/tests/commands/project.test.js
+++ b/tests/commands/project.test.js
@@ -136,6 +136,95 @@ describe('commands/project', () => {
       );
     });
 
+    it('passes expiresAt through to the project link API', async () => {
+      let output = createOutput();
+      let capturedRequest = null;
+
+      await projectLinkCommand(
+        'vizzly/storybook',
+        {
+          name: 'Expiring Link',
+          expiresAt: '2026-06-01T00:00:00.000Z',
+        },
+        {},
+        {
+          output,
+          loadConfig: async () => ({
+            apiUrl: 'https://app.vizzly.dev',
+            userToken: 'user-jwt',
+          }),
+          createApiClient: () => ({
+            request: async (endpoint, options) => {
+              capturedRequest = { endpoint, options };
+              return {
+                organization: { slug: 'vizzly', name: 'Vizzly' },
+                project: { slug: 'storybook', name: 'Storybook' },
+                token: {
+                  id: 'token-id',
+                  token: 'vzt_secret',
+                  token_prefix: 'vzt_sec',
+                  created_at: '2026-05-20T12:00:00.000Z',
+                  expires_at: '2026-06-01T00:00:00.000Z',
+                },
+              };
+            },
+          }),
+          saveProjectLink: async link => ({
+            ...link,
+            storage: 'keychain',
+          }),
+        }
+      );
+
+      assert.deepStrictEqual(JSON.parse(capturedRequest.options.body), {
+        name: 'Expiring Link',
+        expiresAt: '2026-06-01T00:00:00.000Z',
+      });
+    });
+
+    it('uses the global token override for project link requests', async () => {
+      let output = createOutput();
+      let capturedToken = null;
+
+      await projectLinkCommand(
+        'vizzly/storybook',
+        {},
+        { token: 'cli-token' },
+        {
+          output,
+          loadConfig: async (_configPath, cliOverrides) => {
+            assert.strictEqual(cliOverrides.token, 'cli-token');
+            return { apiUrl: 'https://app.vizzly.dev' };
+          },
+          getAccessToken: async () => {
+            throw new Error('CLI token should be used before saved login');
+          },
+          createApiClient: ({ token }) => ({
+            request: async () => {
+              capturedToken = token;
+              return {
+                organization: { slug: 'vizzly', name: 'Vizzly' },
+                project: { slug: 'storybook', name: 'Storybook' },
+                token: {
+                  id: 'token-id',
+                  token: 'vzt_secret',
+                  token_prefix: 'vzt_sec',
+                  created_at: '2026-05-20T12:00:00.000Z',
+                  expires_at: null,
+                },
+              };
+            },
+          }),
+          saveProjectLink: async link => ({
+            ...link,
+            storage: 'keychain',
+          }),
+        }
+      );
+
+      assert.strictEqual(capturedToken, 'cli-token');
+    });
+
     it('asks the user to login before linking', async () => {
       let output = createOutput();
       let exitCode = null;

--- a/tests/commands/run.test.js
+++ b/tests/commands/run.test.js
@@ -610,6 +610,112 @@ describe('commands/run', () => {
       assert.strictEqual(capturedRunOptions.buildName, 'custom-build');
     });
 
+    it('uses configured build metadata when CLI overrides are absent', async () => {
+      let output = createMockOutput();
+      let capturedRunOptions = null;
+
+      await runCommand(
+        'pnpm test',
+        {},
+        {},
+        {
+          loadConfig: async () =>
+            createMockConfig({
+              build: {
+                name: 'Configured Run',
+                branch: 'config-branch',
+                commit: 'config-sha',
+                message: 'Config message',
+                environment: 'preview',
+              },
+            }),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          createUploader: () => ({}),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { buildId: null, screenshotsCaptured: 0 };
+          },
+          detectBranch: async branch => branch,
+          detectCommit: async commit => commit,
+          detectCommitMessage: async () => {
+            throw new Error('should not detect message');
+          },
+          detectPullRequestNumber: () => null,
+          generateBuildNameWithGit: async name => name,
+          output,
+          exit: () => {},
+          processOn: () => {},
+          processRemoveListener: () => {},
+        }
+      );
+
+      assert.strictEqual(capturedRunOptions.branch, 'config-branch');
+      assert.strictEqual(capturedRunOptions.commit, 'config-sha');
+      assert.strictEqual(capturedRunOptions.message, 'Config message');
+      assert.strictEqual(capturedRunOptions.buildName, 'Configured Run');
+      assert.strictEqual(capturedRunOptions.environment, 'preview');
+    });
+
+    it('waits before emitting JSON when --wait and --json are combined', async () => {
+      let output = createMockOutput();
+
+      let result = await runCommand(
+        'pnpm test',
+        { wait: true },
+        { json: true },
+        {
+          loadConfig: async () => createMockConfig(),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          createUploader: () => ({
+            waitForBuild: async buildId => {
+              assert.strictEqual(buildId, 'build-123');
+              return {
+                totalComparisons: 3,
+                newComparisons: 1,
+                failedComparisons: 2,
+                identicalComparisons: 0,
+                approvalStatus: 'pending',
+              };
+            },
+          }),
+          runTests: async () => ({
+            buildId: 'build-123',
+            screenshotsCaptured: 3,
+            url: 'https://app.test/builds/build-123',
+          }),
+          detectBranch: async () => 'main',
+          detectCommit: async () => 'abc123',
+          detectCommitMessage: async () => 'test',
+          detectPullRequestNumber: () => null,
+          generateBuildNameWithGit: async () => 'test-build',
+          output,
+          exit: () => {},
+          processOn: () => {},
+          processRemoveListener: () => {},
+        }
+      );
+
+      let dataCalls = output.calls.filter(c => c.method === 'data');
+
+      assert.strictEqual(dataCalls.length, 1);
+      assert.strictEqual(dataCalls[0].args[0].status, 'failed');
+      assert.deepStrictEqual(dataCalls[0].args[0].comparisons, {
+        total: 3,
+        new: 1,
+        changed: 2,
+        identical: 0,
+      });
+      assert.strictEqual(dataCalls[0].args[0].exitCode, 1);
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.exitCode, 1);
+    });
+
     it('always calls cleanup', async () => {
       let output = createMockOutput();
 
@@ -913,6 +1019,50 @@ describe('commands/run', () => {
           c => c.method === 'warn' && c.args[0].includes('API unavailable')
         )
       );
+    });
+
+    it('emits a JSON skip payload when API returns 5xx error', async () => {
+      let output = createMockOutput();
+      let exitCode = null;
+
+      let apiError = new Error('API request failed: 503');
+      apiError.context = { status: 503 };
+
+      let result = await runCommand(
+        'pnpm test',
+        {},
+        { json: true },
+        {
+          loadConfig: async () => {
+            throw apiError;
+          },
+          output,
+          exit: code => {
+            exitCode = code;
+          },
+          processOn: () => {},
+          processRemoveListener: () => {},
+        }
+      );
+
+      let dataCall = output.calls.find(c => c.method === 'data');
+
+      assert.deepStrictEqual(
+        {
+          buildId: dataCall.args[0].buildId,
+          status: dataCall.args[0].status,
+          message: dataCall.args[0].message,
+        },
+        {
+          buildId: null,
+          status: 'skipped',
+          message: 'Vizzly API unavailable - visual tests skipped',
+        }
+      );
+      assert.strictEqual(typeof dataCall.args[0].executionTimeMs, 'number');
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.result.skipped, true);
+      assert.strictEqual(exitCode, null);
     });
 
     it('does not fail CI when API returns 500 error', async () => {

--- a/tests/commands/tdd-daemon.test.js
+++ b/tests/commands/tdd-daemon.test.js
@@ -138,7 +138,7 @@ describe('commands/tdd-daemon helpers', () => {
       let writes = [];
 
       let result = writeLegacyGlobalServerFile(
-        { pid: 1234, port: 47400 },
+        { pid: 1234, port: 47400, failOnDiff: true },
         {
           home: () => '/home/test',
           exists: () => false,
@@ -162,6 +162,7 @@ describe('commands/tdd-daemon helpers', () => {
             pid: 1234,
             port: '47400',
             startTime: 987654321,
+            failOnDiff: true,
           },
         },
       ]);
@@ -170,6 +171,7 @@ describe('commands/tdd-daemon helpers', () => {
         serverInfo: buildLegacyServerInfo({
           pid: 1234,
           port: 47400,
+          failOnDiff: true,
           now: () => 987654321,
         }),
       });

--- a/tests/commands/tdd.test.js
+++ b/tests/commands/tdd.test.js
@@ -275,6 +275,45 @@ describe('commands/tdd', () => {
       // Summary output is handled by printResults() in tdd-service.js
     });
 
+    it('prints failed JSON when TDD comparisons fail', async () => {
+      let output = createMockOutput();
+
+      let { result } = await tddCommand(
+        'pnpm test',
+        {},
+        { json: true },
+        {
+          loadConfig: async () => createMockConfig(),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          runTests: async () => ({
+            screenshotsCaptured: 1,
+            comparisons: [
+              {
+                name: 'button-primary',
+                status: 'failed',
+                signature: 'button-primary|1920|chromium',
+                diffPercentage: 4.2,
+              },
+            ],
+          }),
+          detectBranch: async () => 'main',
+          detectCommit: async () => 'abc',
+          output,
+        }
+      );
+
+      let dataCall = output.calls.find(call => call.method === 'data');
+
+      assert.strictEqual(result.success, false);
+      assert.strictEqual(result.exitCode, 1);
+      assert.strictEqual(dataCall.args[0].status, 'failed');
+      assert.strictEqual(dataCall.args[0].exitCode, 1);
+      assert.strictEqual(dataCall.args[0].summary.failed, 1);
+    });
+
     it('handles config loading error', async () => {
       let output = createMockOutput();
 
@@ -406,6 +445,143 @@ describe('commands/tdd', () => {
       assert.strictEqual(capturedRunOptions.commit, 'def456');
     });
 
+    it('falls back to build metadata from config', async () => {
+      let output = createMockOutput();
+      let capturedBranchArg = null;
+      let capturedCommitArg = null;
+      let capturedRunOptions = null;
+
+      await tddCommand(
+        'pnpm test',
+        {},
+        {},
+        {
+          loadConfig: async () =>
+            createMockConfig({
+              build: {
+                branch: 'config-branch',
+                commit: 'config-commit',
+                environment: 'test',
+              },
+            }),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { screenshotsCaptured: 0, comparisons: [] };
+          },
+          detectBranch: async branch => {
+            capturedBranchArg = branch;
+            return branch;
+          },
+          detectCommit: async commit => {
+            capturedCommitArg = commit;
+            return commit;
+          },
+          output,
+        }
+      );
+
+      assert.strictEqual(capturedBranchArg, 'config-branch');
+      assert.strictEqual(capturedCommitArg, 'config-commit');
+      assert.strictEqual(capturedRunOptions.branch, 'config-branch');
+      assert.strictEqual(capturedRunOptions.commit, 'config-commit');
+    });
+
+    it('passes build metadata and parallel id through to the TDD run', async () => {
+      let output = createMockOutput();
+      let capturedRunOptions = null;
+
+      await tddCommand(
+        'pnpm test',
+        {},
+        {},
+        {
+          loadConfig: async () =>
+            createMockConfig({
+              build: {
+                name: 'Local TDD Build',
+                environment: 'staging',
+                message: 'Config message',
+              },
+              comparison: { threshold: 2.5, minClusterSize: 7 },
+              parallelId: 'local-parallel',
+            }),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { screenshotsCaptured: 0, comparisons: [] };
+          },
+          detectBranch: async () => 'main',
+          detectCommit: async () => 'abc123',
+          detectPullRequestNumber: () => 42,
+          output,
+        }
+      );
+
+      assert.strictEqual(capturedRunOptions.name, 'Local TDD Build');
+      assert.strictEqual(capturedRunOptions.buildName, 'Local TDD Build');
+      assert.strictEqual(capturedRunOptions.message, 'Config message');
+      assert.strictEqual(capturedRunOptions.environment, 'staging');
+      assert.strictEqual(capturedRunOptions.pullRequestNumber, 42);
+      assert.strictEqual(capturedRunOptions.parallelId, 'local-parallel');
+      assert.deepStrictEqual(capturedRunOptions.metadata, {
+        comparison: {
+          threshold: 2.5,
+          minClusterSize: 7,
+        },
+      });
+    });
+
+    it('derives build names when config still has the default placeholder', async () => {
+      let output = createMockOutput();
+      let capturedRunOptions = null;
+      let capturedBuildNameOverride = 'not-called';
+
+      await tddCommand(
+        'pnpm test',
+        {},
+        {},
+        {
+          loadConfig: async () => createMockConfig(),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { screenshotsCaptured: 0, comparisons: [] };
+          },
+          detectBranch: async () => 'feature/default-name',
+          detectCommit: async () => 'abc123',
+          detectCommitMessage: async () => 'Detected commit message',
+          detectPullRequestNumber: () => 77,
+          generateBuildNameWithGit: async override => {
+            capturedBuildNameOverride = override;
+            return 'feature-default-name-abc1234';
+          },
+          output,
+        }
+      );
+
+      assert.strictEqual(capturedBuildNameOverride, undefined);
+      assert.strictEqual(
+        capturedRunOptions.buildName,
+        'feature-default-name-abc1234'
+      );
+      assert.strictEqual(
+        capturedRunOptions.name,
+        'feature-default-name-abc1234'
+      );
+      assert.strictEqual(capturedRunOptions.message, 'Detected commit message');
+      assert.strictEqual(capturedRunOptions.pullRequestNumber, 77);
+    });
+
     it('passes comparison config through to the TDD run', async () => {
       let output = createMockOutput();
       let capturedRunOptions = null;
@@ -435,6 +611,33 @@ describe('commands/tdd', () => {
 
       assert.strictEqual(capturedRunOptions.threshold, 0);
       assert.strictEqual(capturedRunOptions.minClusterSize, 6);
+    });
+
+    it('passes failOnDiff through to the TDD run', async () => {
+      let output = createMockOutput();
+      let capturedRunOptions = null;
+
+      await tddCommand(
+        'pnpm test',
+        { failOnDiff: true },
+        {},
+        {
+          loadConfig: async () => createMockConfig(),
+          createServerManager: () => ({
+            start: async () => {},
+            stop: async () => {},
+          }),
+          runTests: async ({ runOptions }) => {
+            capturedRunOptions = runOptions;
+            return { screenshotsCaptured: 0, comparisons: [] };
+          },
+          detectBranch: async () => 'main',
+          detectCommit: async () => 'abc123',
+          output,
+        }
+      );
+
+      assert.strictEqual(capturedRunOptions.failOnDiff, true);
     });
 
     it('invokes onBuildCreated callback', async () => {

--- a/tests/commands/upload.test.js
+++ b/tests/commands/upload.test.js
@@ -19,6 +19,7 @@ function createMockOutput() {
     error: (msg, err) => calls.push({ method: 'error', args: [msg, err] }),
     success: msg => calls.push({ method: 'success', args: [msg] }),
     warn: msg => calls.push({ method: 'warn', args: [msg] }),
+    data: value => calls.push({ method: 'data', args: [value] }),
     progress: (msg, cur, tot) =>
       calls.push({ method: 'progress', args: [msg, cur, tot] }),
     startSpinner: msg => calls.push({ method: 'startSpinner', args: [msg] }),
@@ -141,6 +142,29 @@ describe('validateUploadOptions', () => {
     });
   });
 
+  describe('min cluster size validation', () => {
+    it('should pass with valid min cluster size', () => {
+      let errors = validateUploadOptions('./screenshots', {
+        minClusterSize: '2',
+      });
+      assert.strictEqual(errors.length, 0);
+    });
+
+    it('should fail with decimal min cluster size', () => {
+      let errors = validateUploadOptions('./screenshots', {
+        minClusterSize: '2.5',
+      });
+      assert.ok(errors.includes('Min cluster size must be a positive integer'));
+    });
+
+    it('should fail with zero min cluster size', () => {
+      let errors = validateUploadOptions('./screenshots', {
+        minClusterSize: '0',
+      });
+      assert.ok(errors.includes('Min cluster size must be a positive integer'));
+    });
+  });
+
   describe('batch size validation', () => {
     it('should pass with valid batch size', () => {
       let errors = validateUploadOptions('./screenshots', {
@@ -223,11 +247,12 @@ describe('validateUploadOptions', () => {
       let errors = validateUploadOptions(null, {
         metadata: 'invalid-json',
         threshold: '-1',
+        minClusterSize: '0',
         batchSize: '-1',
         uploadTimeout: '0',
       });
 
-      assert.strictEqual(errors.length, 5);
+      assert.strictEqual(errors.length, 6);
       assert.ok(errors.includes('Screenshots path is required'));
       assert.ok(errors.includes('Invalid JSON in --metadata option'));
       assert.ok(
@@ -236,6 +261,7 @@ describe('validateUploadOptions', () => {
         )
       );
       assert.ok(errors.includes('Batch size must be a positive integer'));
+      assert.ok(errors.includes('Min cluster size must be a positive integer'));
       assert.ok(
         errors.includes(
           'Upload timeout must be a positive integer (milliseconds)'
@@ -364,6 +390,7 @@ describe('uploadCommand', () => {
   it('uploads screenshots and finalizes build', async () => {
     let output = createMockOutput();
     let uploadCalled = false;
+    let capturedUploadOptions = null;
     let finalizeCalled = false;
     let finalizeSuccess = null;
 
@@ -376,7 +403,7 @@ describe('uploadCommand', () => {
           apiKey: 'test-token',
           apiUrl: 'https://api.test',
           build: { environment: 'test' },
-          comparison: { threshold: 2.0 },
+          comparison: { threshold: 2.0, minClusterSize: 3 },
         }),
         detectBranch: async () => 'main',
         detectCommit: async () => 'abc123',
@@ -384,8 +411,9 @@ describe('uploadCommand', () => {
         detectPullRequestNumber: () => null,
         generateBuildNameWithGit: async () => 'Test Build',
         createUploader: () => ({
-          upload: async () => {
+          upload: async uploadOptions => {
             uploadCalled = true;
+            capturedUploadOptions = uploadOptions;
             return {
               buildId: 'build-123',
               stats: { uploaded: 5, total: 5 },
@@ -406,10 +434,192 @@ describe('uploadCommand', () => {
 
     assert.strictEqual(result.success, true);
     assert.strictEqual(uploadCalled, true);
+    assert.strictEqual(capturedUploadOptions.threshold, 2.0);
+    assert.strictEqual(capturedUploadOptions.minClusterSize, 3);
     assert.strictEqual(finalizeCalled, true);
     assert.strictEqual(finalizeSuccess, true);
     // Now uses output.complete() instead of output.success()
     assert.ok(output.calls.some(c => c.method === 'complete'));
+  });
+
+  it('passes upload flags, metadata, and session fields through', async () => {
+    let output = createMockOutput();
+    let capturedUploadOptions = null;
+    let capturedSession = null;
+
+    await uploadCommand(
+      './screenshots',
+      {
+        uploadAll: true,
+        metadata: '{"suite":"visual","browser":"chrome"}',
+      },
+      {},
+      {
+        loadConfig: async () => ({
+          apiKey: 'test-token',
+          apiUrl: 'https://api.test',
+          build: { environment: 'preview' },
+          comparison: { threshold: 1.5, minClusterSize: 4 },
+          parallelId: 'parallel-123',
+        }),
+        detectBranch: async () => 'feature/upload',
+        detectCommit: async () => 'abc123',
+        detectCommitMessage: async () => 'Upload snapshots',
+        detectPullRequestNumber: () => 42,
+        generateBuildNameWithGit: async () => 'Upload Build',
+        createUploader: () => ({
+          upload: async uploadOptions => {
+            capturedUploadOptions = uploadOptions;
+            return {
+              buildId: 'build-123',
+              stats: { uploaded: 2, total: 2 },
+            };
+          },
+        }),
+        createApiClient: () => ({}),
+        finalizeBuild: async () => {},
+        buildUrlConstructor: async () =>
+          'https://app.vizzly.dev/builds/build-123',
+        writeSession: session => {
+          capturedSession = session;
+        },
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedUploadOptions.uploadAll, true);
+    assert.strictEqual(capturedUploadOptions.branch, 'feature/upload');
+    assert.strictEqual(capturedUploadOptions.commit, 'abc123');
+    assert.strictEqual(capturedUploadOptions.message, 'Upload snapshots');
+    assert.strictEqual(capturedUploadOptions.environment, 'preview');
+    assert.strictEqual(capturedUploadOptions.threshold, 1.5);
+    assert.strictEqual(capturedUploadOptions.minClusterSize, 4);
+    assert.strictEqual(capturedUploadOptions.pullRequestNumber, 42);
+    assert.strictEqual(capturedUploadOptions.parallelId, 'parallel-123');
+    assert.deepStrictEqual(capturedUploadOptions.metadata, {
+      suite: 'visual',
+      browser: 'chrome',
+    });
+    assert.deepStrictEqual(capturedSession, {
+      buildId: 'build-123',
+      branch: 'feature/upload',
+      commit: 'abc123',
+      parallelId: 'parallel-123',
+    });
+  });
+
+  it('passes resolved upload config to the uploader factory', async () => {
+    let output = createMockOutput();
+    let capturedLoadOptions = null;
+    let capturedUploaderConfig = null;
+
+    await uploadCommand(
+      './screenshots',
+      {
+        batchSize: 7,
+        uploadTimeout: 45_000,
+      },
+      {},
+      {
+        loadConfig: async (_configPath, allOptions) => {
+          capturedLoadOptions = allOptions;
+          return {
+            apiKey: 'test-token',
+            apiUrl: 'https://api.test',
+            build: { environment: 'test' },
+            comparison: { threshold: 2, minClusterSize: 4 },
+            upload: {
+              batchSize: allOptions.batchSize,
+              timeout: allOptions.uploadTimeout,
+            },
+          };
+        },
+        detectBranch: async () => 'main',
+        detectCommit: async () => 'abc123',
+        detectCommitMessage: async () => 'Upload snapshots',
+        detectPullRequestNumber: () => null,
+        generateBuildNameWithGit: async () => 'Upload Build',
+        createUploader: config => {
+          capturedUploaderConfig = config;
+          return {
+            upload: async () => ({
+              buildId: 'build-123',
+              stats: { uploaded: 2, total: 2 },
+            }),
+          };
+        },
+        createApiClient: () => ({}),
+        finalizeBuild: async () => {},
+        buildUrlConstructor: async () =>
+          'https://app.vizzly.dev/builds/build-123',
+        writeSession: () => {},
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedLoadOptions.batchSize, 7);
+    assert.strictEqual(capturedLoadOptions.uploadTimeout, 45_000);
+    assert.deepStrictEqual(capturedUploaderConfig.upload, {
+      batchSize: 7,
+      timeout: 45_000,
+    });
+    assert.strictEqual(capturedUploaderConfig.command, 'upload');
+  });
+
+  it('uses configured build metadata when CLI overrides are absent', async () => {
+    let output = createMockOutput();
+    let capturedUploadOptions = null;
+
+    await uploadCommand(
+      './screenshots',
+      {},
+      {},
+      {
+        loadConfig: async () => ({
+          apiKey: 'test-token',
+          apiUrl: 'https://api.test',
+          build: {
+            name: 'Configured Upload',
+            branch: 'config-branch',
+            commit: 'config-sha',
+            message: 'Config upload message',
+            environment: 'preview',
+          },
+          comparison: { threshold: 2, minClusterSize: 4 },
+        }),
+        detectBranch: async branch => branch,
+        detectCommit: async commit => commit,
+        detectCommitMessage: async () => {
+          throw new Error('should not detect message');
+        },
+        detectPullRequestNumber: () => null,
+        generateBuildNameWithGit: async name => name,
+        createUploader: () => ({
+          upload: async uploadOptions => {
+            capturedUploadOptions = uploadOptions;
+            return {
+              buildId: 'build-123',
+              stats: { uploaded: 2, total: 2 },
+            };
+          },
+        }),
+        createApiClient: () => ({}),
+        finalizeBuild: async () => {},
+        buildUrlConstructor: async () =>
+          'https://app.vizzly.dev/builds/build-123',
+        writeSession: () => {},
+        output,
+        exit: () => {},
+      }
+    );
+
+    assert.strictEqual(capturedUploadOptions.branch, 'config-branch');
+    assert.strictEqual(capturedUploadOptions.commit, 'config-sha');
+    assert.strictEqual(capturedUploadOptions.message, 'Config upload message');
+    assert.strictEqual(capturedUploadOptions.buildName, 'Configured Upload');
+    assert.strictEqual(capturedUploadOptions.environment, 'preview');
   });
 
   it('handles upload errors and marks build as failed', async () => {
@@ -504,7 +714,7 @@ describe('uploadCommand', () => {
   it('shows warning when wait returns failed comparisons', async () => {
     let output = createMockOutput();
 
-    await uploadCommand(
+    let result = await uploadCommand(
       './screenshots',
       { wait: true },
       {},
@@ -545,6 +755,8 @@ describe('uploadCommand', () => {
         c => c.method === 'print' && c.args[0].includes('failed')
       )
     );
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.exitCode, 1);
   });
 
   it('handles finalize error gracefully', async () => {
@@ -716,5 +928,62 @@ describe('uploadCommand', () => {
         c => c.method === 'warn' && c.args[0].includes('API unavailable')
       )
     );
+  });
+
+  it('emits a JSON skip payload when API returns 5xx error', async () => {
+    let output = createMockOutput();
+    let exitCode = null;
+
+    let apiError = new Error('API request failed: 503 - Service Unavailable');
+    apiError.context = { status: 503 };
+
+    let result = await uploadCommand(
+      './screenshots',
+      {},
+      { json: true },
+      {
+        loadConfig: async () => ({
+          apiKey: 'test-token',
+          apiUrl: 'https://api.test',
+          build: { environment: 'test' },
+          comparison: { threshold: 2.0 },
+        }),
+        detectBranch: async () => 'main',
+        detectCommit: async () => 'abc123',
+        detectCommitMessage: async () => 'Test commit',
+        detectPullRequestNumber: () => null,
+        generateBuildNameWithGit: async () => 'Test Build',
+        createUploader: () => ({
+          upload: async () => {
+            throw apiError;
+          },
+        }),
+        createApiClient: () => ({}),
+        finalizeBuild: async () => {},
+        output,
+        exit: code => {
+          exitCode = code;
+        },
+      }
+    );
+
+    let dataCall = output.calls.find(c => c.method === 'data');
+
+    assert.deepStrictEqual(
+      {
+        buildId: dataCall.args[0].buildId,
+        status: dataCall.args[0].status,
+        message: dataCall.args[0].message,
+      },
+      {
+        buildId: null,
+        status: 'skipped',
+        message: 'Vizzly API unavailable - upload skipped',
+      }
+    );
+    assert.strictEqual(typeof dataCall.args[0].executionTimeMs, 'number');
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.result.skipped, true);
+    assert.strictEqual(exitCode, null);
   });
 });

--- a/tests/sdk/client.test.js
+++ b/tests/sdk/client.test.js
@@ -16,6 +16,33 @@ import {
 // Store original env vars
 let originalEnv;
 
+function restoreProcessEnv(snapshot) {
+  for (let key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+
+  for (let [key, value] of Object.entries(snapshot)) {
+    process.env[key] = value;
+  }
+}
+
+function startServer(server, port = 0) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve(server.address().port);
+    });
+  });
+}
+
+async function closeServer(server) {
+  server.closeAllConnections();
+  await new Promise(resolve => server.close(resolve));
+}
+
 describe('client/index', () => {
   beforeEach(() => {
     // Save originals
@@ -26,6 +53,7 @@ describe('client/index', () => {
     delete process.env.VIZZLY_ENABLED;
     delete process.env.VIZZLY_CLIENT_LOG_LEVEL;
     delete process.env.VIZZLY_BUILD_ID;
+    delete process.env.VIZZLY_FAIL_ON_DIFF;
 
     // Re-enable for each test (reset internal state)
     configure({ enabled: true, serverUrl: null });
@@ -33,7 +61,7 @@ describe('client/index', () => {
 
   afterEach(() => {
     // Restore originals
-    process.env = originalEnv;
+    restoreProcessEnv(originalEnv);
     mock.reset();
   });
 
@@ -88,9 +116,20 @@ describe('client/index', () => {
       assert.strictEqual(LOG_LEVELS.warn, 2);
       assert.strictEqual(LOG_LEVELS.error, 3);
     });
+
+    it('cannot be mutated by consumers', () => {
+      assert.throws(() => {
+        LOG_LEVELS.debug = 99;
+      }, TypeError);
+      assert.strictEqual(LOG_LEVELS.debug, 0);
+    });
   });
 
   describe('autoDiscoverTddServer (pure function with DI)', () => {
+    afterEach(() => {
+      delete process.env.VIZZLY_FAIL_ON_DIFF;
+    });
+
     it('returns null when no server.json exists', () => {
       let mockExists = () => false;
       let mockReadFile = () => {
@@ -115,6 +154,36 @@ describe('client/index', () => {
       });
 
       assert.strictEqual(result, 'http://localhost:47392');
+    });
+
+    it('lets VIZZLY_FAIL_ON_DIFF override server.json defaults', () => {
+      let mockExists = path => path === '/project/.vizzly/server.json';
+      let mockReadFile = () =>
+        JSON.stringify({ port: 12345, failOnDiff: false });
+
+      let result = autoDiscoverTddServer('/project/tests/unit', {
+        exists: mockExists,
+        readFile: mockReadFile,
+        env: { VIZZLY_FAIL_ON_DIFF: 'true' },
+      });
+
+      assert.strictEqual(result, 'http://localhost:12345');
+    });
+
+    it('lets explicit configure failOnDiff false override discovered server config', async () => {
+      let mockExists = path => path === '/project/.vizzly/server.json';
+      let mockReadFile = () =>
+        JSON.stringify({ port: 12345, failOnDiff: true });
+
+      let result = autoDiscoverTddServer('/project/tests/unit', {
+        exists: mockExists,
+        readFile: mockReadFile,
+      });
+
+      configure({ serverUrl: result, failOnDiff: false });
+
+      let info = getVizzlyInfo();
+      assert.strictEqual(info.failOnDiff, false);
     });
 
     it('finds server.json in parent directory', () => {
@@ -226,6 +295,14 @@ describe('client/index', () => {
       assert.strictEqual(info.buildId, 'test-build-123');
     });
 
+    it('reports the configured serverUrl from configure()', () => {
+      configure({ serverUrl: 'http://localhost:9999' });
+
+      let info = getVizzlyInfo();
+
+      assert.strictEqual(info.serverUrl, 'http://localhost:9999');
+    });
+
     it('shows disabled state', () => {
       configure({ enabled: false });
 
@@ -233,6 +310,13 @@ describe('client/index', () => {
 
       assert.strictEqual(info.enabled, false);
       assert.strictEqual(info.disabled, true);
+    });
+
+    it('normalizes missing optional values to null', () => {
+      let info = getVizzlyInfo();
+
+      assert.strictEqual(info.serverUrl, null);
+      assert.strictEqual(info.buildId, null);
     });
   });
 
@@ -333,23 +417,17 @@ describe('client/index httpPost integration tests', () => {
     });
 
     // Start server on random available port
-    await new Promise(resolve => {
-      server.listen(0, () => {
-        serverPort = server.address().port;
-        resolve();
-      });
-    });
+    serverPort = await startServer(server);
 
     // Clear env vars and reset state
     delete process.env.VIZZLY_SERVER_URL;
     delete process.env.VIZZLY_ENABLED;
-    configure({ enabled: true, serverUrl: `http://localhost:${serverPort}` });
+    configure({ enabled: true, serverUrl: `http://127.0.0.1:${serverPort}` });
   });
 
   afterEach(async () => {
     // Close all keep-alive connections before closing server
-    server.closeAllConnections();
-    await new Promise(resolve => server.close(resolve));
+    await closeServer(server);
     configure({ enabled: false });
   });
 
@@ -427,6 +505,55 @@ describe('client/index httpPost integration tests', () => {
     });
   });
 
+  it('lets explicit top-level metadata override nested properties', async () => {
+    await vizzlyScreenshot('test', Buffer.from('data'), {
+      browser: 'chromium',
+      url: 'http://localhost:3000/current',
+      viewport: { width: 1440, height: 900 },
+      properties: {
+        browser: 'firefox',
+        url: 'http://stale.example',
+        viewport: { width: 375, height: 667 },
+        theme: 'dark',
+      },
+    });
+
+    assert.strictEqual(requests.length, 1);
+    assert.deepStrictEqual(requests[0].body.properties, {
+      browser: 'chromium',
+      url: 'http://localhost:3000/current',
+      viewport: { width: 1440, height: 900 },
+      theme: 'dark',
+    });
+  });
+
+  it('sends per-call buildId outside screenshot properties', async () => {
+    await vizzlyScreenshot('test', Buffer.from('data'), {
+      buildId: 'build-from-call',
+      properties: { url: 'http://localhost:3000' },
+    });
+
+    assert.strictEqual(requests.length, 1);
+    assert.strictEqual(requests[0].body.buildId, 'build-from-call');
+    assert.deepStrictEqual(requests[0].body.properties, {
+      url: 'http://localhost:3000',
+    });
+  });
+
+  it('uses requestTimeout for transport without serializing it', async () => {
+    await vizzlyScreenshot('test', Buffer.from('data'), {
+      requestTimeout: 30_000,
+      properties: { url: 'http://localhost:3000' },
+    });
+
+    assert.strictEqual(requests.length, 1);
+    assert.strictEqual(requests[0].body.requestTimeout, undefined);
+    assert.strictEqual(requests[0].body.properties.requestTimeout, undefined);
+    assert.deepStrictEqual(requests[0].body.properties, {
+      url: 'http://localhost:3000',
+    });
+  });
+
   it('sends Connection: close header to disable keep-alive', async () => {
     await vizzlyScreenshot('test', Buffer.from('data'));
 
@@ -445,7 +572,7 @@ describe('client/index httpPost integration tests', () => {
     // Point to the TDD diff endpoint
     configure({
       enabled: true,
-      serverUrl: `http://localhost:${serverPort}/screenshot-tdd-diff`.replace(
+      serverUrl: `http://127.0.0.1:${serverPort}/screenshot-tdd-diff`.replace(
         '/screenshot',
         ''
       ),
@@ -453,8 +580,7 @@ describe('client/index httpPost integration tests', () => {
 
     // Need to reconfigure to actually hit the different endpoint
     // Actually, let's use a different approach - modify what endpoint we hit
-    server.closeAllConnections();
-    await new Promise(resolve => server.close(resolve));
+    await closeServer(server);
     requests = [];
 
     server = createServer((req, res) => {
@@ -482,11 +608,9 @@ describe('client/index httpPost integration tests', () => {
       });
     });
 
-    await new Promise(resolve => {
-      server.listen(serverPort, () => resolve());
-    });
+    await startServer(server, serverPort);
 
-    configure({ enabled: true, serverUrl: `http://localhost:${serverPort}` });
+    configure({ enabled: true, serverUrl: `http://127.0.0.1:${serverPort}` });
 
     let result = await vizzlyScreenshot('homepage', Buffer.from('png-data'));
 
@@ -497,9 +621,154 @@ describe('client/index httpPost integration tests', () => {
     assert.strictEqual(result.diffPercentage, 5.2);
   });
 
+  it('throws on TDD visual diffs when failOnDiff is enabled', async () => {
+    await closeServer(server);
+    requests = [];
+
+    server = createServer((req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        requests.push({ method: req.method, url: req.url });
+        res.setHeader('Content-Type', 'application/json');
+        res.statusCode = 422;
+        res.end(
+          JSON.stringify({
+            tddMode: true,
+            comparison: {
+              name: 'homepage',
+              diffPercentage: 5.2,
+            },
+          })
+        );
+      });
+    });
+
+    await startServer(server, serverPort);
+
+    configure({
+      enabled: true,
+      serverUrl: `http://127.0.0.1:${serverPort}`,
+      failOnDiff: true,
+    });
+
+    await assert.rejects(
+      () => vizzlyScreenshot('homepage', Buffer.from('png-data')),
+      /Visual diff detected/
+    );
+  });
+
+  it('throws on current 200 TDD diff responses when failOnDiff is enabled', async () => {
+    await closeServer(server);
+    requests = [];
+
+    server = createServer((req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        requests.push({ method: req.method, url: req.url });
+        res.setHeader('Content-Type', 'application/json');
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            success: true,
+            tddMode: true,
+            status: 'diff',
+            name: 'homepage',
+            diffPercentage: 5.2,
+          })
+        );
+      });
+    });
+
+    await startServer(server, serverPort);
+
+    configure({
+      enabled: true,
+      serverUrl: `http://127.0.0.1:${serverPort}`,
+      failOnDiff: true,
+    });
+
+    await assert.rejects(
+      () => vizzlyScreenshot('homepage', Buffer.from('png-data')),
+      /Visual diff detected/
+    );
+  });
+
+  it('returns current 200 TDD diff responses when failOnDiff is disabled', async () => {
+    await closeServer(server);
+    requests = [];
+
+    server = createServer((req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        requests.push({ method: req.method, url: req.url });
+        res.setHeader('Content-Type', 'application/json');
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            success: true,
+            tddMode: true,
+            status: 'diff',
+            name: 'homepage',
+            diffPercentage: 5.2,
+          })
+        );
+      });
+    });
+
+    await startServer(server, serverPort);
+
+    configure({
+      enabled: true,
+      serverUrl: `http://127.0.0.1:${serverPort}`,
+      failOnDiff: false,
+    });
+
+    let result = await vizzlyScreenshot('homepage', Buffer.from('png-data'));
+
+    assert.strictEqual(result.status, 'diff');
+    assert.strictEqual(result.diffPercentage, 5.2);
+  });
+
+  it('applies failOnDiff changes to an already configured client', async () => {
+    await closeServer(server);
+    requests = [];
+
+    server = createServer((req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        requests.push({ method: req.method, url: req.url });
+        res.setHeader('Content-Type', 'application/json');
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            success: true,
+            tddMode: true,
+            status: 'diff',
+            name: 'homepage',
+            diffPercentage: 5.2,
+          })
+        );
+      });
+    });
+
+    await startServer(server, serverPort);
+
+    configure({
+      enabled: true,
+      serverUrl: `http://127.0.0.1:${serverPort}`,
+      failOnDiff: false,
+    });
+    configure({ failOnDiff: true });
+
+    assert.strictEqual(getVizzlyInfo().failOnDiff, true);
+    await assert.rejects(
+      () => vizzlyScreenshot('homepage', Buffer.from('png-data')),
+      /Visual diff detected/
+    );
+  });
+
   it('handles server error and disables SDK', async () => {
-    server.closeAllConnections();
-    await new Promise(resolve => server.close(resolve));
+    await closeServer(server);
     requests = [];
 
     server = createServer((req, res) => {
@@ -512,11 +781,9 @@ describe('client/index httpPost integration tests', () => {
       });
     });
 
-    await new Promise(resolve => {
-      server.listen(serverPort, () => resolve());
-    });
+    await startServer(server, serverPort);
 
-    configure({ enabled: true, serverUrl: `http://localhost:${serverPort}` });
+    configure({ enabled: true, serverUrl: `http://127.0.0.1:${serverPort}` });
     assert.strictEqual(isVizzlyReady(), true);
 
     let result = await vizzlyScreenshot('test', Buffer.from('data'));
@@ -527,8 +794,7 @@ describe('client/index httpPost integration tests', () => {
   });
 
   it('handles invalid JSON response gracefully', async () => {
-    server.closeAllConnections();
-    await new Promise(resolve => server.close(resolve));
+    await closeServer(server);
     requests = [];
 
     server = createServer((req, res) => {
@@ -541,11 +807,9 @@ describe('client/index httpPost integration tests', () => {
       });
     });
 
-    await new Promise(resolve => {
-      server.listen(serverPort, () => resolve());
-    });
+    await startServer(server, serverPort);
 
-    configure({ enabled: true, serverUrl: `http://localhost:${serverPort}` });
+    configure({ enabled: true, serverUrl: `http://127.0.0.1:${serverPort}` });
 
     // Should not throw - httpPost handles invalid JSON gracefully
     let result = await vizzlyScreenshot('test', Buffer.from('data'));
@@ -557,10 +821,9 @@ describe('client/index httpPost integration tests', () => {
 
   it('handles connection refused error', async () => {
     // Close the server to simulate connection refused
-    server.closeAllConnections();
-    await new Promise(resolve => server.close(resolve));
+    await closeServer(server);
 
-    configure({ enabled: true, serverUrl: 'http://localhost:59999' }); // Unlikely port
+    configure({ enabled: true, serverUrl: 'http://127.0.0.1:59999' }); // Unlikely port
     assert.strictEqual(isVizzlyReady(), true);
 
     let result = await vizzlyScreenshot('test', Buffer.from('data'));
@@ -571,7 +834,31 @@ describe('client/index httpPost integration tests', () => {
 
     // Restart server for cleanup
     server = createServer(() => {});
-    await new Promise(resolve => server.listen(serverPort, resolve));
+    await startServer(server, serverPort);
+  });
+
+  it('uses per-screenshot requestTimeout for SDK transport timeouts', async () => {
+    await closeServer(server);
+    requests = [];
+
+    server = createServer((req, _res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        requests.push({ method: req.method, url: req.url });
+      });
+    });
+
+    await startServer(server, serverPort);
+
+    configure({ enabled: true, serverUrl: `http://127.0.0.1:${serverPort}` });
+    assert.strictEqual(isVizzlyReady(), true);
+
+    let result = await vizzlyScreenshot('test', Buffer.from('data'), {
+      requestTimeout: 25,
+    });
+
+    assert.strictEqual(result, null);
+    assert.strictEqual(isVizzlyReady(), false);
   });
 
   it('makes HTTP request to flush endpoint', async () => {
@@ -583,5 +870,46 @@ describe('client/index httpPost integration tests', () => {
     let req = requests[0];
     assert.strictEqual(req.method, 'POST');
     assert.strictEqual(req.url, '/flush');
+  });
+
+  it('returns summary-shaped flush responses', async () => {
+    await closeServer(server);
+    requests = [];
+
+    server = createServer((req, res) => {
+      req.on('data', () => {});
+      req.on('end', () => {
+        requests.push({ method: req.method, url: req.url });
+        res.setHeader('Content-Type', 'application/json');
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            success: true,
+            summary: {
+              total: 2,
+              passed: 1,
+              failed: 0,
+              new: 1,
+              errors: 0,
+            },
+          })
+        );
+      });
+    });
+
+    await startServer(server, serverPort);
+
+    configure({ enabled: true, serverUrl: `http://127.0.0.1:${serverPort}` });
+
+    let result = await vizzlyFlush();
+
+    assert.strictEqual(result.success, true);
+    assert.deepStrictEqual(result.summary, {
+      total: 2,
+      passed: 1,
+      failed: 0,
+      new: 1,
+      errors: 0,
+    });
   });
 });

--- a/tests/sdk/client.test.js
+++ b/tests/sdk/client.test.js
@@ -365,9 +365,16 @@ describe('client/index httpPost integration tests', () => {
   let server;
   let serverPort;
   let requests = [];
+  let originalConsoleWarn;
+  let consoleWarnings = [];
 
   beforeEach(async () => {
     requests = [];
+    consoleWarnings = [];
+    originalConsoleWarn = console.warn;
+    console.warn = (...args) => {
+      consoleWarnings.push(args.join(' '));
+    };
 
     // Create a real HTTP server to test the httpPost function
     server = createServer((req, res) => {
@@ -429,13 +436,14 @@ describe('client/index httpPost integration tests', () => {
     // Close all keep-alive connections before closing server
     await closeServer(server);
     configure({ enabled: false });
+    console.warn = originalConsoleWarn;
   });
 
   it('makes HTTP POST request to screenshot endpoint', async () => {
     let result = await vizzlyScreenshot(
       'integration-test',
       Buffer.from('fake-png-data'),
-      { browser: 'chrome' }
+      { properties: { browser: 'chrome' } }
     );
 
     assert.strictEqual(result.success, true);
@@ -480,7 +488,6 @@ describe('client/index httpPost integration tests', () => {
     assert.strictEqual(threshold, undefined);
     assert.strictEqual(minClusterSize, undefined);
     assert.deepStrictEqual(properties, {
-      browser: 'firefox',
       url: 'http://localhost:3000',
       threshold: 0.1,
       minClusterSize: 4,
@@ -503,9 +510,40 @@ describe('client/index httpPost integration tests', () => {
       threshold: 0,
       minClusterSize: 2,
     });
+    assert.deepStrictEqual(
+      requests[0].body.warnings.map(warning => warning.option),
+      ['threshold', 'minClusterSize']
+    );
+    assert.ok(
+      consoleWarnings.some(warning =>
+        warning.includes('Move "threshold" out of properties')
+      )
+    );
   });
 
-  it('lets explicit top-level metadata override nested properties', async () => {
+  it('promotes reserved property options and returns warnings', async () => {
+    await vizzlyScreenshot('test', Buffer.from('data'), {
+      properties: {
+        theme: 'dark',
+        buildId: 'build-from-properties',
+        requestTimeout: 30_000,
+        threshold: 1,
+      },
+    });
+
+    assert.strictEqual(requests.length, 1);
+    assert.strictEqual(requests[0].body.buildId, 'build-from-properties');
+    assert.deepStrictEqual(requests[0].body.properties, {
+      theme: 'dark',
+      threshold: 1,
+    });
+    assert.deepStrictEqual(
+      requests[0].body.warnings.map(warning => warning.option),
+      ['buildId', 'requestTimeout', 'threshold']
+    );
+  });
+
+  it('ignores arbitrary top-level metadata outside the user properties bag', async () => {
     await vizzlyScreenshot('test', Buffer.from('data'), {
       browser: 'chromium',
       url: 'http://localhost:3000/current',
@@ -520,9 +558,9 @@ describe('client/index httpPost integration tests', () => {
 
     assert.strictEqual(requests.length, 1);
     assert.deepStrictEqual(requests[0].body.properties, {
-      browser: 'chromium',
-      url: 'http://localhost:3000/current',
-      viewport: { width: 1440, height: 900 },
+      browser: 'firefox',
+      url: 'http://stale.example',
+      viewport: { width: 375, height: 667 },
       theme: 'dark',
     });
   });

--- a/tests/sdk/index.test.js
+++ b/tests/sdk/index.test.js
@@ -171,6 +171,56 @@ describe('sdk/index', () => {
       assert.strictEqual(capturedUploadOptions.threshold, 0);
     });
 
+    it('uses nested config defaults and forwards upload tracking options', async () => {
+      let capturedUploadOptions = null;
+      let sdk = new VizzlySDK(
+        {
+          build: {
+            name: 'Config Build',
+            branch: 'feature/config',
+            commit: 'abc123',
+            message: 'Config message',
+            environment: 'staging',
+          },
+          comparison: {
+            threshold: 2,
+            minClusterSize: 4,
+          },
+          parallelId: 'config-parallel',
+          upload: { screenshotsDir: './configured-screenshots' },
+        },
+        {
+          createUploader: () => ({
+            upload: async uploadOptions => {
+              capturedUploadOptions = uploadOptions;
+              return { buildId: 'build-123' };
+            },
+          }),
+        }
+      );
+
+      await sdk.upload({
+        metadata: { ci: 'github' },
+        pullRequestNumber: 42,
+      });
+
+      assert.deepStrictEqual(capturedUploadOptions, {
+        screenshotsDir: './configured-screenshots',
+        buildName: 'Config Build',
+        branch: 'feature/config',
+        commit: 'abc123',
+        message: 'Config message',
+        environment: 'staging',
+        threshold: 2,
+        minClusterSize: 4,
+        metadata: { ci: 'github' },
+        pullRequestNumber: 42,
+        parallelId: 'config-parallel',
+        onProgress: capturedUploadOptions.onProgress,
+      });
+      assert.strictEqual(typeof capturedUploadOptions.onProgress, 'function');
+    });
+
     it('starts once, captures screenshots through the local server, and stops', async () => {
       let running = false;
       let stopped = false;

--- a/tests/server/handlers/tdd-handler.test.js
+++ b/tests/server/handlers/tdd-handler.test.js
@@ -693,6 +693,59 @@ describe('server/handlers/tdd-handler', () => {
         assert.strictEqual(result.body.tddMode, true);
       });
 
+      it('passes comparison metadata through to screenshot comparison', async () => {
+        let capturedProperties = null;
+        let deps = createMockDeps({
+          tddServiceOverrides: {
+            compareScreenshot: (_name, _imageBuffer, properties) => {
+              capturedProperties = properties;
+              return {
+                id: 'comp-dashboard',
+                name: 'dashboard',
+                status: 'passed',
+                baseline: '/baselines/dashboard.png',
+                current: '/current/dashboard.png',
+                diff: null,
+                threshold: properties.threshold,
+                minClusterSize: properties.minClusterSize,
+              };
+            },
+          },
+        });
+        let handler = createTddHandler({}, '/test', null, null, false, deps);
+
+        let result = await handler.handleScreenshot(
+          'build-1',
+          'dashboard',
+          'base64imagedata',
+          {
+            browser: 'firefox',
+            viewport: { width: 1280, height: 720 },
+            fullPage: false,
+            threshold: 0,
+            minClusterSize: 2,
+          }
+        );
+
+        assert.strictEqual(result.statusCode, 200);
+        assert.deepStrictEqual(capturedProperties, {
+          browser: 'firefox',
+          viewport: { width: 1280, height: 720 },
+          fullPage: false,
+          threshold: 0,
+          minClusterSize: 2,
+          viewport_width: 1280,
+          viewport_height: 720,
+          metadata: {
+            browser: 'firefox',
+            viewport: { width: 1280, height: 720 },
+            fullPage: false,
+            threshold: 0,
+            minClusterSize: 2,
+          },
+        });
+      });
+
       it('returns 400 for invalid screenshot name', async () => {
         let deps = createMockDeps({
           sanitizeScreenshotName: () => {

--- a/tests/server/routers/screenshot.test.js
+++ b/tests/server/routers/screenshot.test.js
@@ -232,6 +232,47 @@ describe('server/routers/screenshot', () => {
         assert.strictEqual(capturedType, undefined);
       });
 
+      it('forwards build id, image, properties, and type unchanged', async () => {
+        let capturedArgs = null;
+        let screenshotHandler = {
+          handleScreenshot: async (...args) => {
+            capturedArgs = args;
+            return { statusCode: 200, body: { success: true } };
+          },
+        };
+        let properties = {
+          browser: 'firefox',
+          viewport_width: 1280,
+          viewport_height: 720,
+          threshold: 0,
+          minClusterSize: 2,
+          fullPage: false,
+        };
+
+        let handler = createScreenshotRouter({
+          screenshotHandler,
+          defaultBuildId: 'default-build',
+        });
+        let req = createMockRequest('POST', {
+          buildId: 'build-from-sdk',
+          name: 'dashboard',
+          image: 'base64data',
+          properties,
+          type: 'base64',
+        });
+        let res = createMockResponse();
+
+        await handler(req, res, '/screenshot');
+
+        assert.deepStrictEqual(capturedArgs, [
+          'build-from-sdk',
+          'dashboard',
+          'base64data',
+          properties,
+          'base64',
+        ]);
+      });
+
       it('returns 400 when name is missing', async () => {
         let handler = createScreenshotRouter({
           screenshotHandler: createMockScreenshotHandler(),
@@ -281,6 +322,37 @@ describe('server/routers/screenshot', () => {
     });
 
     describe('/flush endpoint', () => {
+      it('flushes API-mode handlers before returning success', async () => {
+        let screenshotHandler = {
+          handleScreenshot: async () => ({
+            statusCode: 200,
+            body: { success: true },
+          }),
+          flush: async () => ({
+            uploaded: 2,
+            failed: 1,
+            total: 3,
+          }),
+        };
+        let handler = createScreenshotRouter({
+          screenshotHandler,
+          defaultBuildId: 'build-1',
+        });
+        let req = createMockRequest('POST', {});
+        let res = createMockResponse();
+
+        let result = await handler(req, res, '/flush');
+
+        assert.strictEqual(result, true);
+        assert.strictEqual(res.statusCode, 200);
+        assert.deepStrictEqual(res.getParsedBody(), {
+          success: true,
+          uploaded: 2,
+          failed: 1,
+          total: 3,
+        });
+      });
+
       it('returns summary when getResults is available', async () => {
         let handler = createScreenshotRouter({
           screenshotHandler: createMockScreenshotHandler({

--- a/tests/server/routers/screenshot.test.js
+++ b/tests/server/routers/screenshot.test.js
@@ -232,7 +232,7 @@ describe('server/routers/screenshot', () => {
         assert.strictEqual(capturedType, undefined);
       });
 
-      it('forwards build id, image, properties, and type unchanged', async () => {
+      it('forwards build id, image, properties, type, and warnings unchanged', async () => {
         let capturedArgs = null;
         let screenshotHandler = {
           handleScreenshot: async (...args) => {
@@ -259,6 +259,7 @@ describe('server/routers/screenshot', () => {
           image: 'base64data',
           properties,
           type: 'base64',
+          warnings: [{ code: 'reserved-property-option', option: 'threshold' }],
         });
         let res = createMockResponse();
 
@@ -270,6 +271,7 @@ describe('server/routers/screenshot', () => {
           'base64data',
           properties,
           'base64',
+          [{ code: 'reserved-property-option', option: 'threshold' }],
         ]);
       });
 

--- a/tests/services/build-manager.test.js
+++ b/tests/services/build-manager.test.js
@@ -10,6 +10,8 @@ describe('services/build-manager', () => {
           name: 'Test Build',
           branch: 'main',
           commit: 'abc123',
+          message: 'Test commit',
+          parallelId: 'parallel-1',
           metadata: { ci: true },
         },
         {
@@ -23,7 +25,9 @@ describe('services/build-manager', () => {
         name: 'Test Build',
         branch: 'main',
         commit: 'abc123',
+        message: 'Test commit',
         environment: 'test',
+        parallelId: 'parallel-1',
         metadata: { ci: true },
         status: 'pending',
         createdAt: '2026-05-18T12:00:00.000Z',
@@ -46,6 +50,18 @@ describe('services/build-manager', () => {
       assert.strictEqual(build.branch, 'main');
       assert.strictEqual(build.environment, 'test');
       assert.deepStrictEqual(build.metadata, {});
+    });
+
+    it('uses buildName as the name fallback', () => {
+      let build = createBuildObject(
+        { buildName: 'Fallback Build' },
+        {
+          randomId: () => 'fallback-id',
+          now: () => '2026-05-18T12:00:00.000Z',
+        }
+      );
+
+      assert.strictEqual(build.name, 'Fallback Build');
     });
   });
 });

--- a/tests/test-runner/core.test.js
+++ b/tests/test-runner/core.test.js
@@ -32,6 +32,7 @@ describe('test-runner/core', () => {
         VIZZLY_BUILD_ID: 'build-123',
         VIZZLY_ENABLED: 'true',
         VIZZLY_SET_BASELINE: 'false',
+        VIZZLY_FAIL_ON_DIFF: 'false',
       });
     });
 
@@ -44,6 +45,17 @@ describe('test-runner/core', () => {
       });
 
       assert.strictEqual(env.VIZZLY_SET_BASELINE, 'true');
+    });
+
+    it('sets VIZZLY_FAIL_ON_DIFF when failOnDiff is true', () => {
+      let env = buildTestEnv({
+        port: 3000,
+        buildId: 'build-abc',
+        failOnDiff: true,
+        baseEnv: {},
+      });
+
+      assert.strictEqual(env.VIZZLY_FAIL_ON_DIFF, 'true');
     });
 
     it('preserves existing environment variables', () => {
@@ -66,6 +78,7 @@ describe('test-runner/core', () => {
       });
 
       assert.strictEqual(env.VIZZLY_SET_BASELINE, 'false');
+      assert.strictEqual(env.VIZZLY_FAIL_ON_DIFF, 'false');
     });
   });
 

--- a/tests/uploader/core.test.js
+++ b/tests/uploader/core.test.js
@@ -177,6 +177,11 @@ describe('uploader/core', () => {
         message: 'Test commit',
         environment: 'staging',
         threshold: 0.05,
+        minClusterSize: 4,
+        metadata: {
+          ci: 'github',
+          comparison: { threshold: 9 },
+        },
         pullRequestNumber: 42,
         parallelId: 'parallel-1',
       };
@@ -190,6 +195,13 @@ describe('uploader/core', () => {
         commit_message: 'Test commit',
         environment: 'staging',
         threshold: 0.05,
+        metadata: {
+          ci: 'github',
+          comparison: {
+            threshold: 0.05,
+            minClusterSize: 4,
+          },
+        },
         github_pull_request_number: 42,
         parallel_id: 'parallel-1',
       });
@@ -393,8 +405,12 @@ describe('uploader/core', () => {
         status: 'completed',
         build,
         comparisons: 10,
+        totalComparisons: 10,
         passedComparisons: 8,
         failedComparisons: 2,
+        newComparisons: 0,
+        identicalComparisons: 8,
+        approvalStatus: 'pending',
         url: 'https://example.com/builds/123',
       });
     });
@@ -405,7 +421,34 @@ describe('uploader/core', () => {
 
       assert.strictEqual(result.passedComparisons, 0);
       assert.strictEqual(result.failedComparisons, 0);
+      assert.strictEqual(result.totalComparisons, 0);
+      assert.strictEqual(result.newComparisons, 0);
       assert.strictEqual(result.comparisons, undefined);
+    });
+
+    it('supports snake_case comparison fields from the API', () => {
+      let build = {
+        id: 'build-123',
+        status: 'completed',
+        total_comparisons: 4,
+        passed_comparisons: 1,
+        changed_comparisons: 2,
+        new_comparisons: 1,
+        identical_comparisons: 1,
+        approval_status: 'approved',
+        url: 'https://example.com/builds/123',
+      };
+
+      let result = buildWaitResult(build);
+
+      assert.strictEqual(result.comparisons, 4);
+      assert.strictEqual(result.totalComparisons, 4);
+      assert.strictEqual(result.passedComparisons, 1);
+      assert.strictEqual(result.failedComparisons, 2);
+      assert.strictEqual(result.newComparisons, 1);
+      assert.strictEqual(result.identicalComparisons, 1);
+      assert.strictEqual(result.approvalStatus, 'approved');
+      assert.strictEqual(result.url, 'https://example.com/builds/123');
     });
 
     it('handles missing URL', () => {

--- a/tests/uploader/index.test.js
+++ b/tests/uploader/index.test.js
@@ -108,6 +108,7 @@ describe('uploader/createUploader', () => {
           buildName: 'Release screenshots',
           branch: 'feature/reports',
           environment: 'staging',
+          minClusterSize: 2,
           onProgress: event => progress.push(event),
         });
 
@@ -128,6 +129,11 @@ describe('uploader/createUploader', () => {
           commit_message: undefined,
           environment: 'staging',
           threshold: undefined,
+          metadata: {
+            comparison: {
+              minClusterSize: 2,
+            },
+          },
           github_pull_request_number: undefined,
           parallel_id: undefined,
         });
@@ -187,6 +193,53 @@ describe('uploader/createUploader', () => {
           total: 2,
           uploaded: 1,
           skipped: 1,
+        });
+      }
+    );
+  });
+
+  it('uploads every screenshot without SHA dedupe when uploadAll is enabled', async () => {
+    await withScreenshots(
+      {
+        'home-chrome.png': Buffer.from('home'),
+        'settings-firefox.png': Buffer.from('settings'),
+      },
+      async screenshotsDir => {
+        let files = [
+          join(screenshotsDir, 'home-chrome.png'),
+          join(screenshotsDir, 'settings-firefox.png'),
+        ];
+        let checkShasCalled = false;
+        let uploadedFiles;
+        let client = {
+          request: async (_path, options) => {
+            uploadedFiles = options.body.getAll('screenshots');
+            return { url: 'https://app.test/builds/build-123' };
+          },
+        };
+        let uploader = createTestUploader(
+          {},
+          {
+            client,
+            glob: async () => files,
+            checkShas: async () => {
+              checkShasCalled = true;
+              return { existing: [] };
+            },
+          }
+        );
+
+        let result = await uploader.upload({
+          screenshotsDir,
+          uploadAll: true,
+        });
+
+        assert.equal(checkShasCalled, false);
+        assert.equal(uploadedFiles.length, 2);
+        assert.deepEqual(result.stats, {
+          total: 2,
+          uploaded: 2,
+          skipped: 0,
         });
       }
     );

--- a/tests/utils/config-loader.test.js
+++ b/tests/utils/config-loader.test.js
@@ -57,6 +57,8 @@ describe('utils/config-loader', () => {
         VIZZLY_API_URL: process.env.VIZZLY_API_URL,
         VIZZLY_BUILD_NAME: process.env.VIZZLY_BUILD_NAME,
         VIZZLY_PARALLEL_ID: process.env.VIZZLY_PARALLEL_ID,
+        VIZZLY_THRESHOLD: process.env.VIZZLY_THRESHOLD,
+        VIZZLY_MIN_CLUSTER_SIZE: process.env.VIZZLY_MIN_CLUSTER_SIZE,
         VIZZLY_HOME: process.env.VIZZLY_HOME,
       };
 
@@ -64,6 +66,8 @@ describe('utils/config-loader', () => {
       delete process.env.VIZZLY_TOKEN;
       delete process.env.VIZZLY_BUILD_NAME;
       delete process.env.VIZZLY_PARALLEL_ID;
+      delete process.env.VIZZLY_THRESHOLD;
+      delete process.env.VIZZLY_MIN_CLUSTER_SIZE;
 
       // Create test directory
       if (existsSync(testDir)) {
@@ -138,6 +142,16 @@ describe('utils/config-loader', () => {
 
       assert.strictEqual(config.apiKey, 'env-token');
       assert.strictEqual(config.parallelId, 'parallel-123');
+    });
+
+    it('applies comparison environment variable overrides', async () => {
+      process.env.VIZZLY_THRESHOLD = '0';
+      process.env.VIZZLY_MIN_CLUSTER_SIZE = '1';
+
+      let config = await loadConfig();
+
+      assert.strictEqual(config.comparison.threshold, 0);
+      assert.strictEqual(config.comparison.minClusterSize, 1);
     });
 
     it('keeps user login separate from cloud upload credentials', async () => {

--- a/tests/utils/context.test.js
+++ b/tests/utils/context.test.js
@@ -1,6 +1,13 @@
 import assert from 'node:assert';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import { getContext, getDetailedContext } from '../../src/utils/context.js';
@@ -9,16 +16,13 @@ describe('utils/context', () => {
   let testDir;
   let originalCwd;
   let originalEnv;
-  let originalVizzlyHome;
 
   beforeEach(() => {
     originalCwd = process.cwd();
     originalEnv = { ...process.env };
-    originalVizzlyHome = process.env.VIZZLY_HOME;
 
-    // Create a temp directory for testing
-    testDir = join(homedir(), `.vizzly-test-context-${Date.now()}`);
-    mkdirSync(testDir, { recursive: true });
+    // Create a unique temp directory for testing.
+    testDir = realpathSync(mkdtempSync(join(tmpdir(), 'vizzly-test-context-')));
 
     // Set VIZZLY_HOME to our test dir to isolate from real config
     process.env.VIZZLY_HOME = join(testDir, 'vizzly-home');
@@ -28,9 +32,6 @@ describe('utils/context', () => {
   afterEach(() => {
     process.chdir(originalCwd);
     process.env = originalEnv;
-    if (originalVizzlyHome) {
-      process.env.VIZZLY_HOME = originalVizzlyHome;
-    }
 
     // Clean up test directory
     if (testDir && existsSync(testDir)) {

--- a/tests/utils/environment-config.test.js
+++ b/tests/utils/environment-config.test.js
@@ -7,8 +7,10 @@ import {
   getBuildId,
   getBuildName,
   getLogLevel,
+  getMinClusterSize,
   getParallelId,
   getServerUrl,
+  getThreshold,
   getUserAgent,
   getVizzlyHome,
   isTddMode,
@@ -33,6 +35,8 @@ describe('utils/environment-config', () => {
       'VIZZLY_BUILD_ID',
       'VIZZLY_BUILD_NAME',
       'VIZZLY_PARALLEL_ID',
+      'VIZZLY_THRESHOLD',
+      'VIZZLY_MIN_CLUSTER_SIZE',
       'VIZZLY_TDD',
     ];
     for (let v of vizzlyVars) {
@@ -170,6 +174,30 @@ describe('utils/environment-config', () => {
     });
   });
 
+  describe('getThreshold', () => {
+    it('returns undefined when not set', () => {
+      assert.strictEqual(getThreshold(), undefined);
+    });
+
+    it('returns VIZZLY_THRESHOLD as a number when set', () => {
+      process.env.VIZZLY_THRESHOLD = '0';
+
+      assert.strictEqual(getThreshold(), 0);
+    });
+  });
+
+  describe('getMinClusterSize', () => {
+    it('returns undefined when not set', () => {
+      assert.strictEqual(getMinClusterSize(), undefined);
+    });
+
+    it('returns VIZZLY_MIN_CLUSTER_SIZE as a number when set', () => {
+      process.env.VIZZLY_MIN_CLUSTER_SIZE = '3';
+
+      assert.strictEqual(getMinClusterSize(), 3);
+    });
+  });
+
   describe('isTddMode', () => {
     it('returns false when not set', () => {
       assert.strictEqual(isTddMode(), false);
@@ -229,6 +257,8 @@ describe('utils/environment-config', () => {
         buildId: undefined,
         buildName: undefined,
         parallelId: undefined,
+        threshold: undefined,
+        minClusterSize: undefined,
         tddMode: false,
       });
     });
@@ -244,6 +274,8 @@ describe('utils/environment-config', () => {
       process.env.VIZZLY_BUILD_ID = 'build';
       process.env.VIZZLY_BUILD_NAME = 'My Build';
       process.env.VIZZLY_PARALLEL_ID = 'parallel';
+      process.env.VIZZLY_THRESHOLD = '1.5';
+      process.env.VIZZLY_MIN_CLUSTER_SIZE = '4';
       process.env.VIZZLY_TDD = 'true';
 
       let config = getAllEnvironmentConfig();
@@ -259,6 +291,8 @@ describe('utils/environment-config', () => {
         buildId: 'build',
         buildName: 'My Build',
         parallelId: 'parallel',
+        threshold: 1.5,
+        minClusterSize: 4,
         tddMode: true,
       });
     });

--- a/tests/utils/output-tui.test.js
+++ b/tests/utils/output-tui.test.js
@@ -97,12 +97,13 @@ describe('Output - TUI Helpers', () => {
       assert.ok(lastCall.arguments.join(' ').includes('Operation completed'));
     });
 
-    it('outputs JSON in json mode', () => {
+    it('outputs JSON status to stderr in json mode', () => {
       configure({ json: true });
       success('Done', { extra: 'data' });
 
-      assert.strictEqual(consoleLogMock.mock.calls.length, 1);
-      let output = JSON.parse(consoleLogMock.mock.calls[0].arguments[0]);
+      assert.strictEqual(consoleLogMock.mock.calls.length, 0);
+      assert.strictEqual(consoleErrorMock.mock.calls.length, 1);
+      let output = JSON.parse(consoleErrorMock.mock.calls[0].arguments[0]);
       assert.strictEqual(output.status, 'success');
       assert.strictEqual(output.message, 'Done');
       assert.strictEqual(output.extra, 'data');
@@ -130,11 +131,13 @@ describe('Output - TUI Helpers', () => {
       assert.ok(output.includes('·'));
     });
 
-    it('outputs JSON in json mode', () => {
+    it('outputs JSON status to stderr in json mode', () => {
       configure({ json: true });
       result('Done');
 
-      let output = JSON.parse(consoleLogMock.mock.calls[0].arguments[0]);
+      assert.strictEqual(consoleLogMock.mock.calls.length, 0);
+      assert.strictEqual(consoleErrorMock.mock.calls.length, 1);
+      let output = JSON.parse(consoleErrorMock.mock.calls[0].arguments[0]);
       assert.strictEqual(output.status, 'complete');
       assert.strictEqual(output.message, 'Done');
       assert.ok(output.elapsed);
@@ -453,11 +456,13 @@ describe('Output - TUI Helpers', () => {
       assert.ok(output.includes('in 2.3s'));
     });
 
-    it('outputs JSON in json mode', () => {
+    it('outputs JSON status to stderr in json mode', () => {
       configure({ json: true });
       complete('Done', { detail: 'extra' });
 
-      let output = JSON.parse(consoleLogMock.mock.calls[0].arguments[0]);
+      assert.strictEqual(consoleLogMock.mock.calls.length, 0);
+      assert.strictEqual(consoleErrorMock.mock.calls.length, 1);
+      let output = JSON.parse(consoleErrorMock.mock.calls[0].arguments[0]);
       assert.strictEqual(output.status, 'complete');
       assert.strictEqual(output.message, 'Done');
       assert.strictEqual(output.detail, 'extra');

--- a/tests/utils/project-link-store.test.js
+++ b/tests/utils/project-link-store.test.js
@@ -78,6 +78,26 @@ describe('utils/project-link-store', () => {
     assert.strictEqual(activeLink.projectSlug, 'storybook');
   });
 
+  it('round-trips linked project token expiration', async () => {
+    let store = createConfigStore();
+
+    await saveProjectLink(
+      createLink({ expiresAt: '2026-06-01T00:00:00.000Z' }),
+      {
+        loadConfig: store.loadConfig,
+        saveConfig: store.saveConfig,
+        saveSecret: async () => false,
+      }
+    );
+
+    let activeLink = await getActiveProjectLink(
+      { apiUrl: 'https://app.vizzly.dev' },
+      { loadConfig: store.loadConfig }
+    );
+
+    assert.strictEqual(activeLink.expiresAt, '2026-06-01T00:00:00.000Z');
+  });
+
   it('keeps linked project tokens out of config when the secure store is available', async () => {
     let store = createConfigStore();
     let secrets = new Map();

--- a/tests/utils/screenshot-options.test.js
+++ b/tests/utils/screenshot-options.test.js
@@ -66,13 +66,7 @@ describe('createScreenshotProperties', () => {
     assert.strictEqual(normalized.requestTimeout, 60_000);
     assert.deepStrictEqual(
       normalized.warnings.map(warning => warning.option),
-      [
-        'threshold',
-        'minClusterSize',
-        'fullPage',
-        'buildId',
-        'requestTimeout',
-      ]
+      ['threshold', 'minClusterSize', 'fullPage', 'buildId', 'requestTimeout']
     );
   });
 

--- a/tests/utils/screenshot-options.test.js
+++ b/tests/utils/screenshot-options.test.js
@@ -37,4 +37,25 @@ describe('createScreenshotProperties', () => {
       minClusterSize: 2,
     });
   });
+
+  it('lets explicit top-level metadata override nested properties', () => {
+    let properties = createScreenshotProperties({
+      browser: 'chromium',
+      url: 'http://localhost:3000/current',
+      viewport: { width: 1440, height: 900 },
+      properties: {
+        browser: 'firefox',
+        url: 'http://stale.example',
+        viewport: { width: 375, height: 667 },
+        theme: 'dark',
+      },
+    });
+
+    assert.deepStrictEqual(properties, {
+      browser: 'chromium',
+      url: 'http://localhost:3000/current',
+      viewport: { width: 1440, height: 900 },
+      theme: 'dark',
+    });
+  });
 });

--- a/tests/utils/screenshot-options.test.js
+++ b/tests/utils/screenshot-options.test.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { createScreenshotProperties } from '../../src/utils/screenshot-options.js';
+import {
+  createScreenshotProperties,
+  normalizeScreenshotOptions,
+} from '../../src/utils/screenshot-options.js';
 
 describe('createScreenshotProperties', () => {
   it('normalizes comparison options into the server properties payload', () => {
@@ -14,7 +17,6 @@ describe('createScreenshotProperties', () => {
     });
 
     assert.deepStrictEqual(properties, {
-      browser: 'chromium',
       url: '/checkout',
       threshold: 0,
       minClusterSize: 3,
@@ -23,7 +25,7 @@ describe('createScreenshotProperties', () => {
   });
 
   it('lets dedicated comparison options override nested properties', () => {
-    let properties = createScreenshotProperties({
+    let normalized = normalizeScreenshotOptions({
       threshold: 1,
       minClusterSize: 2,
       properties: {
@@ -32,13 +34,49 @@ describe('createScreenshotProperties', () => {
       },
     });
 
-    assert.deepStrictEqual(properties, {
+    assert.deepStrictEqual(normalized.properties, {
       threshold: 1,
       minClusterSize: 2,
     });
+    assert.deepStrictEqual(
+      normalized.warnings.map(warning => warning.option),
+      ['threshold', 'minClusterSize']
+    );
   });
 
-  it('lets explicit top-level metadata override nested properties', () => {
+  it('promotes reserved property options when top-level options are absent', () => {
+    let normalized = normalizeScreenshotOptions({
+      properties: {
+        theme: 'dark',
+        threshold: 0.2,
+        minClusterSize: 5,
+        fullPage: true,
+        buildId: 'build-from-properties',
+        requestTimeout: 60_000,
+      },
+    });
+
+    assert.deepStrictEqual(normalized.properties, {
+      theme: 'dark',
+      threshold: 0.2,
+      minClusterSize: 5,
+      fullPage: true,
+    });
+    assert.strictEqual(normalized.buildId, 'build-from-properties');
+    assert.strictEqual(normalized.requestTimeout, 60_000);
+    assert.deepStrictEqual(
+      normalized.warnings.map(warning => warning.option),
+      [
+        'threshold',
+        'minClusterSize',
+        'fullPage',
+        'buildId',
+        'requestTimeout',
+      ]
+    );
+  });
+
+  it('ignores arbitrary top-level metadata outside the user properties bag', () => {
     let properties = createScreenshotProperties({
       browser: 'chromium',
       url: 'http://localhost:3000/current',
@@ -52,9 +90,9 @@ describe('createScreenshotProperties', () => {
     });
 
     assert.deepStrictEqual(properties, {
-      browser: 'chromium',
-      url: 'http://localhost:3000/current',
-      viewport: { width: 1440, height: 900 },
+      browser: 'firefox',
+      url: 'http://stale.example',
+      viewport: { width: 375, height: 667 },
       theme: 'dark',
     });
   });


### PR DESCRIPTION
## Why

This PR is the foundation for the SDK alignment stack. The later SDK PRs depend on this one because this is where the CLI, JS client, uploader, local TDD server, API helpers, config loading, environment loading, and public types agree on the same option contract.

The problem was not one isolated bug. It was drift across entry points. Users could set an option in one place and have it work, then set the same conceptual option through config, env, `vizzly run`, `vizzly upload`, TDD, or the JS client and have it get dropped, renamed, serialized into the wrong place, or returned in a different result shape.

That is especially risky for visual testing because options are part of the product contract. If we say `threshold`, `minClusterSize`, `buildId`, `parallelId`, PR metadata, or request timeout exists, users should be able to trust where it goes and what it changes.

## What changed

### Option and config contract

- Threads build metadata through the core paths: build name, branch, commit, message, environment, PR number, and parallel ID.
- Threads comparison metadata through upload/run/TDD/SDK paths, including `threshold` and `minClusterSize`.
- Adds env support for `VIZZLY_THRESHOLD` and `VIZZLY_MIN_CLUSTER_SIZE`.
- Makes upload helpers read the current nested config shape (`build.*`, `comparison.*`, `parallelId`) instead of stale top-level aliases.
- Keeps `requestTimeout` and `buildId` as transport/request options rather than screenshot metadata.

### Screenshot properties contract

- Treats `properties` as the user metadata bag.
- Stops accepting arbitrary top-level keys as screenshot metadata. SDK/config options need to stay top-level and typed.
- Strips reserved/config options from `properties` when users accidentally put them there.
- Promotes those reserved values to the correct option behavior when there is no top-level value already set.
- Emits warnings through the CLI/JS client path and includes warnings in screenshot/TDD/API responses so the local UI can surface the issue.

This matters because silently accepting `properties: { threshold: 0.1 }` as metadata is misleading. The user meant comparison behavior, not a random stored metadata key. We now normalize it into the right place and tell them what happened.

### CLI behavior

- Parses global `--token` before plugin loading so plugins see the same auth context as normal commands.
- Adds and validates `upload --min-cluster-size`.
- Makes `upload --wait` fail when completed comparisons contain failures, including JSON mode.
- Makes `run --json --wait` wait for the build result before emitting final JSON.
- Emits structured JSON skip payloads for Vizzly 5xx/API-unavailable paths while keeping infrastructure failures non-fatal to the user’s test run.
- Rejects `api --data` unless the method is POST.
- Tightens `preview --base` path resolution and JSON output.
- Lets `project link` respect a CLI token override before stored login state.

### JS client and local TDD

- Gives `getVizzlyInfo()` stable values and reports missing optional values as `null`.
- Lets `configure({ failOnDiff })` update an existing configured client.
- Reads `VIZZLY_FAIL_ON_DIFF` and local daemon server info through the same behavior path.
- Sends per-screenshot `buildId` as a request build ID.
- Applies per-screenshot `requestTimeout` to the HTTP request.
- Lets TDD diff responses either return for summary collection or throw when `failOnDiff` is enabled.

### API, uploader, and build results

- Preserves comparison metadata in upload build metadata.
- Makes `uploadAll` truly bypass SHA deduplication.
- Normalizes wait result comparison counts from both camelCase and snake_case API fields.
- Preserves build name, commit message, and parallel ID in local build objects.
- Lets the screenshot router prefer a handler-level `flush()` result when available.

### Public types

- Expands the public option/result types to describe the contract the code now supports.
- Removes the loose top-level screenshot option escape hatch so TypeScript users are guided toward explicit SDK options and `properties` for metadata.
- Updates type tests for build/request/comparison fields and result shapes.

## Testing

This PR adds focused coverage at the boundaries users actually touch:

- CLI JSON behavior for progress/success separation, wait output, and 5xx skip payloads.
- Plugin token loading before plugin initialization.
- `run`, `upload`, and `tdd` option precedence from CLI/config/env/git detection.
- Upload metadata, session writing, wait failure exit behavior, `uploadAll`, and comparison settings.
- JS client HTTP integration for metadata normalization, transport-only fields, warning propagation, flush results, request timeouts, and `failOnDiff`.
- API request validation, preview path resolution, project token override, daemon server info, build-manager fields, screenshot router behavior, config/env loading, context rendering, and output/TUI behavior.

One honest note: this does not add the broad visual-diff E2E matrix we still want. The current tests prove the option contract through CLI/client/server boundaries, but a follow-up should run a tiny fixture app end to end, intentionally create a visual diff, and assert the real CLI/API/dashboard outputs without mocking our own code.

## Review guide

1. Start with `src/utils/screenshot-options.js`, `src/client/index.js`, `src/sdk/index.js`, and `src/server/routers/screenshot.js` for the screenshot option/property contract.
2. Review option sources in `src/cli.js`, `src/utils/config-loader.js`, and `src/utils/environment-config.js`.
3. Follow the values into `src/commands/run.js`, `src/commands/upload.js`, `src/commands/tdd.js`, `src/commands/api.js`, `src/commands/preview.js`, and `src/commands/project.js`.
4. Check upload/build result normalization in `src/uploader/*`, `src/test-runner/*`, and `src/services/build-manager.js`.
5. Check public types in `src/types/*.d.ts` and `test-d/*`.

## Verification

- Full preservation branch verification before splitting: `pnpm test`, `pnpm run lint`, `pnpm run test:types`, `git diff --check`.
- Focused post-split verification: `node --test tests/utils/screenshot-options.test.js tests/sdk/client.test.js tests/server/routers/screenshot.test.js`.
- Focused post-split verification: `node --test tests/server/handlers/api-handler.test.js tests/server/handlers/tdd-handler.test.js`.
- Focused post-split verification: `CI=true pnpm run test:types`.
- Stack cleanup verification: `git diff --check` and PR file-list checks for #283 through #287.
