### PR TITLE
✨ Align Vitest and Ember SDKs

### DIFF
--- a/clients/ember/README.md
+++ b/clients/ember/README.md
@@ -184,8 +184,16 @@ await vizzlyScreenshot('screenshot-name', {
     user: 'admin'
   },
 
-  // Fail test if visual diff detected (overrides --fail-on-diff flag)
-  failOnDiff: true
+  // Comparison tuning
+  threshold: 5,
+  minClusterSize: 10,
+
+  // Fail this test if a visual diff is detected
+  failOnDiff: true,
+
+  // Optional per-screenshot transport options
+  buildId: 'build_123',
+  requestTimeout: 60000
 });
 ```
 
@@ -197,9 +205,21 @@ await vizzlyScreenshot('screenshot-name', {
 | `height` | number | 720 | Viewport height for the screenshot |
 | `selector` | string | null | CSS selector to capture specific element |
 | `scope` | string | 'app' | What to capture: `'app'` (just #ember-testing), `'container'`, or `'page'` (full page including QUnit) |
-| `fullPage` | boolean | false | Capture full scrollable content |
+| `fullPage` | boolean | false | Capture full scrollable content for `scope: 'page'`; app, container, and selector captures are element-sized |
 | `properties` | object | {} | Custom metadata attached to the screenshot |
-| `failOnDiff` | boolean | null | Fail the test when visual diff is detected. `null` uses the `--fail-on-diff` CLI flag. |
+| `threshold` | number | null | Vizzly comparison threshold. `null` uses the server config. |
+| `minClusterSize` | number | null | Ignore connected diff clusters smaller than this size. `null` uses the server config. |
+| `failOnDiff` | boolean | null | Fail the test when visual diff is detected. `null` uses the launcher/server setting; explicit `true` or `false` overrides it for this screenshot. |
+| `buildId` | string | injected | Build ID override for this screenshot. Defaults to the build ID injected by `vizzly run`. |
+| `requestTimeout` | number | null | HTTP request timeout in milliseconds for sending this screenshot to Vizzly. |
+
+`failOnDiff` is resolved in this order: the per-screenshot option, the launcher
+setting injected from `VIZZLY_FAIL_ON_DIFF` or `.vizzly/server.json`, then
+non-failing mode.
+
+Each screenshot also includes Vizzly metadata for grouping and comparison:
+`browser`, `viewport_width`, `viewport_height`, `url`, and any custom
+`properties` you provide.
 
 The function automatically:
 - Waits for Ember's `settled()` before capturing
@@ -248,6 +268,7 @@ For CI environments, ensure:
 
 1. Browsers are installed: `pnpm exec playwright install chromium`
 2. Vizzly token is set: `VIZZLY_TOKEN=your-token`
+3. Tests run through the Vizzly CLI wrapper so cloud uploads are finalized
 
 ```yaml
 # GitHub Actions example
@@ -257,7 +278,7 @@ For CI environments, ensure:
 - name: Run Tests
   env:
     VIZZLY_TOKEN: ${{ secrets.VIZZLY_TOKEN }}
-  run: ember test
+  run: pnpm exec vizzly run "ember test"
 ```
 
 ### Failing on Visual Diffs

--- a/clients/ember/bin/vizzly-testem-launcher.js
+++ b/clients/ember/bin/vizzly-testem-launcher.js
@@ -119,6 +119,7 @@ async function main() {
     browserInstance = await launchBrowser(browserType, testUrl, {
       screenshotUrl,
       failOnDiff,
+      buildId: process.env.VIZZLY_BUILD_ID || null,
       playwrightOptions,
       onPageCreated: page => {
         setPage(page);

--- a/clients/ember/package.json
+++ b/clients/ember/package.json
@@ -43,8 +43,8 @@
     "bin",
     "src",
     "README.md",
-    "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "scripts": {
     "test": "node --test --test-reporter=spec 'tests/unit/**/*.test.js'",

--- a/clients/ember/src/launcher/browser.js
+++ b/clients/ember/src/launcher/browser.js
@@ -38,16 +38,11 @@ function isCI() {
  * Get default Chromium args for stability
  * @returns {string[]}
  */
-function getDefaultChromiumArgs() {
+export function getDefaultChromiumArgs() {
   let args = ['--no-sandbox', '--disable-setuid-sandbox'];
 
   if (isCI()) {
-    args.push(
-      '--disable-dev-shm-usage',
-      '--disable-gpu',
-      '--disable-software-rasterizer',
-      '--disable-extensions'
-    );
+    args.push('--disable-dev-shm-usage', '--disable-extensions');
   }
 
   return args;
@@ -61,6 +56,7 @@ function getDefaultChromiumArgs() {
  * @param {Object} options - Launch options
  * @param {string} options.screenshotUrl - URL of the screenshot HTTP server
  * @param {boolean} [options.failOnDiff] - Whether tests should fail on visual diffs
+ * @param {string|null} [options.buildId] - Build ID to attach to screenshots
  * @param {Object} [options.playwrightOptions] - Playwright launch options (headless, slowMo, timeout, etc.)
  * @param {Function} [options.onPageCreated] - Callback when page is created (before navigation)
  * @param {Function} [options.onBrowserDisconnected] - Callback when browser disconnects unexpectedly
@@ -70,6 +66,7 @@ export async function launchBrowser(browserType, testUrl, options = {}) {
   let {
     screenshotUrl,
     failOnDiff,
+    buildId = null,
     playwrightOptions = {},
     onPageCreated,
     onBrowserDisconnected,
@@ -114,11 +111,12 @@ export async function launchBrowser(browserType, testUrl, options = {}) {
 
   // Inject Vizzly config into page context BEFORE navigation
   await page.addInitScript(
-    ({ screenshotUrl, failOnDiff }) => {
+    ({ screenshotUrl, failOnDiff, buildId }) => {
       window.__VIZZLY_SCREENSHOT_URL__ = screenshotUrl;
       window.__VIZZLY_FAIL_ON_DIFF__ = failOnDiff;
+      window.__VIZZLY_BUILD_ID__ = buildId;
     },
-    { screenshotUrl, failOnDiff }
+    { screenshotUrl, failOnDiff, buildId }
   );
 
   // Call onPageCreated callback BEFORE navigation

--- a/clients/ember/src/launcher/screenshot-server.js
+++ b/clients/ember/src/launcher/screenshot-server.js
@@ -111,37 +111,43 @@ export function clearServerInfoCache() {
  * @param {string} name - Screenshot name
  * @param {Buffer} imageBuffer - PNG image data
  * @param {Object} properties - Screenshot metadata
+ * @param {Object} [options] - Forwarding options
+ * @param {string|null} [options.buildId] - Build ID to attach to screenshot
+ * @param {number|null} [options.requestTimeout] - HTTP request timeout in milliseconds
  * @returns {Promise<Object>} Response from TDD server
  */
-async function forwardToVizzly(name, imageBuffer, properties = {}) {
+async function forwardToVizzly(
+  name,
+  imageBuffer,
+  properties = {},
+  { buildId = null, requestTimeout = null } = {}
+) {
   let serverInfo = autoDiscoverTddServer();
 
   if (!serverInfo) {
-    // Check for cloud mode via environment
-    if (process.env.VIZZLY_TOKEN) {
-      // In cloud mode, we'd queue for upload
-      // For MVP, return success and let TDD server handle cloud forwarding
-      return { success: true, mode: 'cloud', queued: true };
-    }
-
     throw new Error(
-      'No Vizzly server found. Run `vizzly tdd start` first, or set VIZZLY_TOKEN for cloud mode.'
+      'No Vizzly server found. Run `vizzly tdd start` first, or run tests through `vizzly run` for cloud uploads.'
     );
   }
 
   let tddServerUrl = serverInfo.url;
 
   let payload = {
+    ...(buildId ? { buildId } : {}),
     name,
     image: imageBuffer.toString('base64'),
     properties: {
-      framework: 'ember',
       ...properties,
+      framework: 'ember',
     },
   };
 
   // Use node:http directly with Connection: close to prevent keep-alive hangs
-  let result = await httpPost(`${tddServerUrl}/screenshot`, payload);
+  let result = await httpPost(
+    `${tddServerUrl}/screenshot`,
+    payload,
+    requestTimeout
+  );
   return result;
 }
 
@@ -149,9 +155,10 @@ async function forwardToVizzly(name, imageBuffer, properties = {}) {
  * Make HTTP POST request without keep-alive (prevents process hang on shutdown)
  * @param {string} url - Target URL
  * @param {Object} data - JSON payload
+ * @param {number|null} [timeoutMs] - Request timeout in milliseconds
  * @returns {Promise<Object>} Parsed JSON response
  */
-function httpPost(url, data) {
+function httpPost(url, data, timeoutMs = null) {
   return new Promise((resolve, reject) => {
     let parsedUrl = new URL(url);
     let isHttps = parsedUrl.protocol === 'https:';
@@ -197,6 +204,14 @@ function httpPost(url, data) {
     });
 
     req.on('error', reject);
+
+    if (timeoutMs) {
+      req.setTimeout(timeoutMs, () => {
+        req.destroy();
+        reject(new Error('Request timeout'));
+      });
+    }
+
     req.write(body);
     req.end();
   });
@@ -216,7 +231,15 @@ async function handleScreenshot(req, res) {
 
   req.on('end', async () => {
     try {
-      let { name, selector, fullPage, properties } = JSON.parse(body);
+      let {
+        buildId,
+        name,
+        selector,
+        fullPage,
+        properties,
+        viewport,
+        requestTimeout,
+      } = JSON.parse(body);
 
       if (!name) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -239,8 +262,20 @@ async function handleScreenshot(req, res) {
       };
 
       let imageBuffer;
+      if (
+        viewport?.width &&
+        viewport?.height &&
+        typeof pageRef.setViewportSize === 'function'
+      ) {
+        await pageRef.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+      }
 
       if (selector) {
+        delete screenshotOptions.fullPage;
+
         // Capture specific element
         let element = pageRef.locator(selector).first();
         let elementHandle = await element.elementHandle();
@@ -258,7 +293,10 @@ async function handleScreenshot(req, res) {
       }
 
       // Forward to Vizzly TDD server
-      let result = await forwardToVizzly(name, imageBuffer, properties);
+      let result = await forwardToVizzly(name, imageBuffer, properties, {
+        buildId,
+        requestTimeout,
+      });
 
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(result));

--- a/clients/ember/src/test-support/index.js
+++ b/clients/ember/src/test-support/index.js
@@ -182,12 +182,16 @@ function shouldFailOnDiff() {
  * @param {string} name - Unique name for this screenshot
  * @param {Object} [options] - Screenshot options
  * @param {string} [options.selector] - CSS selector to capture specific element within the app
- * @param {boolean} [options.fullPage=false] - Capture full scrollable content
+ * @param {boolean} [options.fullPage=false] - Capture full scrollable content for page-scoped screenshots
  * @param {number} [options.width=1280] - Viewport width for the screenshot
  * @param {number} [options.height=720] - Viewport height for the screenshot
  * @param {string} [options.scope='app'] - What to capture: 'app' (default), 'container', or 'page'
  * @param {Object} [options.properties] - Additional metadata for the screenshot
+ * @param {number} [options.threshold] - Vizzly comparison threshold. Omitted values use server config.
+ * @param {number} [options.minClusterSize] - Ignore connected diff clusters smaller than this size. Omitted values use server config.
  * @param {boolean} [options.failOnDiff] - Fail the test if visual diff is detected (overrides env var)
+ * @param {string} [options.buildId] - Build ID override for this screenshot
+ * @param {number} [options.requestTimeout] - HTTP request timeout in milliseconds
  * @returns {Promise<Object>} Screenshot result from Vizzly server
  *
  * @example
@@ -214,7 +218,11 @@ export async function vizzlyScreenshot(name, options = {}) {
     height = 720,
     scope = 'app',
     properties = {},
+    threshold = null,
+    minClusterSize = null,
     failOnDiff = null, // null means use env var, true/false overrides
+    buildId = null,
+    requestTimeout = null,
   } = options;
 
   // Get screenshot URL injected by the launcher
@@ -234,13 +242,6 @@ export async function vizzlyScreenshot(name, options = {}) {
     await settled();
   }
 
-  // Prepare testing container for screenshot (expand to full size)
-  let cleanup = prepareTestingContainer(width, height, fullPage);
-
-  // Force a repaint to ensure styles are applied
-  // eslint-disable-next-line no-unused-expressions
-  document.body.offsetHeight;
-
   // Determine what selector to pass to Playwright
   let captureSelector = null;
 
@@ -259,25 +260,78 @@ export async function vizzlyScreenshot(name, options = {}) {
   }
   // scope === 'page' means captureSelector stays null (full page)
 
+  let effectiveFullPage = captureSelector ? false : fullPage;
+
+  // Prepare testing container for screenshot (expand to full size)
+  let cleanup = prepareTestingContainer(width, height, effectiveFullPage);
+
+  // Force a repaint to ensure styles are applied
+  // eslint-disable-next-line no-unused-expressions
+  document.body.offsetHeight;
+
+  let customViewport = properties.viewport;
+  let customViewportWidth = properties.viewport_width;
+  let customViewportHeight = properties.viewport_height;
+  let screenshotProperties = {
+    ...properties,
+    framework: 'ember',
+    browser: detectBrowser(),
+    viewport_width: width,
+    viewport_height: height,
+    url: window.location.href,
+  };
+
+  if (customViewport !== undefined) {
+    screenshotProperties.viewport = customViewport;
+  }
+
+  if (customViewportWidth !== undefined) {
+    screenshotProperties.viewport_width = customViewportWidth;
+  }
+
+  if (customViewportHeight !== undefined) {
+    screenshotProperties.viewport_height = customViewportHeight;
+  }
+
+  if (threshold !== null) {
+    screenshotProperties.threshold = threshold;
+  }
+
+  if (minClusterSize !== null) {
+    screenshotProperties.minClusterSize = minClusterSize;
+  }
+
+  if (!captureSelector && effectiveFullPage !== null) {
+    screenshotProperties.fullPage = effectiveFullPage;
+  }
+
   // Build request payload
   let payload = {
+    buildId: buildId || window.__VIZZLY_BUILD_ID__ || null,
     name,
     selector: captureSelector,
-    fullPage,
-    properties: {
-      browser: detectBrowser(),
-      viewport_width: width,
-      viewport_height: height,
-      url: window.location.href,
-      ...properties,
+    fullPage: effectiveFullPage,
+    viewport: {
+      width,
+      height,
     },
+    properties: screenshotProperties,
+    requestTimeout,
   };
 
   try {
+    let signal =
+      requestTimeout &&
+      typeof AbortSignal !== 'undefined' &&
+      typeof AbortSignal.timeout === 'function'
+        ? AbortSignal.timeout(requestTimeout)
+        : undefined;
+
     // Send screenshot request to server
     let response = await fetch(`${screenshotUrl}/screenshot`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      ...(signal ? { signal } : {}),
       body: JSON.stringify(payload),
     });
 

--- a/clients/ember/src/testem-config.js
+++ b/clients/ember/src/testem-config.js
@@ -7,7 +7,7 @@
  * @module @vizzly-testing/ember/testem
  */
 
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -76,14 +76,18 @@ function createLaunchers() {
  * @param {Object} options - Playwright launch options
  */
 function writePlaywrightConfig(options) {
-  if (!options || Object.keys(options).length === 0) return;
-
   let vizzlyDir = join(process.cwd(), '.vizzly');
+  let configPath = join(vizzlyDir, 'playwright.json');
+
+  if (!options || Object.keys(options).length === 0) {
+    rmSync(configPath, { force: true });
+    return;
+  }
+
   if (!existsSync(vizzlyDir)) {
     mkdirSync(vizzlyDir, { recursive: true });
   }
 
-  let configPath = join(vizzlyDir, 'playwright.json');
   writeFileSync(configPath, JSON.stringify(options, null, 2));
 }
 

--- a/clients/ember/test-app/testem.cjs
+++ b/clients/ember/test-app/testem.cjs
@@ -14,7 +14,7 @@ if (typeof module !== 'undefined') {
     browser_start_timeout: 120,
     browser_args: {
       Chrome: {
-        ci: ['--headless', '--disable-gpu'],
+        ci: ['--headless'],
         dev: [], // headed for local debugging
       },
     },

--- a/clients/ember/tests/unit/browser.test.js
+++ b/clients/ember/tests/unit/browser.test.js
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { getDefaultChromiumArgs } from '../../src/launcher/browser.js';
+
+let originalCi = process.env.CI;
+
+afterEach(() => {
+  if (originalCi === undefined) {
+    delete process.env.CI;
+  } else {
+    process.env.CI = originalCi;
+  }
+});
+
+describe('launcher/browser', () => {
+  describe('getDefaultChromiumArgs', () => {
+    it('keeps CI Chromium flags to sandbox and shared-memory stability args', () => {
+      process.env.CI = 'true';
+
+      let args = getDefaultChromiumArgs();
+
+      assert.ok(args.includes('--no-sandbox'));
+      assert.ok(args.includes('--disable-setuid-sandbox'));
+      assert.ok(args.includes('--disable-dev-shm-usage'));
+      assert.ok(args.includes('--disable-extensions'));
+      assert.equal(args.includes('--disable-gpu'), false);
+      assert.equal(args.includes('--disable-software-rasterizer'), false);
+    });
+  });
+});

--- a/clients/ember/tests/unit/screenshot-server.test.js
+++ b/clients/ember/tests/unit/screenshot-server.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
@@ -13,6 +14,8 @@ import {
 
 describe('screenshot-server', () => {
   let server = null;
+  let originalVizzlyServerUrl = process.env.VIZZLY_SERVER_URL;
+  let originalVizzlyToken = process.env.VIZZLY_TOKEN;
 
   afterEach(async () => {
     if (server) {
@@ -20,6 +23,16 @@ describe('screenshot-server', () => {
       server = null;
     }
     setPage(null);
+    if (originalVizzlyServerUrl === undefined) {
+      delete process.env.VIZZLY_SERVER_URL;
+    } else {
+      process.env.VIZZLY_SERVER_URL = originalVizzlyServerUrl;
+    }
+    if (originalVizzlyToken === undefined) {
+      delete process.env.VIZZLY_TOKEN;
+    } else {
+      process.env.VIZZLY_TOKEN = originalVizzlyToken;
+    }
   });
 
   describe('startScreenshotServer()', () => {
@@ -156,6 +169,164 @@ describe('screenshot-server', () => {
       assert.ok(
         response.headers.get('Access-Control-Allow-Methods').includes('POST')
       );
+    });
+
+    it('sets requested viewport before capturing the screenshot', async () => {
+      let viewportCalls = [];
+      let screenshotCalls = [];
+      let forwardedPayload = null;
+      let vizzlyServer = await startFakeVizzlyServer(payload => {
+        forwardedPayload = payload;
+      });
+      process.env.VIZZLY_SERVER_URL = `http://127.0.0.1:${vizzlyServer.port}`;
+
+      setPage({
+        async setViewportSize(viewport) {
+          viewportCalls.push(viewport);
+        },
+        async screenshot(options) {
+          screenshotCalls.push(options);
+          return Buffer.from('png');
+        },
+      });
+
+      try {
+        let response = await fetch(
+          `http://127.0.0.1:${server.port}/screenshot`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              buildId: 'build-from-ember',
+              name: 'mobile-dashboard',
+              fullPage: false,
+              viewport: { width: 375, height: 667 },
+              properties: { browser: 'chromium' },
+              requestTimeout: 30_000,
+            }),
+          }
+        );
+
+        assert.strictEqual(response.status, 200);
+        assert.deepStrictEqual(viewportCalls, [{ width: 375, height: 667 }]);
+        assert.strictEqual(screenshotCalls.length, 1);
+        assert.strictEqual(forwardedPayload.buildId, 'build-from-ember');
+        assert.strictEqual(forwardedPayload.name, 'mobile-dashboard');
+        assert.deepStrictEqual(forwardedPayload.properties, {
+          framework: 'ember',
+          browser: 'chromium',
+        });
+      } finally {
+        await vizzlyServer.stop();
+      }
+    });
+
+    it('keeps framework pinned to ember when forwarding screenshot properties', async () => {
+      let forwardedPayload = null;
+      let vizzlyServer = await startFakeVizzlyServer(payload => {
+        forwardedPayload = payload;
+      });
+      process.env.VIZZLY_SERVER_URL = `http://127.0.0.1:${vizzlyServer.port}`;
+
+      setPage({
+        async screenshot() {
+          return Buffer.from('png');
+        },
+      });
+
+      try {
+        let response = await fetch(
+          `http://127.0.0.1:${server.port}/screenshot`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              name: 'dashboard',
+              properties: {
+                framework: 'custom-framework',
+                theme: 'dark',
+              },
+            }),
+          }
+        );
+
+        assert.strictEqual(response.status, 200);
+        assert.deepStrictEqual(forwardedPayload.properties, {
+          framework: 'ember',
+          theme: 'dark',
+        });
+      } finally {
+        await vizzlyServer.stop();
+      }
+    });
+
+    it('does not pass fullPage to element screenshots', async () => {
+      let screenshotCalls = [];
+      let vizzlyServer = await startFakeVizzlyServer();
+      process.env.VIZZLY_SERVER_URL = `http://127.0.0.1:${vizzlyServer.port}`;
+
+      setPage({
+        locator() {
+          return {
+            first() {
+              return {
+                async elementHandle() {
+                  return {};
+                },
+                async screenshot(options) {
+                  screenshotCalls.push(options);
+                  return Buffer.from('png');
+                },
+              };
+            },
+          };
+        },
+      });
+
+      try {
+        let response = await fetch(
+          `http://127.0.0.1:${server.port}/screenshot`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              name: 'button',
+              selector: '#ember-testing button',
+              fullPage: true,
+              properties: {},
+            }),
+          }
+        );
+
+        assert.strictEqual(response.status, 200);
+        assert.deepStrictEqual(screenshotCalls, [{ type: 'png' }]);
+      } finally {
+        await vizzlyServer.stop();
+      }
+    });
+
+    it('does not fake cloud success when no Vizzly server is running', async () => {
+      delete process.env.VIZZLY_SERVER_URL;
+      process.env.VIZZLY_TOKEN = 'token-without-wrapper';
+
+      setPage({
+        async screenshot() {
+          return Buffer.from('png');
+        },
+      });
+
+      let response = await fetch(`http://127.0.0.1:${server.port}/screenshot`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'cloud-without-wrapper',
+          properties: {},
+        }),
+      });
+
+      assert.strictEqual(response.status, 500);
+      let body = await response.json();
+      assert.match(body.error, /vizzly run/);
     });
   });
 
@@ -314,3 +485,37 @@ describe('screenshot-server', () => {
     });
   });
 });
+
+function startFakeVizzlyServer(onPayload = () => {}) {
+  return new Promise((resolve, reject) => {
+    let server = createServer((req, res) => {
+      if (req.method !== 'POST' || req.url !== '/screenshot') {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
+      let chunks = [];
+      req.on('data', chunk => {
+        chunks.push(chunk);
+      });
+      req.on('end', () => {
+        let body = Buffer.concat(chunks).toString();
+        onPayload(body ? JSON.parse(body) : {});
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'match' }));
+      });
+    });
+
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: server.address().port,
+        stop: () =>
+          new Promise(stopResolve => {
+            server.close(stopResolve);
+          }),
+      });
+    });
+  });
+}

--- a/clients/ember/tests/unit/test-support.test.js
+++ b/clients/ember/tests/unit/test-support.test.js
@@ -1,0 +1,251 @@
+import assert from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { vizzlyScreenshot } from '../../src/test-support/index.js';
+
+let originalDocument = globalThis.document;
+let originalFetch = globalThis.fetch;
+let originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'navigator'
+);
+let originalWindow = globalThis.window;
+
+function createElement(scrollHeight = 720) {
+  return {
+    style: { cssText: '' },
+    scrollHeight,
+  };
+}
+
+function installBrowserGlobals(fetchImpl) {
+  let container = createElement();
+  let testing = createElement(920);
+
+  globalThis.document = {
+    body: { offsetHeight: 0 },
+    getElementById(id) {
+      if (id === 'ember-testing-container') return container;
+      if (id === 'ember-testing') return testing;
+      return null;
+    },
+  };
+
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: {
+      userAgent:
+        'Mozilla/5.0 AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36',
+    },
+  });
+
+  globalThis.window = {
+    __VIZZLY_SCREENSHOT_URL__: 'http://127.0.0.1:47393',
+    location: { href: 'http://localhost:4200/dashboard' },
+  };
+
+  globalThis.fetch = fetchImpl;
+}
+
+function restoreBrowserGlobals() {
+  globalThis.document = originalDocument;
+  globalThis.fetch = originalFetch;
+  globalThis.window = originalWindow;
+
+  if (originalNavigatorDescriptor) {
+    Object.defineProperty(globalThis, 'navigator', originalNavigatorDescriptor);
+  } else {
+    delete globalThis.navigator;
+  }
+}
+
+describe('test-support', () => {
+  afterEach(() => {
+    restoreBrowserGlobals();
+  });
+
+  describe('vizzlyScreenshot()', () => {
+    it('forwards comparison options as screenshot properties', async () => {
+      let capturedBody = null;
+
+      installBrowserGlobals(async (_url, request) => {
+        capturedBody = JSON.parse(request.body);
+        return {
+          ok: true,
+          async json() {
+            return { status: 'match' };
+          },
+        };
+      });
+
+      let result = await vizzlyScreenshot('dashboard', {
+        scope: 'page',
+        fullPage: true,
+        threshold: 5,
+        minClusterSize: 10,
+        width: 1440,
+        height: 900,
+        properties: {
+          theme: 'dark',
+        },
+      });
+
+      assert.strictEqual(result.status, 'match');
+      assert.strictEqual(capturedBody.buildId, null);
+      assert.strictEqual(capturedBody.name, 'dashboard');
+      assert.strictEqual(capturedBody.fullPage, true);
+      assert.strictEqual(capturedBody.requestTimeout, null);
+      assert.deepStrictEqual(capturedBody.viewport, {
+        width: 1440,
+        height: 900,
+      });
+      assert.deepStrictEqual(capturedBody.properties, {
+        framework: 'ember',
+        browser: 'chromium',
+        viewport_width: 1440,
+        viewport_height: 900,
+        url: 'http://localhost:4200/dashboard',
+        theme: 'dark',
+        threshold: 5,
+        minClusterSize: 10,
+        fullPage: true,
+      });
+    });
+
+    it('keeps reserved metadata stable while allowing custom viewport metadata', async () => {
+      let capturedBody = null;
+
+      installBrowserGlobals(async (_url, request) => {
+        capturedBody = JSON.parse(request.body);
+        return {
+          ok: true,
+          async json() {
+            return { status: 'match' };
+          },
+        };
+      });
+
+      await vizzlyScreenshot('dashboard', {
+        properties: {
+          theme: 'dark',
+          browser: 'webkit',
+          framework: 'custom-framework',
+          url: 'http://evil.example',
+          viewport: { width: 375, height: 667 },
+          viewport_width: 375,
+          viewport_height: 667,
+        },
+      });
+
+      assert.deepStrictEqual(capturedBody.properties, {
+        framework: 'ember',
+        browser: 'chromium',
+        url: 'http://localhost:4200/dashboard',
+        theme: 'dark',
+        viewport: { width: 375, height: 667 },
+        viewport_width: 375,
+        viewport_height: 667,
+      });
+    });
+
+    it('does not forward fullPage for element screenshots', async () => {
+      let capturedBody = null;
+      let styleDuringCapture = null;
+
+      installBrowserGlobals(async (_url, request) => {
+        capturedBody = JSON.parse(request.body);
+        styleDuringCapture = document.getElementById('ember-testing-container')
+          .style.cssText;
+        return {
+          ok: true,
+          async json() {
+            return { status: 'match' };
+          },
+        };
+      });
+
+      await vizzlyScreenshot('button', {
+        selector: 'button.primary',
+        fullPage: true,
+      });
+
+      assert.strictEqual(
+        capturedBody.selector,
+        '#ember-testing button.primary'
+      );
+      assert.strictEqual(capturedBody.fullPage, false);
+      assert.strictEqual(capturedBody.properties.fullPage, undefined);
+      assert.match(styleDuringCapture, /overflow: hidden/);
+      assert.doesNotMatch(styleDuringCapture, /overflow: visible/);
+    });
+
+    it('forwards injected build id and request timeout to the screenshot server', async () => {
+      let capturedBody = null;
+      let capturedSignal = null;
+
+      installBrowserGlobals(async (_url, request) => {
+        capturedBody = JSON.parse(request.body);
+        capturedSignal = request.signal;
+        return {
+          ok: true,
+          async json() {
+            return { status: 'match' };
+          },
+        };
+      });
+      window.__VIZZLY_BUILD_ID__ = 'build-from-run';
+
+      await vizzlyScreenshot('dashboard', {
+        requestTimeout: 25_000,
+      });
+
+      assert.strictEqual(capturedBody.buildId, 'build-from-run');
+      assert.strictEqual(capturedBody.requestTimeout, 25_000);
+      if (
+        typeof AbortSignal !== 'undefined' &&
+        typeof AbortSignal.timeout === 'function'
+      ) {
+        assert.ok(capturedSignal instanceof AbortSignal);
+      }
+    });
+
+    it('lets per-screenshot build id override the injected build id', async () => {
+      let capturedBody = null;
+
+      installBrowserGlobals(async (_url, request) => {
+        capturedBody = JSON.parse(request.body);
+        return {
+          ok: true,
+          async json() {
+            return { status: 'match' };
+          },
+        };
+      });
+      window.__VIZZLY_BUILD_ID__ = 'build-from-run';
+
+      await vizzlyScreenshot('dashboard', {
+        buildId: 'build-from-call',
+      });
+
+      assert.strictEqual(capturedBody.buildId, 'build-from-call');
+    });
+
+    it('lets per-screenshot failOnDiff false override injected fail setting', async () => {
+      installBrowserGlobals(async () => ({
+        ok: true,
+        async json() {
+          return {
+            status: 'diff',
+            diffPercentage: 4.2,
+          };
+        },
+      }));
+      window.__VIZZLY_FAIL_ON_DIFF__ = true;
+
+      let result = await vizzlyScreenshot('optional-diff', {
+        failOnDiff: false,
+      });
+
+      assert.strictEqual(result.status, 'diff');
+    });
+  });
+});

--- a/clients/ember/tests/unit/testem-config.test.js
+++ b/clients/ember/tests/unit/testem-config.test.js
@@ -146,19 +146,15 @@ describe('testem-config', () => {
       });
     });
 
-    it('does not write playwright.json when playwrightOptions is empty', () => {
+    it('removes stale playwright.json when playwrightOptions is empty', () => {
       // Clean up any existing file first
       let configPath = join(process.cwd(), '.vizzly', 'playwright.json');
-      if (existsSync(configPath)) {
-        rmSync(configPath);
-      }
+      configure({}, { headless: false });
+      assert.ok(existsSync(configPath), 'precondition should write config');
 
       configure({}, {});
 
-      assert.ok(
-        !existsSync(configPath),
-        'should not write empty playwright.json'
-      );
+      assert.ok(!existsSync(configPath), 'should remove stale playwright.json');
     });
 
     it('handles lowercase browser names', () => {

--- a/clients/vitest/README.md
+++ b/clients/vitest/README.md
@@ -25,7 +25,7 @@ standard `toMatchScreenshot` API - no code changes required!
 ## Installation
 
 ```bash
-pnpm install -D @vizzly-testing/vitest @vizzly-testing/cli
+pnpm install -D @vizzly-testing/vitest @vizzly-testing/cli vitest @vitest/browser @vitest/browser-playwright
 ```
 
 ## Quick Start
@@ -65,7 +65,7 @@ import { page } from 'vitest/browser'
 
 test('homepage looks correct', async () => {
   // Render your component/page
-  document.body.innerHTML = '<div class="hero">Hello World</div>'
+  document.body.innerHTML = '<h1 class="hero">Hello World</h1>'
 
   // Basic screenshot
   await expect(page.getByRole('heading')).toMatchScreenshot('homepage.png')
@@ -73,8 +73,7 @@ test('homepage looks correct', async () => {
   // With properties for multi-variant testing
   await expect(page.getByRole('heading')).toMatchScreenshot('hero-section.png', {
     properties: {
-      theme: 'dark',
-      viewport: '1920x1080'
+      theme: 'dark'
     },
     threshold: 5
   })
@@ -87,7 +86,7 @@ test('homepage looks correct', async () => {
 
 ```bash
 # Terminal 1: Start Vizzly TDD server
-pnpm exec vizzly dev start
+pnpm exec vizzly tdd start
 
 # Terminal 2: Run tests
 pnpm exec vitest
@@ -107,20 +106,16 @@ pnpm exec vizzly run "pnpm exec vitest" --wait
 
 ## API Reference
 
-### Plugin Options
+### Plugin
 
-The plugin requires no configuration, but you can pass options if needed:
+The plugin does not take configuration today. Add it once to your Vitest
+plugins list and pass screenshot-specific options to `toMatchScreenshot`.
 
 ```javascript
 import { vizzlyPlugin } from '@vizzly-testing/vitest'
 
 // Simple - just add the plugin
 vizzlyPlugin()
-
-// Or with options (rarely needed)
-vizzlyPlugin({
-  // Plugin-specific options can go here
-})
 ```
 
 ### Screenshot Options
@@ -136,8 +131,11 @@ await expect(page).toMatchScreenshot('screenshot.png', {
     userRole: 'admin'
   },
 
-  // Comparison threshold (0-100)
+  // Vizzly diff sensitivity threshold
   threshold: 5,
+
+  // Ignore tiny connected pixel clusters
+  minClusterSize: 10,
 
   // Full page capture
   fullPage: true
@@ -146,9 +144,19 @@ await expect(page).toMatchScreenshot('screenshot.png', {
 
 **Available Options:**
 
-- `properties` (object) - Custom metadata for signature-based baseline matching
-- `threshold` (number, 0-100) - Acceptable difference percentage (default: 0)
-- `fullPage` (boolean) - Capture full scrollable page instead of viewport
+- Playwright/Vitest screenshot options such as `animations`, `caret`, `mask`,
+  `maskColor`, `omitBackground`, `scale`, and `timeout` are passed through to
+  the browser screenshot capture.
+- Vizzly automatically adds `browser`, `url`, `viewport`, `viewport_width`, and
+  `viewport_height` metadata based on the current browser session.
+- `properties` (object) - Custom metadata for signature-based baseline matching.
+  Reserved runtime fields stay pinned to the current browser session; explicit
+  viewport fields are still allowed when a test intentionally needs a custom
+  signature.
+- `threshold` (number) - Vizzly diff sensitivity threshold. When omitted, the Vizzly server configuration is used.
+- `minClusterSize` (number) - Ignore connected diff clusters smaller than this size
+- `fullPage` (boolean) - Capture full scrollable page instead of viewport. This applies to page targets; locator targets stay element-sized.
+- `failOnDiff` (boolean) - Fail this assertion when Vizzly reports a visual diff. When omitted, the Vizzly server or environment setting is used.
 
 ## Multi-Variant Testing
 
@@ -210,8 +218,7 @@ test('typed screenshot', async () => {
   await expect(page).toMatchScreenshot('hero.png', {
     properties: {
       // Full autocomplete support
-      theme: 'dark',
-      viewport: '1920x1080'
+      theme: 'dark'
     },
     threshold: 5,
     fullPage: true
@@ -245,7 +252,7 @@ test('manual screenshot', async () => {
 
 ## Examples & Tests
 
-See the tests in this package at `tests/`:
+See the package tests in the Vizzly CLI repo under `clients/vitest/tests/`:
 
 - **vitest-plugin.spec.js** - Unit tests for plugin configuration and comparator function
 - **e2e/** - End-to-end test project running actual Vitest tests with the plugin
@@ -256,8 +263,8 @@ The E2E tests serve as both validation and a working example. Run them with:
 # From clients/vitest directory
 pnpm install
 pnpm run test:unit    # Run unit tests
-pnpm run test:e2e     # Run E2E tests (requires vizzly dev start)
-pnpm test            # Run all tests
+pnpm run test:e2e     # Run E2E tests (requires vizzly tdd start)
+pnpm test            # Run unit tests
 ```
 
 ## Troubleshooting
@@ -265,12 +272,12 @@ pnpm test            # Run all tests
 ### "Vizzly not available" message
 
 Make sure you're running tests with either:
-- `vizzly dev start` (TDD mode)
+- `vizzly tdd start` (TDD mode)
 - `vizzly run "pnpm exec vitest"` (cloud mode)
 
 ### Screenshots not appearing in dashboard
 
-1. Check `vizzly status` for TDD, make sure `VIZZLY_TOKEN` is set for cloud capture
+1. Check `pnpm exec vizzly tdd status` for TDD, make sure `VIZZLY_TOKEN` is set for cloud capture
 2. Verify API token is set: `pnpm exec vizzly whoami`
 3. Check console for error messages
 

--- a/clients/vitest/package.json
+++ b/clients/vitest/package.json
@@ -33,10 +33,9 @@
   "types": "./src/index.d.ts",
   "files": [
     "src",
-    "eslint.config.js",
     "README.md",
-    "LICENSE",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "scripts": {
     "test": "pnpm run test:unit",

--- a/clients/vitest/src/index.d.ts
+++ b/clients/vitest/src/index.d.ts
@@ -7,28 +7,54 @@
  */
 export interface VizzlyScreenshotOptions {
   /**
-   * Custom metadata properties for multi-variant testing
-   * @example { theme: 'dark', viewport: '1920x1080' }
+   * Forwarded to Vitest/Playwright screenshot capture.
    */
-  properties?: Record<string, any>;
+  animations?: 'disabled' | 'allow';
+  caret?: 'hide' | 'initial';
+  mask?: readonly unknown[];
+  maskColor?: string;
+  omitBackground?: boolean;
+  scale?: 'css' | 'device';
+  timeout?: number;
 
   /**
-   * Comparison threshold (0-100)
-   * @default 0
+   * Custom metadata properties for multi-variant testing.
+   * Vizzly automatically adds browser, url, and viewport metadata;
+   * reserved runtime fields stay pinned to the browser session, while
+   * explicit viewport fields can override the detected viewport signature.
+   * @example { theme: 'dark' }
+   */
+  properties?: Record<string, unknown>;
+
+  /**
+   * Visual comparison sensitivity threshold used by Vizzly's diff engine.
+   * When omitted, the Vizzly server configuration is used.
    */
   threshold?: number;
 
   /**
-   * Whether this is a full page screenshot
+   * Minimum connected-pixel cluster size to count as a difference
+   */
+  minClusterSize?: number;
+
+  /**
+   * Whether this is a full page screenshot.
+   * Only applies when the screenshot target is the page; element targets ignore it.
    */
   fullPage?: boolean;
+
+  /**
+   * Fail this assertion when Vizzly reports a visual diff.
+   * When omitted, the Vizzly server or environment setting is used.
+   */
+  failOnDiff?: boolean;
 }
 
 /**
  * Vitest plugin for Vizzly integration
  * Extends expect API with custom toMatchScreenshot matcher
  */
-export function vizzlyPlugin(options?: Record<string, any>): {
+export function vizzlyPlugin(): {
   name: string;
   config(config: any, context: { mode: string }): any;
 };
@@ -40,7 +66,10 @@ export function getVizzlyStatus(): {
   enabled: boolean;
   ready: boolean;
   tddMode: boolean;
-  serverUrl?: string;
+  serverUrl: string | null;
+  buildId: string | null;
+  disabled: boolean;
+  failOnDiff: boolean;
 };
 
 /**
@@ -57,5 +86,6 @@ declare module 'vitest' {
       name?: string,
       options?: VizzlyScreenshotOptions
     ): Promise<void>;
+    toMatchScreenshot(options?: VizzlyScreenshotOptions): Promise<void>;
   }
 }

--- a/clients/vitest/src/index.js
+++ b/clients/vitest/src/index.js
@@ -40,7 +40,7 @@
  *   await expect(page).toMatchScreenshot('hero.png', {
  *     properties: {
  *       theme: 'dark',
- *       viewport: '1920x1080'
+ *       viewport: { width: 1920, height: 1080 }
  *     },
  *     threshold: 5
  *   })
@@ -51,7 +51,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { getVizzlyInfo } from '@vizzly-testing/cli/client';
 
-export function vizzlyPlugin(_options = {}) {
+export function vizzlyPlugin() {
   return {
     name: 'vitest-vizzly',
     config() {
@@ -59,27 +59,34 @@ export function vizzlyPlugin(_options = {}) {
       // Search for .vizzly/server.json from process.cwd() up to root
       let serverUrl = process.env.VIZZLY_SERVER_URL || '';
       let buildId = process.env.VIZZLY_BUILD_ID || '';
+      let failOnDiff = process.env.VIZZLY_FAIL_ON_DIFF || '';
 
-      if (!serverUrl) {
-        // Search for .vizzly/server.json in current working directory and parent directories
-        let currentDir = process.cwd();
-        while (currentDir !== '/') {
-          let serverJsonPath = join(currentDir, '.vizzly', 'server.json');
-          if (existsSync(serverJsonPath)) {
-            try {
-              let serverConfig = JSON.parse(
-                readFileSync(serverJsonPath, 'utf-8')
-              );
+      // Search for .vizzly/server.json in current working directory and parent directories
+      let currentDir = process.cwd();
+      while (currentDir !== '/') {
+        let serverJsonPath = join(currentDir, '.vizzly', 'server.json');
+        if (existsSync(serverJsonPath)) {
+          try {
+            let serverConfig = JSON.parse(
+              readFileSync(serverJsonPath, 'utf-8')
+            );
+
+            if (!serverUrl && serverConfig.port) {
               serverUrl = `http://localhost:${serverConfig.port}`;
-              break;
-            } catch {
-              // Ignore malformed server.json
             }
+
+            if (!failOnDiff && serverConfig.failOnDiff === true) {
+              failOnDiff = 'true';
+            }
+
+            break;
+          } catch {
+            // Ignore malformed server.json
           }
-          let parentDir = resolve(currentDir, '..');
-          if (parentDir === currentDir) break;
-          currentDir = parentDir;
         }
+        let parentDir = resolve(currentDir, '..');
+        if (parentDir === currentDir) break;
+        currentDir = parentDir;
       }
 
       return {
@@ -95,6 +102,7 @@ export function vizzlyPlugin(_options = {}) {
         define: {
           __VIZZLY_SERVER_URL__: JSON.stringify(serverUrl),
           __VIZZLY_BUILD_ID__: JSON.stringify(buildId),
+          __VIZZLY_FAIL_ON_DIFF__: JSON.stringify(failOnDiff),
         },
       };
     },

--- a/clients/vitest/src/setup.js
+++ b/clients/vitest/src/setup.js
@@ -4,9 +4,123 @@
  */
 import { expect } from 'vitest';
 
+export function buildScreenshotProperties(
+  options = {},
+  locationHref = '',
+  context = {}
+) {
+  let customProperties = options.properties ?? {};
+  let customViewport = customProperties.viewport;
+  let customViewportWidth = customProperties.viewport_width;
+  let customViewportHeight = customProperties.viewport_height;
+  let viewportWidth = context.viewport?.width;
+  let viewportHeight = context.viewport?.height;
+  let properties = {
+    ...customProperties,
+    framework: 'vitest',
+    vitest: true,
+    url: locationHref,
+    browser: context.browser || detectBrowser(),
+  };
+
+  if (Number.isFinite(viewportWidth) && Number.isFinite(viewportHeight)) {
+    properties.viewport = { width: viewportWidth, height: viewportHeight };
+    properties.viewport_width = viewportWidth;
+    properties.viewport_height = viewportHeight;
+  }
+
+  if (customViewport !== undefined) {
+    properties.viewport = customViewport;
+  }
+
+  if (customViewportWidth !== undefined) {
+    properties.viewport_width = customViewportWidth;
+  }
+
+  if (customViewportHeight !== undefined) {
+    properties.viewport_height = customViewportHeight;
+  }
+
+  if (options.threshold !== undefined) {
+    properties.threshold = options.threshold;
+  }
+
+  if (options.minClusterSize !== undefined) {
+    properties.minClusterSize = options.minClusterSize;
+  }
+
+  if (!context.element && options.fullPage !== undefined) {
+    properties.fullPage = options.fullPage;
+  }
+
+  return properties;
+}
+
+export function detectBrowser(userAgent = globalThis.navigator?.userAgent) {
+  if (!userAgent) return 'unknown';
+
+  let normalizedUserAgent = userAgent.toLowerCase();
+
+  if (normalizedUserAgent.includes('firefox')) return 'firefox';
+  if (normalizedUserAgent.includes('edg/')) return 'edge';
+  if (normalizedUserAgent.includes('chrome')) return 'chromium';
+  if (normalizedUserAgent.includes('safari')) return 'webkit';
+
+  return 'unknown';
+}
+
+export function buildScreenshotCaptureOptions(options = {}, context = {}) {
+  let captureOptions = { ...options };
+  delete captureOptions.properties;
+  delete captureOptions.threshold;
+  delete captureOptions.minClusterSize;
+  delete captureOptions.failOnDiff;
+  delete captureOptions.buildId;
+  delete captureOptions.requestTimeout;
+
+  if (context.element) {
+    delete captureOptions.fullPage;
+  }
+
+  return captureOptions;
+}
+
+export function normalizeScreenshotMatcherArgs(name, options = {}) {
+  if (name && typeof name === 'object') {
+    return { name: undefined, options: name };
+  }
+
+  return { name, options };
+}
+
+export function isElementScreenshotTarget(target, page) {
+  return (
+    target &&
+    target !== page &&
+    typeof target === 'object' &&
+    typeof target.screenshot === 'function'
+  );
+}
+
+export function shouldFailOnDiff(override = null) {
+  if (override !== null && override !== undefined) {
+    return override === true;
+  }
+
+  let value =
+    typeof __VIZZLY_FAIL_ON_DIFF__ !== 'undefined'
+      ? __VIZZLY_FAIL_ON_DIFF__
+      : '';
+  return value === true || value === 'true' || value === '1';
+}
+
 // Custom matcher that completely replaces Vitest's toMatchScreenshot
 // This runs in browser context, so we make direct HTTP calls instead of using Node SDK
 async function toMatchScreenshot(element, name, options = {}) {
+  let args = normalizeScreenshotMatcherArgs(name, options);
+  name = args.name;
+  options = args.options;
+
   let serverUrl =
     typeof __VIZZLY_SERVER_URL__ !== 'undefined' ? __VIZZLY_SERVER_URL__ : '';
   let buildId =
@@ -22,32 +136,31 @@ async function toMatchScreenshot(element, name, options = {}) {
   }
 
   // Import page from Vitest browser context
-  const { page } = await import('vitest/browser');
+  let { page } = await import('vitest/browser');
 
   // Take screenshot - Vitest browser mode returns a file path, not the image data
   let screenshotPath;
-  if (typeof element === 'object' && element.locator) {
-    // It's a Playwright locator
-    screenshotPath = await element.screenshot(options);
+  if (isElementScreenshotTarget(element, page)) {
+    let captureOptions = buildScreenshotCaptureOptions(options, {
+      element: true,
+    });
+    screenshotPath = await element.screenshot(captureOptions);
   } else {
     // It's the page object
-    screenshotPath = await page.screenshot(options);
+    let captureOptions = buildScreenshotCaptureOptions(options);
+    screenshotPath = await page.screenshot(captureOptions);
   }
 
   let screenshotName = name || `screenshot-${Date.now()}`;
 
-  // Extract options from top-level
-  let threshold = options.threshold ?? 0;
-  let fullPage = options.fullPage;
-  let customProperties = options.properties ?? {};
-
   // Prepare properties
-  let properties = {
-    framework: 'vitest',
-    vitest: true,
-    url: window.location.href,
-    ...customProperties,
-  };
+  let properties = buildScreenshotProperties(options, window.location.href, {
+    element: isElementScreenshotTarget(element, page),
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    },
+  });
 
   try {
     // Vitest browser mode saves screenshots to disk and returns the file path
@@ -63,8 +176,6 @@ async function toMatchScreenshot(element, name, options = {}) {
         image: screenshotPath, // Send file path directly
         type: 'file-path',
         buildId: buildId || null,
-        threshold,
-        fullPage,
         properties,
       }),
     });
@@ -90,7 +201,7 @@ async function toMatchScreenshot(element, name, options = {}) {
 
     if (comparisonStatus === 'new') {
       return {
-        pass: false,
+        pass: true,
         message: () =>
           `New screenshot baseline created: ${screenshotName}. View at http://localhost:47392/dashboard`,
       };
@@ -110,11 +221,11 @@ async function toMatchScreenshot(element, name, options = {}) {
         ? comparison.diffPercentage.toFixed(2)
         : '0.00';
 
-      if (comparison.diffPercentage <= threshold) {
+      if (!shouldFailOnDiff(options.failOnDiff)) {
         return {
           pass: true,
           message: () =>
-            `Screenshot within threshold: ${screenshotName} (${diffPercent}% ≤ ${threshold.toFixed(2)}%)`,
+            `Visual difference recorded: ${screenshotName} (${diffPercent}% difference). View at http://localhost:47392/dashboard`,
         };
       }
 

--- a/clients/vitest/tests/e2e/example.test.js
+++ b/clients/vitest/tests/e2e/example.test.js
@@ -5,7 +5,7 @@
  * - Page screenshots
  * - Element screenshots
  * - Properties/metadata
- * - Threshold options
+ * - Threshold/minClusterSize options
  *
  * Uses the shared test-site CSS for consistent styling.
  */
@@ -83,6 +83,7 @@ describe('Vizzly Vitest Plugin', () => {
 
     await expect(page).toMatchScreenshot('warning.png', {
       threshold: 5,
+      minClusterSize: 10,
     });
   });
 

--- a/clients/vitest/tests/vitest-plugin.spec.js
+++ b/clients/vitest/tests/vitest-plugin.spec.js
@@ -7,14 +7,30 @@
  * These run in Node environment to test the Vite plugin configuration.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import {
+  buildScreenshotCaptureOptions,
+  buildScreenshotProperties,
+  detectBrowser,
+  isElementScreenshotTarget,
+  normalizeScreenshotMatcherArgs,
+  shouldFailOnDiff,
+} from '../src/setup.js';
 
 describe('Vitest Plugin Integration', () => {
   describe('Plugin Configuration', () => {
     it('should register setup file', async () => {
-      const { vizzlyPlugin } = await import('../src/index.js');
+      let { vizzlyPlugin } = await import('../src/index.js');
 
       let config = { test: {} };
       let plugin = vizzlyPlugin();
@@ -28,7 +44,7 @@ describe('Vitest Plugin Integration', () => {
     });
 
     it('should not duplicate user setupFiles (vitest merges them automatically)', async () => {
-      const { vizzlyPlugin } = await import('../src/index.js');
+      let { vizzlyPlugin } = await import('../src/index.js');
 
       // Simulate user config with existing setupFiles
       let userConfig = {
@@ -54,7 +70,7 @@ describe('Vitest Plugin Integration', () => {
     });
 
     it('should not duplicate user setupFiles when given as string', async () => {
-      const { vizzlyPlugin } = await import('../src/index.js');
+      let { vizzlyPlugin } = await import('../src/index.js');
 
       // User might specify setupFiles as a single string
       let userConfig = {
@@ -72,7 +88,7 @@ describe('Vitest Plugin Integration', () => {
     });
 
     it('should result in correct merged config after vitest merging', async () => {
-      const { vizzlyPlugin } = await import('../src/index.js');
+      let { vizzlyPlugin } = await import('../src/index.js');
 
       let userConfig = {
         test: {
@@ -96,7 +112,7 @@ describe('Vitest Plugin Integration', () => {
     });
 
     it('should pass environment variables to browser context', async () => {
-      const { vizzlyPlugin } = await import('../src/index.js');
+      let { vizzlyPlugin } = await import('../src/index.js');
 
       let config = { test: {} };
       let plugin = vizzlyPlugin();
@@ -105,12 +121,221 @@ describe('Vitest Plugin Integration', () => {
       expect(config.define).toBeDefined();
       expect(config.define.__VIZZLY_SERVER_URL__).toBeDefined();
       expect(config.define.__VIZZLY_BUILD_ID__).toBeDefined();
+      expect(config.define.__VIZZLY_FAIL_ON_DIFF__).toBeDefined();
+    });
+
+    it('should pass failOnDiff from discovered server config', async () => {
+      let { vizzlyPlugin } = await import('../src/index.js');
+      let originalCwd = process.cwd();
+      let tempDir = mkdtempSync(resolve(tmpdir(), 'vizzly-vitest-'));
+      let originalServerUrl = process.env.VIZZLY_SERVER_URL;
+      let originalFailOnDiff = process.env.VIZZLY_FAIL_ON_DIFF;
+
+      delete process.env.VIZZLY_SERVER_URL;
+      delete process.env.VIZZLY_FAIL_ON_DIFF;
+      mkdirSync(resolve(tempDir, '.vizzly'));
+      writeFileSync(
+        resolve(tempDir, '.vizzly/server.json'),
+        JSON.stringify({ port: 47392, failOnDiff: true })
+      );
+
+      try {
+        process.chdir(tempDir);
+        let plugin = vizzlyPlugin();
+        let config = plugin.config({ test: {} }, { mode: 'test' });
+
+        expect(JSON.parse(config.define.__VIZZLY_SERVER_URL__)).toBe(
+          'http://localhost:47392'
+        );
+        expect(JSON.parse(config.define.__VIZZLY_FAIL_ON_DIFF__)).toBe('true');
+      } finally {
+        process.chdir(originalCwd);
+        rmSync(tempDir, { recursive: true, force: true });
+
+        if (originalServerUrl === undefined) {
+          delete process.env.VIZZLY_SERVER_URL;
+        } else {
+          process.env.VIZZLY_SERVER_URL = originalServerUrl;
+        }
+
+        if (originalFailOnDiff === undefined) {
+          delete process.env.VIZZLY_FAIL_ON_DIFF;
+        } else {
+          process.env.VIZZLY_FAIL_ON_DIFF = originalFailOnDiff;
+        }
+      }
     });
   });
 
   describe('Custom Matcher', () => {
+    it('sends comparison options as screenshot properties', () => {
+      let properties = buildScreenshotProperties(
+        {
+          properties: { theme: 'dark' },
+          threshold: 5,
+          minClusterSize: 10,
+          fullPage: true,
+        },
+        'http://localhost/component',
+        { viewport: { width: 1920, height: 1080 } }
+      );
+
+      expect(properties).toEqual({
+        framework: 'vitest',
+        vitest: true,
+        url: 'http://localhost/component',
+        browser: 'unknown',
+        viewport: { width: 1920, height: 1080 },
+        viewport_width: 1920,
+        viewport_height: 1080,
+        theme: 'dark',
+        threshold: 5,
+        minClusterSize: 10,
+        fullPage: true,
+      });
+    });
+
+    it('keeps reserved screenshot metadata stable while preserving viewport overrides', () => {
+      let properties = buildScreenshotProperties(
+        {
+          properties: {
+            browser: 'webkit',
+            framework: 'custom-framework',
+            url: 'http://evil.example',
+            vitest: false,
+            viewport: { width: 375, height: 667 },
+            viewport_width: 375,
+            viewport_height: 667,
+          },
+        },
+        'http://localhost/component',
+        { viewport: { width: 1920, height: 1080 } }
+      );
+
+      expect(properties).toMatchObject({
+        framework: 'vitest',
+        vitest: true,
+        url: 'http://localhost/component',
+        browser: 'unknown',
+        viewport: { width: 375, height: 667 },
+        viewport_width: 375,
+        viewport_height: 667,
+      });
+    });
+
+    it('normalizes browser metadata for screenshot signatures', () => {
+      expect(
+        detectBrowser(
+          'Mozilla/5.0 AppleWebKit/537.36 Chrome/126.0.0.0 Safari/537.36'
+        )
+      ).toBe('chromium');
+      expect(detectBrowser('Mozilla/5.0 Firefox/127.0')).toBe('firefox');
+      expect(
+        detectBrowser('Mozilla/5.0 AppleWebKit/605.1.15 Version/17.0 Safari')
+      ).toBe('webkit');
+    });
+
+    it('does not pass Vizzly-only options to browser screenshots', () => {
+      let captureOptions = buildScreenshotCaptureOptions({
+        properties: { theme: 'dark' },
+        threshold: 5,
+        minClusterSize: 10,
+        failOnDiff: true,
+        buildId: 'build-from-env',
+        requestTimeout: 30_000,
+        fullPage: true,
+        animations: 'disabled',
+      });
+
+      expect(captureOptions).toEqual({
+        fullPage: true,
+        animations: 'disabled',
+      });
+    });
+
+    it('lets per-screenshot failOnDiff override the server setting', () => {
+      expect(shouldFailOnDiff(true)).toBe(true);
+      expect(shouldFailOnDiff(false)).toBe(false);
+    });
+
+    it('does not pass fullPage to element screenshots', () => {
+      let captureOptions = buildScreenshotCaptureOptions(
+        {
+          fullPage: true,
+          animations: 'disabled',
+        },
+        { element: true }
+      );
+
+      expect(captureOptions).toEqual({
+        animations: 'disabled',
+      });
+    });
+
+    it('does not mark element screenshots as full page in Vizzly properties', () => {
+      let properties = buildScreenshotProperties(
+        { fullPage: true, properties: { state: 'open' } },
+        'http://localhost/component',
+        { element: true }
+      );
+
+      expect(properties).toEqual({
+        framework: 'vitest',
+        vitest: true,
+        url: 'http://localhost/component',
+        browser: 'unknown',
+        state: 'open',
+      });
+    });
+
+    it('lets explicit user viewport properties override detected viewport metadata', () => {
+      let properties = buildScreenshotProperties(
+        {
+          properties: {
+            viewport: { width: 375, height: 667 },
+            viewport_width: 375,
+            viewport_height: 667,
+          },
+        },
+        'http://localhost/component',
+        { viewport: { width: 1920, height: 1080 } }
+      );
+
+      expect(properties).toMatchObject({
+        viewport: { width: 375, height: 667 },
+        viewport_width: 375,
+        viewport_height: 667,
+      });
+    });
+
+    it('detects Vitest locator-style element screenshot targets', () => {
+      let page = { screenshot: async () => '/tmp/page.png' };
+      let locator = { screenshot: async () => '/tmp/button.png' };
+
+      expect(isElementScreenshotTarget(locator, page)).toBe(true);
+      expect(isElementScreenshotTarget(page, page)).toBe(false);
+    });
+
+    it('supports Vitest options-only matcher arguments', () => {
+      expect(
+        normalizeScreenshotMatcherArgs({ properties: { state: 'open' } })
+      ).toEqual({
+        name: undefined,
+        options: { properties: { state: 'open' } },
+      });
+
+      expect(
+        normalizeScreenshotMatcherArgs('menu-open', {
+          properties: { state: 'open' },
+        })
+      ).toEqual({
+        name: 'menu-open',
+        options: { properties: { state: 'open' } },
+      });
+    });
+
     it('should not export toMatchScreenshot (registered via setup.js)', async () => {
-      const exports = await import('../src/index.js');
+      let exports = await import('../src/index.js');
 
       // toMatchScreenshot is registered via expect.extend() in setup.js, not exported
       expect(exports.toMatchScreenshot).toBeUndefined();
@@ -119,10 +344,10 @@ describe('Vitest Plugin Integration', () => {
 
   describe('TypeScript Declarations', () => {
     it('should have valid TypeScript declarations', () => {
-      const dtsPath = resolve(process.cwd(), 'src/index.d.ts');
+      let dtsPath = resolve(process.cwd(), 'src/index.d.ts');
       expect(existsSync(dtsPath)).toBe(true);
 
-      const content = readFileSync(dtsPath, 'utf-8');
+      let content = readFileSync(dtsPath, 'utf-8');
       // Check for core exports
       expect(content).toContain('export function vizzlyPlugin');
       expect(content).toContain('export function getVizzlyStatus');
@@ -131,10 +356,10 @@ describe('Vitest Plugin Integration', () => {
   });
 
   describe('Package Configuration', () => {
-    it('should have correct package.json exports', () => {
-      const pkgPath = resolve(process.cwd(), 'package.json');
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    let pkgPath = resolve(process.cwd(), 'package.json');
+    let pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
 
+    it('should have correct package.json exports', () => {
       expect(pkg.type).toBe('module');
       expect(pkg.exports['.']).toBeDefined();
       expect(pkg.exports['.'].import).toBe('./src/index.js');
@@ -142,17 +367,11 @@ describe('Vitest Plugin Integration', () => {
     });
 
     it('should have no runtime dependencies', () => {
-      const pkgPath = resolve(process.cwd(), 'package.json');
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-
       // Vitest plugin has no runtime dependencies - everything runs in browser context
       expect(Object.keys(pkg.dependencies || {})).toHaveLength(0);
     });
 
     it('should have correct peer dependencies', () => {
-      const pkgPath = resolve(process.cwd(), 'package.json');
-      const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-
       expect(pkg.peerDependencies).toHaveProperty('@vizzly-testing/cli');
       expect(pkg.peerDependencies).toHaveProperty('vitest');
     });
@@ -160,17 +379,17 @@ describe('Vitest Plugin Integration', () => {
 
   describe('Helper Functions', () => {
     it('should export getVizzlyStatus', async () => {
-      const { getVizzlyStatus } = await import('../src/index.js');
+      let { getVizzlyStatus } = await import('../src/index.js');
 
       expect(typeof getVizzlyStatus).toBe('function');
 
-      const status = getVizzlyStatus();
+      let status = getVizzlyStatus();
       expect(status).toHaveProperty('enabled');
       expect(status).toHaveProperty('ready');
     });
 
     it('should re-export getVizzlyInfo', async () => {
-      const { getVizzlyInfo } = await import('../src/index.js');
+      let { getVizzlyInfo } = await import('../src/index.js');
 
       expect(typeof getVizzlyInfo).toBe('function');
     });


### PR DESCRIPTION
## Why

This PR aligns the test-runner SDKs: Vitest and Ember. These integrations are close to the user’s actual test code, so the contract has to be exact. When someone calls `expect(...).toMatchScreenshot(...)` or `vizzlyScreenshot(...)`, they need to know which options affect browser capture, which options affect Vizzly comparison/routing, which options are metadata, and when a visual diff fails the test.

Before this pass, that boundary was fuzzy. Vitest could pass Vizzly-only options toward browser screenshot APIs. Element captures could receive page-only `fullPage` behavior. Ember could not reliably bridge build ID, request timeout, viewport, threshold, and min-cluster settings from browser test code to the node screenshot server and then to Vizzly.

The goal here is boring parity: Vitest, Ember, the JS client, and the CLI should describe the same screenshot in the same conceptual way.

## What changed

### Vitest

- Discovers `failOnDiff` from `.vizzly/server.json` and exposes it to the browser context with server URL and build ID.
- Removes unused plugin options from `vizzlyPlugin()` so screenshot behavior lives on matcher calls.
- Supports both named and options-only matcher call shapes.
- Strips Vizzly-only fields before calling Playwright/Vitest screenshot APIs: `properties`, `threshold`, `minClusterSize`, `failOnDiff`, `buildId`, and `requestTimeout`.
- Prevents element screenshots from receiving page-only `fullPage`.
- Adds stable screenshot metadata for framework, browser, URL, viewport, viewport dimensions, threshold, min cluster size, full-page mode, and user properties.
- Treats new baselines as successful captures.
- Fails assertions for real visual diffs only when `failOnDiff` resolves to true.
- Updates matcher types for supported Playwright screenshot options plus Vizzly comparison/request options.

### Ember

- Injects screenshot URL, build ID, and fail-on-diff settings into the test page before navigation.
- Forwards `buildId` and `requestTimeout` from the screenshot server to Vizzly.
- Sets viewport before capture when the helper asks for a specific size.
- Keeps `fullPage` on page captures and strips it from selector captures.
- Forwards `threshold`, `minClusterSize`, `buildId`, `requestTimeout`, viewport, and user properties in a stable payload.
- Allows per-screenshot `failOnDiff` to override launcher/server settings.
- Improves the no-server error so users are pointed to `vizzly tdd start` or `vizzly run`.
- Keeps the Chromium CI stability args small and directly tested.

## Properties and options

This PR follows the core contract from #283. `properties` is the user metadata bag. Options that change capture, comparison, routing, request timeout, build grouping, or failure behavior stay as explicit options.

That is why the bridge code strips Vizzly-only fields before calling browser screenshot APIs and forwards them separately to Vizzly. It keeps browser capture behavior, comparison behavior, and metadata from quietly bleeding into one another.

## Testing

- Vitest plugin discovery of local server config and `failOnDiff`.
- Vitest matcher argument normalization, browser detection, metadata generation, element/page capture behavior, and option filtering.
- Ember launcher injection of build/fail settings.
- Ember screenshot-server request payloads, viewport handling, request timeout forwarding, selector/full-page behavior, and error handling.
- Ember test-support payload construction, reserved metadata behavior, injected/per-call build IDs, request timeout, and per-screenshot diff behavior.

This is good boundary coverage for option flow. It still does not replace a product-level E2E visual-diff fixture that proves the whole CLI/API/UI loop with a real changed screenshot.

## Verification

- `pnpm --dir clients/vitest test`: 23 passed.
- Ember package tests were verified in the preservation branch: 49 passed.
- Covered by the full preservation branch verification before the stack was split.
- Stack cleanup verification: `git diff --check` and PR file-list checks for #283 through #287.
