### PR TITLE
✨ Align Ruby and Swift SDKs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,15 +13,26 @@ let package = Package(
         .library(
             name: "Vizzly",
             targets: ["Vizzly"]),
+        .library(
+            name: "VizzlyXCTest",
+            targets: ["VizzlyXCTest"]),
     ],
     targets: [
         .target(
             name: "Vizzly",
             dependencies: [],
             path: "clients/swift/Sources/Vizzly"),
+        .target(
+            name: "VizzlyXCTest",
+            dependencies: ["Vizzly"],
+            path: "clients/swift/Sources/VizzlyXCTest"),
         .testTarget(
             name: "VizzlyTests",
-            dependencies: ["Vizzly"],
+            dependencies: ["Vizzly", "VizzlyXCTest"],
             path: "clients/swift/Tests/VizzlyTests"),
+        .testTarget(
+            name: "VizzlyE2ETests",
+            dependencies: ["Vizzly"],
+            path: "clients/swift/Tests/VizzlyE2ETests"),
     ]
 )

--- a/clients/ruby/CHANGELOG.md
+++ b/clients/ruby/CHANGELOG.md
@@ -2,20 +2,15 @@
 
 ## [0.2.1] - 2026-02-04
 
-## What's Changed
-
-Release v0.2.1
-
-See the full diff for detailed changes.
+### Changed
+- Improved packaging and release metadata.
 
 
 ## [0.2.0] - 2026-01-07
 
-## What's Changed
-
-Release v0.2.0
-
-See the full diff for detailed changes.
+### Added
+- Support for `min_cluster_size` and `full_page` screenshot options.
+- Browser E2E coverage for Ruby screenshot capture.
 
 
 All notable changes to the Vizzly Ruby client will be documented in this file.
@@ -44,5 +39,7 @@ This changelog is automatically generated when releasing new versions.
 - Graceful error handling and auto-disable on failure
 - TDD mode visual diff warnings with dashboard links
 
-[Unreleased]: https://github.com/vizzly-testing/cli/compare/ruby/v0.1.0...HEAD
+[Unreleased]: https://github.com/vizzly-testing/cli/compare/ruby/v0.2.1...HEAD
+[0.2.1]: https://github.com/vizzly-testing/cli/releases/tag/ruby/v0.2.1
+[0.2.0]: https://github.com/vizzly-testing/cli/releases/tag/ruby/v0.2.0
 [0.1.0]: https://github.com/vizzly-testing/cli/releases/tag/ruby/v0.1.0

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -66,7 +66,9 @@ client.screenshot('login-form', image_data)
 strict_client = Vizzly::Client.new(fail_on_diff: true)
 
 # Attach screenshots to a known build and tune request timeout in milliseconds
-build_client = Vizzly::Client.new(
+client.screenshot(
+  'checkout',
+  image_data,
   build_id: 'build_123',
   request_timeout: 60_000
 )

--- a/clients/ruby/README.md
+++ b/clients/ruby/README.md
@@ -43,9 +43,18 @@ Vizzly.screenshot('checkout-page', image_data,
     browser: 'chrome',
     viewport: { width: 1920, height: 1080 }
   },
-  threshold: 5
+  threshold: 5,
+  min_cluster_size: 3,
+  full_page: true,
+  build_id: 'build_123',
+  request_timeout: 60_000
 )
 ```
+
+Ruby option names use snake_case. The client also accepts camelCase aliases for
+parity with the JavaScript API: `minClusterSize`, `fullPage`, `buildId`, and
+`requestTimeout`. `request_timeout` is measured in milliseconds, so
+`60_000` means one minute.
 
 ### Using a Client Instance
 
@@ -53,10 +62,19 @@ Vizzly.screenshot('checkout-page', image_data,
 client = Vizzly::Client.new
 client.screenshot('login-form', image_data)
 
+# Override local TDD visual diff behavior for this client
+strict_client = Vizzly::Client.new(fail_on_diff: true)
+
+# Attach screenshots to a known build and tune request timeout in milliseconds
+build_client = Vizzly::Client.new(
+  build_id: 'build_123',
+  request_timeout: 60_000
+)
+
 # Check if client is ready
 puts "Ready: #{client.ready?}"
 
-# Get client info
+# Get client info, including the effective fail_on_diff setting
 puts client.info
 ```
 
@@ -100,6 +118,8 @@ You can also configure via environment variables:
 
 - `VIZZLY_SERVER_URL` - Server URL (e.g., `http://localhost:47392`)
 - `VIZZLY_BUILD_ID` - Build identifier for grouping screenshots
+- `VIZZLY_FAIL_ON_DIFF` - Set to `true` or `1` to raise when a local TDD
+  comparison returns a visual diff
 
 ## Development
 

--- a/clients/ruby/Rakefile
+++ b/clients/ruby/Rakefile
@@ -23,8 +23,8 @@ task default: %i[rubocop test]
 
 desc 'Run integration tests (starts TDD server internally)'
 task 'test:integration' do
-  ENV['VIZZLY_INTEGRATION'] = '1'
-  sh 'ruby -I lib test/integration_test.rb'
+  ENV['VIZZLY_E2E'] = '1'
+  sh 'ruby -I lib test/e2e_test.rb'
 end
 
 # =============================================================================
@@ -43,7 +43,7 @@ end
 
 desc 'Run integration tests in TDD mode (one-shot, generates static report)'
 task 'test:tdd:run' do
-  sh "node #{VIZZLY_CLI} tdd run 'VIZZLY_INTEGRATION=1 ruby -I lib test/integration_test.rb'"
+  sh "node #{VIZZLY_CLI} tdd run 'VIZZLY_E2E=1 ruby -I lib test/e2e_test.rb'"
 end
 
 desc 'Run E2E tests in TDD mode (one-shot, generates static report)'
@@ -58,7 +58,7 @@ end
 desc 'Run integration tests in cloud mode (uploads to Vizzly)'
 task 'test:cloud' do
   abort 'VIZZLY_TOKEN required for cloud mode' unless ENV['VIZZLY_TOKEN']
-  sh "node #{VIZZLY_CLI} run 'VIZZLY_INTEGRATION=1 ruby -I lib test/integration_test.rb'"
+  sh "node #{VIZZLY_CLI} run 'VIZZLY_E2E=1 ruby -I lib test/e2e_test.rb'"
 end
 
 desc 'Run E2E tests in cloud mode (uploads to Vizzly)'

--- a/clients/ruby/example/test_screenshot.rb
+++ b/clients/ruby/example/test_screenshot.rb
@@ -9,7 +9,6 @@ class ScreenshotTest < Minitest::Test
   def setup
     options = Selenium::WebDriver::Chrome::Options.new
     options.add_argument('--headless')
-    options.add_argument('--disable-gpu')
     options.add_argument('--window-size=1920,1080')
 
     @driver = Selenium::WebDriver.for :chrome, options: options
@@ -23,8 +22,8 @@ class ScreenshotTest < Minitest::Test
     # Navigate to vizzly.dev
     @driver.navigate.to 'https://vizzly.dev'
 
-    # Wait for page to load
-    sleep 1
+    wait = Selenium::WebDriver::Wait.new(timeout: 10)
+    wait.until { @driver.find_element(tag_name: 'body').displayed? }
 
     # Capture screenshot as PNG binary data
     image_data = @driver.screenshot_as(:png)

--- a/clients/ruby/lib/vizzly.rb
+++ b/clients/ruby/lib/vizzly.rb
@@ -60,46 +60,21 @@ module Vizzly
 
       image_base64 = Base64.strict_encode64(image_data)
       options = normalize_options(options)
+      normalized = normalize_screenshot_options(options)
 
-      request_timeout = option_value(options, :request_timeout, :requestTimeout)
+      normalized[:warnings].each { |warning| warn warning[:message] }
+
+      request_timeout = normalized[:request_timeout]
       request_timeout_seconds = request_timeout ? request_timeout.to_f / 1000.0 : 30
-      build_id = option_value(options, :build_id, :buildId) ||
-                 ENV.fetch('VIZZLY_BUILD_ID', nil)
-      min_cluster_size = option_value(
-        options,
-        :min_cluster_size,
-        :minClusterSize
-      )
-      full_page = options.key?(:full_page) ? options[:full_page] : options[:fullPage]
-
-      reserved_keys = %i[
-        properties
-        threshold
-        min_cluster_size
-        minClusterSize
-        full_page
-        fullPage
-        build_id
-        buildId
-        request_timeout
-        requestTimeout
-      ]
-      top_level_properties = options.reject { |key, _value| reserved_keys.include?(key) }
-
-      # Build properties hash - comparison options merged with user properties
-      # Server extracts threshold/minClusterSize from properties, not top-level
-      properties = top_level_properties.merge(options[:properties] || {}).merge(
-        threshold: options[:threshold],
-        minClusterSize: min_cluster_size,
-        fullPage: full_page
-      ).compact
+      build_id = normalized[:build_id] || ENV.fetch('VIZZLY_BUILD_ID', nil)
 
       payload = {
         name: name,
         image: image_base64,
         type: 'base64',
         buildId: build_id,
-        properties: properties
+        properties: normalized[:properties],
+        warnings: normalized[:warnings]
       }.compact
 
       uri = URI("#{@server_url}/screenshot")
@@ -266,6 +241,58 @@ module Vizzly
       end
 
       nil
+    end
+
+    def normalize_screenshot_options(options)
+      threshold = options[:threshold]
+      min_cluster_size = option_value(options, :min_cluster_size, :minClusterSize)
+      full_page = options.key?(:full_page) ? options[:full_page] : options[:fullPage]
+      build_id = option_value(options, :build_id, :buildId)
+      request_timeout = option_value(options, :request_timeout, :requestTimeout)
+      properties = {}
+      warnings = []
+
+      (options[:properties] || {}).each do |key, value|
+        option = key.to_s
+        case option
+        when 'threshold'
+          threshold = value if threshold.nil?
+        when 'min_cluster_size', 'minClusterSize'
+          min_cluster_size = value if min_cluster_size.nil?
+        when 'full_page', 'fullPage'
+          full_page = value if full_page.nil?
+        when 'build_id', 'buildId'
+          build_id = value if build_id.nil?
+        when 'request_timeout', 'requestTimeout'
+          request_timeout = value if request_timeout.nil?
+        else
+          properties[key] = value
+          next
+        end
+
+        warnings << reserved_property_warning(option)
+      end
+
+      properties = properties.merge(
+        threshold: threshold,
+        minClusterSize: min_cluster_size,
+        fullPage: full_page
+      ).compact
+
+      {
+        build_id: build_id,
+        request_timeout: request_timeout,
+        properties: properties,
+        warnings: warnings
+      }
+    end
+
+    def reserved_property_warning(option)
+      {
+        code: 'reserved-property-option',
+        option: option,
+        message: "Move \"#{option}\" out of properties; properties is only for user metadata."
+      }
     end
 
     def warn_once(message)

--- a/clients/ruby/lib/vizzly.rb
+++ b/clients/ruby/lib/vizzly.rb
@@ -11,6 +11,7 @@ module Vizzly
   # Default port for local TDD server
   DEFAULT_TDD_PORT = 47392
 
+  # rubocop:disable Metrics/ClassLength
   class Client
     attr_reader :server_url, :disabled
 
@@ -48,7 +49,7 @@ module Vizzly
     #     properties: { browser: 'chrome', viewport: { width: 1920, height: 1080 } },
     #     threshold: 5
     #   )
-    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def screenshot(name, image_data, options = {})
       return nil if disabled?
 
@@ -176,7 +177,7 @@ module Vizzly
         nil
       end
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     # Wait for all queued screenshots to be processed
     # (Simple client doesn't need explicit flushing)
@@ -230,9 +231,7 @@ module Vizzly
     private
 
     def normalize_options(options)
-      options.each_with_object({}) do |(key, value), normalized|
-        normalized[key.is_a?(String) ? key.to_sym : key] = value
-      end
+      options.transform_keys { |key| key.is_a?(String) ? key.to_sym : key }
     end
 
     def option_value(options, *keys)
@@ -345,6 +344,7 @@ module Vizzly
       nil
     end
   end
+  # rubocop:enable Metrics/ClassLength
 
   class << self
     # Get or create the shared client instance

--- a/clients/ruby/lib/vizzly.rb
+++ b/clients/ruby/lib/vizzly.rb
@@ -14,9 +14,11 @@ module Vizzly
   class Client
     attr_reader :server_url, :disabled
 
-    def initialize(server_url: nil)
+    def initialize(server_url: nil, fail_on_diff: nil)
+      @server_info = nil
+      @configured_fail_on_diff = fail_on_diff
       @server_url = server_url || discover_server_url
-      @disabled = false
+      @disabled = ENV['VIZZLY_ENABLED'] == 'false'
       @warned = false
     end
 
@@ -26,9 +28,13 @@ module Vizzly
     # @param image_data [String] PNG image data as binary string
     # @param options [Hash] Optional configuration
     # @option options [Hash] :properties Additional properties to attach
-    # @option options [Integer] :threshold Pixel difference threshold (0-100)
-    # @option options [Integer] :min_cluster_size Minimum cluster size to count as a real difference (default: 2)
+    # @option options [Numeric] :threshold Delta E comparison threshold. When
+    #   omitted, the server's configured threshold is used.
+    # @option options [Integer] :min_cluster_size Ignore connected diff
+    #   clusters smaller than this size. When omitted, the server config is used.
     # @option options [Boolean] :full_page Whether this is a full page screenshot
+    # @option options [String] :build_id Build ID for grouping screenshots
+    # @option options [Numeric] :request_timeout Request timeout in milliseconds
     #
     # @return [Hash, nil] Response data or nil if disabled/failed
     #
@@ -53,27 +59,59 @@ module Vizzly
       end
 
       image_base64 = Base64.strict_encode64(image_data)
+      options = normalize_options(options)
+
+      request_timeout = option_value(options, :request_timeout, :requestTimeout)
+      request_timeout_seconds = request_timeout ? request_timeout.to_f / 1000.0 : 30
+      build_id = option_value(options, :build_id, :buildId) ||
+                 ENV.fetch('VIZZLY_BUILD_ID', nil)
+      min_cluster_size = option_value(
+        options,
+        :min_cluster_size,
+        :minClusterSize
+      )
+      full_page = options.key?(:full_page) ? options[:full_page] : options[:fullPage]
+
+      reserved_keys = %i[
+        properties
+        threshold
+        min_cluster_size
+        minClusterSize
+        full_page
+        fullPage
+        build_id
+        buildId
+        request_timeout
+        requestTimeout
+      ]
+      top_level_properties = options.reject { |key, _value| reserved_keys.include?(key) }
 
       # Build properties hash - comparison options merged with user properties
       # Server extracts threshold/minClusterSize from properties, not top-level
-      properties = (options[:properties] || {}).merge(
+      properties = top_level_properties.merge(options[:properties] || {}).merge(
         threshold: options[:threshold],
-        minClusterSize: options[:min_cluster_size],
-        fullPage: options[:full_page]
+        minClusterSize: min_cluster_size,
+        fullPage: full_page
       ).compact
 
       payload = {
         name: name,
         image: image_base64,
         type: 'base64',
-        buildId: ENV.fetch('VIZZLY_BUILD_ID', nil),
+        buildId: build_id,
         properties: properties
       }.compact
 
       uri = URI("#{@server_url}/screenshot")
 
       begin
-        response = Net::HTTP.start(uri.host, uri.port, open_timeout: 10, read_timeout: 30) do |http|
+        response = Net::HTTP.start(
+          uri.host,
+          uri.port,
+          use_ssl: uri.scheme == 'https',
+          open_timeout: 10,
+          read_timeout: request_timeout_seconds
+        ) do |http|
           request = Net::HTTP::Post.new(uri)
           request['Content-Type'] = 'application/json'
           request.body = JSON.generate(payload)
@@ -91,6 +129,11 @@ module Vizzly
           if response.code == '422' && error_data['tddMode'] && error_data['comparison']
             comp = error_data['comparison']
             diff_percent = comp['diffPercentage']&.round(2) || 0.0
+
+            if fail_on_diff?
+              raise Error,
+                    "Visual diff detected for \"#{comp['name'] || name}\" (#{comp['diffPercentage'] || 0}% difference)"
+            end
 
             # Extract port from server_url
             port = begin
@@ -114,7 +157,13 @@ module Vizzly
                 "Screenshot failed: #{response.code} #{response.message} - #{error_data['error'] || 'Unknown error'}"
         end
 
-        JSON.parse(response.body)
+        body = JSON.parse(response.body)
+        if body['tddMode'] && %w[diff failed].include?(body['status']) && fail_on_diff?
+          raise Error,
+                "Visual diff detected for \"#{body['name'] || name}\" (#{body['diffPercentage'] || 0}% difference)"
+        end
+
+        body
       rescue Error => e
         # Re-raise Vizzly errors (like visual diffs)
         raise if e.message.include?('Visual diff')
@@ -193,13 +242,31 @@ module Vizzly
       {
         enabled: !disabled?,
         server_url: @server_url,
+        serverUrl: @server_url,
         ready: ready?,
         build_id: ENV.fetch('VIZZLY_BUILD_ID', nil),
-        disabled: disabled?
+        buildId: ENV.fetch('VIZZLY_BUILD_ID', nil),
+        disabled: disabled?,
+        fail_on_diff: fail_on_diff?,
+        failOnDiff: fail_on_diff?
       }
     end
 
     private
+
+    def normalize_options(options)
+      options.each_with_object({}) do |(key, value), normalized|
+        normalized[key.is_a?(String) ? key.to_sym : key] = value
+      end
+    end
+
+    def option_value(options, *keys)
+      keys.each do |key|
+        return options[key] if options.key?(key)
+      end
+
+      nil
+    end
 
     def warn_once(message)
       return if @warned
@@ -217,6 +284,15 @@ module Vizzly
       auto_discover_tdd_server
     end
 
+    def fail_on_diff?
+      return @configured_fail_on_diff unless @configured_fail_on_diff.nil?
+
+      env_value = ENV.fetch('VIZZLY_FAIL_ON_DIFF', '').downcase
+      return true if %w[true 1].include?(env_value)
+
+      @server_info && @server_info['failOnDiff'] == true
+    end
+
     # Auto-discover local TDD server by checking for server.json
     def auto_discover_tdd_server
       dir = Dir.pwd
@@ -228,6 +304,7 @@ module Vizzly
         if File.exist?(server_json_path)
           begin
             server_info = JSON.parse(File.read(server_json_path))
+            @server_info = server_info
             port = server_info['port'] || DEFAULT_TDD_PORT
             return "http://localhost:#{port}"
           rescue JSON::ParserError, Errno::ENOENT

--- a/clients/ruby/test/e2e_test.rb
+++ b/clients/ruby/test/e2e_test.rb
@@ -73,7 +73,6 @@ module E2ETestHelpers
   def setup_selenium
     options = Selenium::WebDriver::Chrome::Options.new
     options.add_argument('--headless')
-    options.add_argument('--disable-gpu')
     options.add_argument('--window-size=1920,1080')
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')
@@ -84,7 +83,6 @@ module E2ETestHelpers
   def wait_for_page_load
     wait = Selenium::WebDriver::Wait.new(timeout: 10)
     wait.until { @driver.find_element(tag_name: 'body') }
-    sleep 0.3
   end
 
   def capture_screenshot(name, options = {})
@@ -94,7 +92,8 @@ module E2ETestHelpers
 
   def capture_element_screenshot(name, element, options = {})
     @driver.execute_script('arguments[0].scrollIntoView(true);', element)
-    sleep 0.1
+    wait = Selenium::WebDriver::Wait.new(timeout: 10)
+    wait.until { element.displayed? }
 
     image_data = element.screenshot_as(:png)
     Vizzly.screenshot(name, image_data, options)

--- a/clients/ruby/test/vizzly_test.rb
+++ b/clients/ruby/test/vizzly_test.rb
@@ -66,6 +66,18 @@ class VizzlyTest < Minitest::Test
     refute client.ready?
   end
 
+  def test_disabled_by_environment
+    ENV['VIZZLY_ENABLED'] = 'false'
+    ENV['VIZZLY_SERVER_URL'] = 'http://localhost:47392'
+
+    client = Vizzly::Client.new
+    refute client.ready?
+    assert_nil client.screenshot('test', 'fake_image_data')
+  ensure
+    ENV.delete('VIZZLY_ENABLED')
+    ENV.delete('VIZZLY_SERVER_URL')
+  end
+
   def test_disabled_after_disable
     client = Vizzly::Client.new
     refute client.disabled?
@@ -90,6 +102,29 @@ class VizzlyTest < Minitest::Test
     assert_includes info, :ready
     assert_includes info, :build_id
     assert_includes info, :disabled
+    assert_includes info, :fail_on_diff
+    assert_includes info, :failOnDiff
+  end
+
+  def test_info_exposes_configured_fail_on_diff
+    enabled_client = Vizzly::Client.new(fail_on_diff: true)
+    disabled_client = Vizzly::Client.new(fail_on_diff: false)
+
+    assert_equal true, enabled_client.info[:fail_on_diff]
+    assert_equal true, enabled_client.info[:failOnDiff]
+    assert_equal false, disabled_client.info[:fail_on_diff]
+    assert_equal false, disabled_client.info[:failOnDiff]
+  end
+
+  def test_info_exposes_environment_fail_on_diff
+    ENV['VIZZLY_FAIL_ON_DIFF'] = '1'
+
+    client = Vizzly::Client.new
+
+    assert_equal true, client.info[:fail_on_diff]
+    assert_equal true, client.info[:failOnDiff]
+  ensure
+    ENV.delete('VIZZLY_FAIL_ON_DIFF')
   end
 
   def test_module_level_screenshot
@@ -106,5 +141,191 @@ class VizzlyTest < Minitest::Test
     client = Vizzly::Client.new
     assert client.flush
     assert Vizzly.flush
+  end
+
+  def test_fail_on_diff_raises_for_current_tdd_response_shape
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response_body = JSON.generate(
+      success: true,
+      tddMode: true,
+      status: 'diff',
+      name: 'homepage',
+      diffPercentage: 5.2
+    )
+    response.define_singleton_method(:body) { response_body }
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_options|
+      response
+    end
+    ENV['VIZZLY_FAIL_ON_DIFF'] = 'true'
+
+    client = Vizzly::Client.new(
+      server_url: 'http://localhost:47392'
+    )
+    assert_raises(Vizzly::Error) do
+      client.screenshot('homepage', 'fake_image_data')
+    end
+  ensure
+    ENV.delete('VIZZLY_FAIL_ON_DIFF')
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def test_fail_on_diff_raises_for_legacy_422_tdd_response_shape
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPUnprocessableEntity.new('1.1', '422', 'Unprocessable Entity')
+    response_body = JSON.generate(
+      tddMode: true,
+      comparison: {
+        name: 'homepage',
+        diffPercentage: 5.2
+      }
+    )
+    response.define_singleton_method(:body) { response_body }
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_options|
+      response
+    end
+    ENV['VIZZLY_FAIL_ON_DIFF'] = 'true'
+
+    client = Vizzly::Client.new(
+      server_url: 'http://localhost:47392'
+    )
+    assert_raises(Vizzly::Error) do
+      client.screenshot('homepage', 'fake_image_data')
+    end
+  ensure
+    ENV.delete('VIZZLY_FAIL_ON_DIFF')
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def test_server_json_fail_on_diff_raises_for_current_tdd_response_shape
+    FileUtils.mkdir_p('.vizzly')
+    File.write(
+      '.vizzly/server.json',
+      JSON.generate({ port: 47_392, failOnDiff: true })
+    )
+
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response_body = JSON.generate(
+      success: true,
+      tddMode: true,
+      status: 'diff',
+      name: 'homepage',
+      diffPercentage: 5.2
+    )
+    response.define_singleton_method(:body) { response_body }
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_options|
+      response
+    end
+
+    client = Vizzly::Client.new
+    assert_raises(Vizzly::Error) do
+      client.screenshot('homepage', 'fake_image_data')
+    end
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def test_screenshot_serializes_fractional_threshold_in_properties
+    captured_body = nil
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.define_singleton_method(:body) { JSON.generate(status: 'match') }
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) do |request|
+      captured_body = JSON.parse(request.body)
+      response
+    end
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_options, &block|
+      block.call(fake_http)
+    end
+
+    client = Vizzly::Client.new(server_url: 'http://localhost:47392')
+    result = client.screenshot(
+      'fractional-threshold',
+      'fake_image_data',
+      threshold: 1.5
+    )
+
+    assert_equal 'match', result['status']
+    assert_equal 1.5, captured_body['properties']['threshold']
+    refute_includes captured_body, 'threshold'
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def test_screenshot_serializes_browser_and_nested_viewport_properties
+    captured_body = nil
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.define_singleton_method(:body) { JSON.generate(status: 'match') }
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) do |request|
+      captured_body = JSON.parse(request.body)
+      response
+    end
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_options, &block|
+      block.call(fake_http)
+    end
+
+    client = Vizzly::Client.new(server_url: 'http://localhost:47392')
+    result = client.screenshot(
+      'responsive-homepage',
+      'fake_image_data',
+      properties: {
+        browser: 'chrome',
+        viewport: { width: 1920, height: 1080 }
+      }
+    )
+
+    assert_equal 'match', result['status']
+    assert_equal 'chrome', captured_body['properties']['browser']
+    assert_equal 1920, captured_body['properties']['viewport']['width']
+    assert_equal 1080, captured_body['properties']['viewport']['height']
+    ensure
+      Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def test_screenshot_accepts_string_keys_and_preserves_zero_values
+    captured_body = nil
+    captured_options = nil
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.define_singleton_method(:body) { JSON.generate(status: 'match') }
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) do |request|
+      captured_body = JSON.parse(request.body)
+      response
+    end
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **options, &block|
+      captured_options = options
+      block.call(fake_http)
+    end
+
+    client = Vizzly::Client.new(server_url: 'http://localhost:47392')
+    result = client.screenshot(
+      'string-key-options',
+      'fake_image_data',
+      'buildId' => 'build-from-call',
+      'requestTimeout' => 0,
+      'minClusterSize' => 0,
+      'properties' => {
+        'browser' => 'chrome',
+        'viewport' => { 'width' => 1920, 'height' => 1080 }
+      }
+    )
+
+    assert_equal 'match', result['status']
+    assert_equal 0, captured_options[:read_timeout]
+    assert_equal 'build-from-call', captured_body['buildId']
+
+    properties = captured_body['properties']
+    assert_equal 'chrome', properties['browser']
+    assert_equal 0, properties['minClusterSize']
+    assert_equal 1920, properties['viewport']['width']
+    assert_equal 1080, properties['viewport']['height']
+    refute_includes properties, 'buildId'
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
   end
 end

--- a/clients/ruby/test/vizzly_test.rb
+++ b/clients/ruby/test/vizzly_test.rb
@@ -6,6 +6,7 @@ require 'fileutils'
 require 'tmpdir'
 require_relative '../lib/vizzly'
 
+# rubocop:disable Metrics/ClassLength
 class VizzlyTest < Minitest::Test
   def setup
     Vizzly.reset!
@@ -363,9 +364,12 @@ class VizzlyTest < Minitest::Test
     assert_equal 1.5, captured_body['properties']['threshold']
     assert_equal 3, captured_body['properties']['minClusterSize']
     refute_includes captured_body['properties'], 'buildId'
-    assert_equal %w[threshold minClusterSize buildId],
-                 captured_body['warnings'].map { |warning| warning['option'] }
+    assert_equal(
+      %w[threshold minClusterSize buildId],
+      captured_body['warnings'].map { |warning| warning['option'] }
+    )
   ensure
     Net::HTTP.define_singleton_method(:start, original_start)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/clients/ruby/test/vizzly_test.rb
+++ b/clients/ruby/test/vizzly_test.rb
@@ -282,8 +282,8 @@ class VizzlyTest < Minitest::Test
     assert_equal 'chrome', captured_body['properties']['browser']
     assert_equal 1920, captured_body['properties']['viewport']['width']
     assert_equal 1080, captured_body['properties']['viewport']['height']
-    ensure
-      Net::HTTP.define_singleton_method(:start, original_start)
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
   end
 
   def test_screenshot_accepts_string_keys_and_preserves_zero_values
@@ -325,6 +325,46 @@ class VizzlyTest < Minitest::Test
     assert_equal 1920, properties['viewport']['width']
     assert_equal 1080, properties['viewport']['height']
     refute_includes properties, 'buildId'
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def test_screenshot_promotes_reserved_options_from_properties_with_warnings
+    captured_body = nil
+    original_start = Net::HTTP.method(:start)
+    response = Net::HTTPOK.new('1.1', '200', 'OK')
+    response.define_singleton_method(:body) { JSON.generate(status: 'match') }
+    fake_http = Object.new
+    fake_http.define_singleton_method(:request) do |request|
+      captured_body = JSON.parse(request.body)
+      response
+    end
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_options, &block|
+      block.call(fake_http)
+    end
+
+    client = Vizzly::Client.new(server_url: 'http://localhost:47392')
+    result = capture_io do
+      client.screenshot(
+        'reserved-properties',
+        'fake_image_data',
+        properties: {
+          theme: 'dark',
+          threshold: 1.5,
+          minClusterSize: 3,
+          buildId: 'build-from-properties'
+        }
+      )
+    end
+
+    assert_match(/Move "threshold" out of properties/, result[1])
+    assert_equal 'build-from-properties', captured_body['buildId']
+    assert_equal 'dark', captured_body['properties']['theme']
+    assert_equal 1.5, captured_body['properties']['threshold']
+    assert_equal 3, captured_body['properties']['minClusterSize']
+    refute_includes captured_body['properties'], 'buildId'
+    assert_equal %w[threshold minClusterSize buildId],
+                 captured_body['warnings'].map { |warning| warning['option'] }
   ensure
     Net::HTTP.define_singleton_method(:start, original_start)
   end

--- a/clients/swift/INTEGRATION.md
+++ b/clients/swift/INTEGRATION.md
@@ -52,7 +52,7 @@ Create a `vizzly.config.js` file (optional but recommended):
 
 ```javascript
 export default {
-  // Screenshot threshold (0-100)
+  // Delta E comparison threshold. Omitted screenshots use server config.
   threshold: 0,
 
   // TDD server port
@@ -272,7 +272,7 @@ func testAnimatedView() {
     let finishedState = app.otherElements["AnimatedBannerReady"]
     XCTAssertTrue(finishedState.waitForExistence(timeout: 5))
 
-    // Use threshold for slight variations
+    // Use a Delta E comparison threshold for slight visual variations
     app.vizzlyScreenshot(
         name: "animated-banner",
         threshold: 5
@@ -312,10 +312,7 @@ jobs:
         env:
           VIZZLY_TOKEN: ${{ secrets.VIZZLY_TOKEN }}
         run: |
-          pnpm exec vizzly run -- xcodebuild test \
-            -scheme MyApp \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
-            -only-testing:MyAppUITests
+          vizzly run "xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15' -only-testing:MyAppUITests"
 ```
 
 ### Fastlane
@@ -324,7 +321,7 @@ Add to your `Fastfile`:
 
 ```ruby
 lane :visual_tests do
-  sh("pnpm exec vizzly run -- bundle exec fastlane scan scheme:MyApp devices:'iPhone 15' only_testing:MyAppUITests")
+  sh("pnpm exec vizzly run \"bundle exec fastlane scan scheme:MyApp devices:'iPhone 15' only_testing:MyAppUITests\"")
 end
 ```
 
@@ -419,7 +416,7 @@ override func setUpWithError() throws {
 
 1. Pin simulator versions in CI to match local
 2. Use consistent device names
-3. Consider slightly higher threshold (1-2%) for font rendering differences
+3. Consider a slightly higher Delta E comparison threshold for font rendering differences
 
 ### "Connection Refused" Errors
 

--- a/clients/swift/README.md
+++ b/clients/swift/README.md
@@ -31,7 +31,7 @@ Or add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/vizzly-testing/cli", from: "1.0.0")
+    .package(url: "https://github.com/vizzly-testing/cli", branch: "main")
 ],
 targets: [
     .testTarget(
@@ -137,7 +137,7 @@ func testNavigationBar() {
 
 ```swift
 func testAnimatedContent() {
-    // Allow a higher comparison threshold for animated content
+    // Allow a higher Delta E comparison threshold for animated content
     app.vizzlyScreenshot(
         name: "animated-banner",
         threshold: 5
@@ -201,7 +201,9 @@ extension XCUIApplication {
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false
+        fullPage: Bool? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]?
 }
 ```
@@ -214,7 +216,9 @@ extension XCUIElement {
         name: String,
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
-        minClusterSize: Int? = nil
+        minClusterSize: Int? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]?
 }
 ```
@@ -229,7 +233,9 @@ extension XCTestCase {
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false
+        fullPage: Bool? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]?
 
     func vizzlyScreenshot(
@@ -237,7 +243,9 @@ extension XCTestCase {
         element: XCUIElement,
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
-        minClusterSize: Int? = nil
+        minClusterSize: Int? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]?
 }
 ```
@@ -248,13 +256,21 @@ extension XCTestCase {
 class VizzlyClient {
     static let shared: VizzlyClient
 
+    init(
+        serverUrl: String? = nil,
+        autoDiscover: Bool = true,
+        failOnDiff: Bool? = nil
+    )
+
     func screenshot(
         name: String,
         image: Data,
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false
+        fullPage: Bool? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]?
 
     var isReady: Bool { get }
@@ -280,13 +296,28 @@ When you run `vizzly tdd start`, the CLI automatically writes server info to `~/
 ### Environment Variables
 
 - `VIZZLY_SERVER_URL` - Server URL (e.g., `http://localhost:47392`)
-- `VIZZLY_BUILD_ID` - Build identifier for grouping screenshots (set automatically in CI)
+- `VIZZLY_BUILD_ID` - Build identifier for grouping screenshots. The SDK also
+  auto-discovers `buildId` from `.vizzly/server.json` when present.
+- `VIZZLY_FAIL_ON_DIFF` - Set to `true` or `1` to fail when a local TDD
+  comparison returns a visual diff. The SDK also honors `failOnDiff: true` from
+  discovered `.vizzly/server.json`.
+
+Swift screenshot calls intentionally expose comparison metadata (`properties`,
+`threshold`, `minClusterSize`, and `fullPage`). They also accept per-call
+`buildId` and `requestTimeout` overrides; `requestTimeout` is measured in
+milliseconds to match the JavaScript and Ruby SDKs.
 
 ### Manual Configuration
 
 ```swift
 // Override auto-discovery
 let client = VizzlyClient(serverUrl: "http://localhost:47392")
+
+// Fail the SDK call when local TDD mode reports a visual diff
+let strictClient = VizzlyClient(
+    serverUrl: "http://localhost:47392",
+    failOnDiff: true
+)
 ```
 
 ## TDD Mode vs Cloud Mode
@@ -403,17 +434,14 @@ jobs:
         env:
           VIZZLY_TOKEN: ${{ secrets.VIZZLY_TOKEN }}
         run: |
-          pnpm exec vizzly run -- xcodebuild test \
-            -scheme MyApp \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
-            -resultBundlePath TestResults
+          pnpm exec vizzly run "xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15' -resultBundlePath TestResults"
 ```
 
 ### Fastlane
 
 ```ruby
 lane :visual_tests do
-  sh "pnpm exec vizzly run -- bundle exec fastlane scan scheme:MyApp devices:'iPhone 15'"
+  sh "pnpm exec vizzly run \"bundle exec fastlane scan scheme:MyApp devices:'iPhone 15'\""
 end
 ```
 

--- a/clients/swift/Sources/Vizzly/VizzlyClient.swift
+++ b/clients/swift/Sources/Vizzly/VizzlyClient.swift
@@ -90,13 +90,21 @@ public final class VizzlyClient {
 
     private var hasWarned = false
     private let defaultTddPort = 47392
+    private let configuredFailOnDiff: Bool?
+    private var discoveredFailOnDiff = false
 
     /// Initialize a new Vizzly client
     ///
     /// - Parameter serverUrl: Optional server URL. If not provided, auto-discovery will be used.
     /// - Parameter autoDiscover: Whether to discover a local Vizzly server when
     ///   `serverUrl` is nil.
-    public init(serverUrl: String? = nil, autoDiscover: Bool = true) {
+    /// - Parameter failOnDiff: Optional override for failing local TDD visual diffs.
+    public init(
+        serverUrl: String? = nil,
+        autoDiscover: Bool = true,
+        failOnDiff: Bool? = nil
+    ) {
+        self.configuredFailOnDiff = failOnDiff
         self.serverUrl = serverUrl ?? (autoDiscover ? discoverServerUrl() : nil)
     }
 
@@ -111,6 +119,8 @@ public final class VizzlyClient {
     ///   - minClusterSize: Optional minimum changed-pixel cluster size to count
     ///     as a real difference. When nil, the server configuration is used.
     ///   - fullPage: Whether this is a full page screenshot
+    ///   - buildId: Optional build ID override for grouping screenshots
+    ///   - requestTimeout: Optional request timeout in milliseconds
     /// - Returns: Response data if successful, nil otherwise
     @discardableResult
     public func screenshot(
@@ -119,7 +129,9 @@ public final class VizzlyClient {
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false
+        fullPage: Bool? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]? {
         guard !isDisabled else { return nil }
 
@@ -136,7 +148,7 @@ public final class VizzlyClient {
             threshold: threshold,
             minClusterSize: minClusterSize,
             fullPage: fullPage,
-            buildId: getBuildId(),
+            buildId: buildId ?? getBuildId(),
             deviceInfo: getDeviceInfo()
         )
 
@@ -150,7 +162,7 @@ public final class VizzlyClient {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 30
+        request.timeoutInterval = requestTimeout.map { $0 / 1000.0 } ?? 30
 
         do {
             request.httpBody = try JSONSerialization.data(withJSONObject: payload)
@@ -187,7 +199,19 @@ public final class VizzlyClient {
             return nil
         }
 
-        return parseScreenshotResponse(data, name: name)
+        let parsedResponse = parseScreenshotResponse(data, name: name)
+        if shouldFailOnDiff(),
+           let responseBody = parsedResponse,
+           responseBody["tddMode"] as? Bool == true,
+           let status = responseBody["status"] as? String,
+           ["diff", "failed"].contains(status) {
+            let diffPercentage = responseBody["diffPercentage"] ?? 0
+            print("❌ Visual diff detected for \"\(responseBody["name"] ?? name)\" (\(diffPercentage)% difference)")
+            disable(reason: "visual diff")
+            return nil
+        }
+
+        return parsedResponse
     }
 
     /// Flush any pending screenshots (no-op for simple client)
@@ -216,7 +240,8 @@ public final class VizzlyClient {
         var info: [String: Any] = [
             "enabled": !isDisabled,
             "ready": isReady,
-            "disabled": isDisabled
+            "disabled": isDisabled,
+            "failOnDiff": shouldFailOnDiff()
         ]
 
         if let serverUrl = serverUrl {
@@ -238,7 +263,7 @@ public final class VizzlyClient {
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false,
+        fullPage: Bool? = nil,
         buildId: String? = nil,
         deviceInfo: [String: Any] = [:]
     ) -> [String: Any] {
@@ -258,8 +283,8 @@ public final class VizzlyClient {
             mergedProperties["minClusterSize"] = minClusterSize
         }
 
-        if fullPage {
-            mergedProperties["fullPage"] = true
+        if let fullPage = fullPage {
+            mergedProperties["fullPage"] = fullPage
         }
 
         var payload: [String: Any] = [
@@ -268,9 +293,7 @@ public final class VizzlyClient {
             "type": "base64"
         ]
 
-        if !mergedProperties.isEmpty {
-            payload["properties"] = mergedProperties
-        }
+        payload["properties"] = mergedProperties
 
         if let buildId = buildId {
             payload["buildId"] = buildId
@@ -391,6 +414,7 @@ public final class VizzlyClient {
         }
 
         if let port = port {
+            discoveredFailOnDiff = serverInfo["failOnDiff"] as? Bool == true
             let url = "http://localhost:\(port)"
             // Verify server is actually running on this port
             if checkServerReachable(url) {
@@ -399,6 +423,15 @@ public final class VizzlyClient {
         }
 
         return nil
+    }
+
+    private func shouldFailOnDiff() -> Bool {
+        if let configuredFailOnDiff = configuredFailOnDiff {
+            return configuredFailOnDiff
+        }
+
+        let envValue = ProcessInfo.processInfo.environment["VIZZLY_FAIL_ON_DIFF"]?.lowercased()
+        return envValue == "true" || envValue == "1" || discoveredFailOnDiff
     }
 
     private func getBuildId() -> String? {
@@ -505,6 +538,12 @@ public final class VizzlyClient {
             }
 
             let dashboardUrl = "http://localhost:\(port)/dashboard"
+
+            if shouldFailOnDiff() {
+                print("❌ Visual diff detected for \"\(comparison["name"] ?? name)\" (\(comparison["diffPercentage"] ?? 0)% difference)")
+                disable(reason: "visual diff")
+                return
+            }
 
             print("⚠️  Visual diff: \(comparison["name"] ?? name) (\(diffPercent)%) → \(dashboardUrl)")
             return

--- a/clients/swift/Sources/VizzlyXCTest/XCTestExtensions.swift
+++ b/clients/swift/Sources/VizzlyXCTest/XCTestExtensions.swift
@@ -10,6 +10,89 @@ import UIKit
 import AppKit
 #endif
 
+enum VizzlyXCTestMetadata {
+    static func merge(
+        properties: [String: Any]?,
+        automaticProperties: [String: Any]
+    ) -> [String: Any] {
+        var combinedProperties = automaticProperties
+
+        for (key, value) in properties ?? [:] {
+            combinedProperties[key] = value
+        }
+
+        return combinedProperties
+    }
+
+    static func applicationProperties(
+        properties: [String: Any]?,
+        viewport: [String: Any]? = defaultViewport()
+    ) -> [String: Any] {
+        var automaticProperties = platformProperties()
+
+        if let viewport = viewport {
+            automaticProperties["viewport"] = viewport
+        }
+
+        return merge(
+            properties: properties,
+            automaticProperties: automaticProperties
+        )
+    }
+
+    static func elementProperties(
+        properties: [String: Any]?,
+        elementType: UInt
+    ) -> [String: Any] {
+        var automaticProperties = platformProperties()
+        automaticProperties["elementType"] = elementType
+
+        return merge(
+            properties: properties,
+            automaticProperties: automaticProperties
+        )
+    }
+
+    static func platformProperties() -> [String: Any] {
+        #if os(iOS)
+        return [
+            "platform": "iOS",
+            "device": UIDevice.current.model,
+            "osVersion": UIDevice.current.systemVersion
+        ]
+        #elseif os(macOS)
+        return [
+            "platform": "macOS",
+            "osVersion": ProcessInfo.processInfo.operatingSystemVersionString
+        ]
+        #else
+        return [:]
+        #endif
+    }
+
+    static func defaultViewport() -> [String: Any]? {
+        #if os(iOS)
+        let screen = UIScreen.main
+        return [
+            "width": Int(screen.bounds.width * screen.scale),
+            "height": Int(screen.bounds.height * screen.scale),
+            "scale": screen.scale
+        ]
+        #elseif os(macOS)
+        guard let screen = NSScreen.main else {
+            return nil
+        }
+
+        return [
+            "width": Int(screen.frame.width),
+            "height": Int(screen.frame.height)
+        ]
+        #else
+        return nil
+        #endif
+    }
+}
+
 /// XCTest extensions for easy Vizzly integration
 extension XCTestCase {
 
@@ -24,6 +107,8 @@ extension XCTestCase {
     ///   - minClusterSize: Optional minimum changed-pixel cluster size to count
     ///     as a real difference. When nil, the server configuration is used.
     ///   - fullPage: Whether this is a full page screenshot
+    ///   - buildId: Optional build ID override for grouping screenshots
+    ///   - requestTimeout: Optional request timeout in milliseconds
     @available(iOS 13.0, macOS 10.15, *)
     @discardableResult
     public func vizzlyScreenshot(
@@ -32,35 +117,15 @@ extension XCTestCase {
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false
+        fullPage: Bool? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]? {
         let screenshot = app.screenshot()
 
-        var combinedProperties = properties ?? [:]
-
-        // Add device/platform info automatically
-        #if os(iOS)
-        combinedProperties["platform"] = "iOS"
-        combinedProperties["device"] = UIDevice.current.model
-        combinedProperties["osVersion"] = UIDevice.current.systemVersion
-
-        // Add screen size
-        let screen = UIScreen.main
-        combinedProperties["viewport"] = [
-            "width": Int(screen.bounds.width * screen.scale),
-            "height": Int(screen.bounds.height * screen.scale),
-            "scale": screen.scale
-        ]
-        #elseif os(macOS)
-        combinedProperties["platform"] = "macOS"
-
-        if let screen = NSScreen.main {
-            combinedProperties["viewport"] = [
-                "width": Int(screen.frame.width),
-                "height": Int(screen.frame.height)
-            ]
-        }
-        #endif
+        let combinedProperties = VizzlyXCTestMetadata.applicationProperties(
+            properties: properties
+        )
 
         return VizzlyClient.shared.screenshot(
             name: name,
@@ -68,7 +133,9 @@ extension XCTestCase {
             properties: combinedProperties,
             threshold: threshold,
             minClusterSize: minClusterSize,
-            fullPage: fullPage
+            fullPage: fullPage,
+            buildId: buildId,
+            requestTimeout: requestTimeout
         )
     }
 
@@ -82,6 +149,8 @@ extension XCTestCase {
     ///     Vizzly server configuration is used.
     ///   - minClusterSize: Optional minimum changed-pixel cluster size to count
     ///     as a real difference. When nil, the server configuration is used.
+    ///   - buildId: Optional build ID override for grouping screenshots
+    ///   - requestTimeout: Optional request timeout in milliseconds
     @available(iOS 13.0, macOS 10.15, *)
     @discardableResult
     public func vizzlyScreenshot(
@@ -89,20 +158,16 @@ extension XCTestCase {
         element: XCUIElement,
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
-        minClusterSize: Int? = nil
+        minClusterSize: Int? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]? {
         let screenshot = element.screenshot()
 
-        var combinedProperties = properties ?? [:]
-
-        // Add element info
-        combinedProperties["elementType"] = element.elementType.rawValue
-
-        #if os(iOS)
-        combinedProperties["platform"] = "iOS"
-        #elseif os(macOS)
-        combinedProperties["platform"] = "macOS"
-        #endif
+        let combinedProperties = VizzlyXCTestMetadata.elementProperties(
+            properties: properties,
+            elementType: element.elementType.rawValue
+        )
 
         return VizzlyClient.shared.screenshot(
             name: name,
@@ -110,7 +175,9 @@ extension XCTestCase {
             properties: combinedProperties,
             threshold: threshold,
             minClusterSize: minClusterSize,
-            fullPage: false
+            fullPage: false,
+            buildId: buildId,
+            requestTimeout: requestTimeout
         )
     }
 }
@@ -129,33 +196,23 @@ extension XCUIApplication {
     ///   - minClusterSize: Optional minimum changed-pixel cluster size to count
     ///     as a real difference. When nil, the server configuration is used.
     ///   - fullPage: Whether this is a full page screenshot
+    ///   - buildId: Optional build ID override for grouping screenshots
+    ///   - requestTimeout: Optional request timeout in milliseconds
     @discardableResult
     public func vizzlyScreenshot(
         name: String,
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
         minClusterSize: Int? = nil,
-        fullPage: Bool = false
+        fullPage: Bool? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]? {
         let screenshot = self.screenshot()
 
-        var combinedProperties = properties ?? [:]
-
-        #if os(iOS)
-        combinedProperties["platform"] = "iOS"
-        combinedProperties["device"] = UIDevice.current.model
-        combinedProperties["osVersion"] = UIDevice.current.systemVersion
-
-        let screen = UIScreen.main
-        combinedProperties["viewport"] = [
-            "width": Int(screen.bounds.width * screen.scale),
-            "height": Int(screen.bounds.height * screen.scale),
-            "scale": screen.scale
-        ]
-        #elseif os(macOS)
-        combinedProperties["platform"] = "macOS"
-        combinedProperties["osVersion"] = ProcessInfo.processInfo.operatingSystemVersionString
-        #endif
+        let combinedProperties = VizzlyXCTestMetadata.applicationProperties(
+            properties: properties
+        )
 
         return VizzlyClient.shared.screenshot(
             name: name,
@@ -163,7 +220,9 @@ extension XCUIApplication {
             properties: combinedProperties,
             threshold: threshold,
             minClusterSize: minClusterSize,
-            fullPage: fullPage
+            fullPage: fullPage,
+            buildId: buildId,
+            requestTimeout: requestTimeout
         )
     }
 }
@@ -181,25 +240,23 @@ extension XCUIElement {
     ///     Vizzly server configuration is used.
     ///   - minClusterSize: Optional minimum changed-pixel cluster size to count
     ///     as a real difference. When nil, the server configuration is used.
+    ///   - buildId: Optional build ID override for grouping screenshots
+    ///   - requestTimeout: Optional request timeout in milliseconds
     @discardableResult
     public func vizzlyScreenshot(
         name: String,
         properties: [String: Any]? = nil,
         threshold: Double? = nil,
-        minClusterSize: Int? = nil
+        minClusterSize: Int? = nil,
+        buildId: String? = nil,
+        requestTimeout: Double? = nil
     ) -> [String: Any]? {
         let screenshot = self.screenshot()
 
-        var combinedProperties = properties ?? [:]
-        combinedProperties["elementType"] = self.elementType.rawValue
-
-        #if os(iOS)
-        combinedProperties["platform"] = "iOS"
-        combinedProperties["osVersion"] = UIDevice.current.systemVersion
-        #elseif os(macOS)
-        combinedProperties["platform"] = "macOS"
-        combinedProperties["osVersion"] = ProcessInfo.processInfo.operatingSystemVersionString
-        #endif
+        let combinedProperties = VizzlyXCTestMetadata.elementProperties(
+            properties: properties,
+            elementType: self.elementType.rawValue
+        )
 
         return VizzlyClient.shared.screenshot(
             name: name,
@@ -207,7 +264,9 @@ extension XCUIElement {
             properties: combinedProperties,
             threshold: threshold,
             minClusterSize: minClusterSize,
-            fullPage: false
+            fullPage: false,
+            buildId: buildId,
+            requestTimeout: requestTimeout
         )
     }
 }

--- a/clients/swift/Tests/VizzlyTests/VizzlyClientTests.swift
+++ b/clients/swift/Tests/VizzlyTests/VizzlyClientTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import Vizzly
-import VizzlyXCTest
+@testable import VizzlyXCTest
 
 final class VizzlyClientTests: XCTestCase {
 
@@ -22,9 +22,19 @@ final class VizzlyClientTests: XCTestCase {
         XCTAssertNotNil(info["enabled"])
         XCTAssertNotNil(info["ready"])
         XCTAssertNotNil(info["disabled"])
+        XCTAssertNotNil(info["failOnDiff"])
 
         XCTAssertTrue(info["enabled"] as? Bool ?? false)
         XCTAssertFalse(info["disabled"] as? Bool ?? true)
+        XCTAssertFalse(info["failOnDiff"] as? Bool ?? true)
+    }
+
+    func testClientInfoExposesConfiguredFailOnDiff() {
+        let enabledClient = VizzlyClient(autoDiscover: false, failOnDiff: true)
+        let disabledClient = VizzlyClient(autoDiscover: false, failOnDiff: false)
+
+        XCTAssertEqual(enabledClient.info["failOnDiff"] as? Bool, true)
+        XCTAssertEqual(disabledClient.info["failOnDiff"] as? Bool, false)
     }
 
     func testClientDisable() {
@@ -120,6 +130,52 @@ final class VizzlyClientTests: XCTestCase {
         XCTAssertEqual(properties?["fullPage"] as? Bool, true)
     }
 
+    func testExplicitFullPageFalseIsSentAsProperty() {
+        let payload = VizzlyClient.makeScreenshotPayload(
+            name: "test",
+            image: createTestImage(),
+            fullPage: false
+        )
+
+        let properties = payload["properties"] as? [String: Any]
+        XCTAssertEqual(properties?["fullPage"] as? Bool, false)
+    }
+
+    func testPerCallBuildIdIsSentOutsideProperties() {
+        let payload = VizzlyClient.makeScreenshotPayload(
+            name: "test",
+            image: createTestImage(),
+            properties: ["theme": "dark"],
+            buildId: "build-from-call"
+        )
+
+        XCTAssertEqual(payload["buildId"] as? String, "build-from-call")
+        let properties = payload["properties"] as? [String: Any]
+        XCTAssertEqual(properties?["theme"] as? String, "dark")
+        XCTAssertNil(properties?["buildId"])
+    }
+
+    func testBrowserAndNestedViewportPropertiesAreSent() {
+        let payload = VizzlyClient.makeScreenshotPayload(
+            name: "responsive-homepage",
+            image: createTestImage(),
+            properties: [
+                "browser": "chrome",
+                "viewport": [
+                    "width": 1920,
+                    "height": 1080
+                ]
+            ]
+        )
+
+        let properties = payload["properties"] as? [String: Any]
+        XCTAssertEqual(properties?["browser"] as? String, "chrome")
+
+        let viewport = properties?["viewport"] as? [String: Any]
+        XCTAssertEqual(viewport?["width"] as? Int, 1920)
+        XCTAssertEqual(viewport?["height"] as? Int, 1080)
+    }
+
     func testDefaultComparisonOptionsUseServerConfiguration() {
         let payload = VizzlyClient.makeScreenshotPayload(
             name: "test",
@@ -129,7 +185,41 @@ final class VizzlyClientTests: XCTestCase {
         XCTAssertNil(payload["threshold"])
         XCTAssertNil(payload["minClusterSize"])
         XCTAssertNil(payload["fullPage"])
-        XCTAssertNil(payload["properties"])
+        let properties = payload["properties"] as? [String: Any]
+        XCTAssertEqual(properties?.isEmpty, true)
+    }
+
+    func testXCTestApplicationMetadataMergesUserProperties() {
+        let properties = VizzlyXCTestMetadata.applicationProperties(
+            properties: [
+                "platform": "custom-platform",
+                "theme": "dark"
+            ],
+            viewport: [
+                "width": 390,
+                "height": 844
+            ]
+        )
+
+        XCTAssertEqual(properties["platform"] as? String, "custom-platform")
+        XCTAssertEqual(properties["theme"] as? String, "dark")
+
+        let viewport = properties["viewport"] as? [String: Any]
+        XCTAssertEqual(viewport?["width"] as? Int, 390)
+        XCTAssertEqual(viewport?["height"] as? Int, 844)
+    }
+
+    func testXCTestElementMetadataMergesElementTypeAndUserProperties() {
+        let properties = VizzlyXCTestMetadata.elementProperties(
+            properties: [
+                "state": "selected"
+            ],
+            elementType: 42
+        )
+
+        XCTAssertEqual(properties["elementType"] as? UInt, 42)
+        XCTAssertEqual(properties["state"] as? String, "selected")
+        XCTAssertNotNil(properties["platform"])
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Why

This PR aligns the Ruby and Swift SDKs with the contract established by the core, web, Vitest, and Ember slices.

These SDKs are especially important because users do not see the main JavaScript implementation details. They just call `Vizzly.screenshot(...)`, `client.screenshot(...)`, or `app.vizzlyScreenshot(...)` and expect the same build grouping, metadata, request timeout, comparison, and diff-failure behavior they get elsewhere.

Before this pass, Ruby and Swift were close but not fully aligned. Build IDs and request timeouts could be treated like metadata. `failOnDiff` was not consistently available. Swift XCTest helpers duplicated metadata construction across overloads. Ruby accepted flexible option shapes, but the behavior was not crisp enough about what was a real SDK option versus user metadata.

The goal is parity without overbuilding: one conceptual contract, expressed idiomatically in Ruby and Swift.

## What changed

### Ruby SDK

- Adds `fail_on_diff:` and honors `VIZZLY_FAIL_ON_DIFF` plus discovered `.vizzly/server.json` settings.
- Honors `VIZZLY_ENABLED=false` and reports disabled/ready state consistently.
- Accepts snake_case options and JS-style camelCase aliases where useful: `min_cluster_size`/`minClusterSize`, `full_page`/`fullPage`, `build_id`/`buildId`, and `request_timeout`/`requestTimeout`.
- Sends `buildId` as a request field, not screenshot metadata.
- Applies `request_timeout` to the HTTP read timeout in milliseconds.
- Treats `properties` as the user metadata bag.
- Strips reserved/config options from `properties`, promotes them to the correct behavior when no top-level value exists, and emits a warning.
- Raises on both current 200-style and older 422-style TDD diff responses when fail-on-diff is enabled.
- Exposes both snake_case and camelCase info fields where that helps Ruby users and cross-SDK tooling.

### Swift SDK

- Adds optional `failOnDiff` override and honors `VIZZLY_FAIL_ON_DIFF` plus discovered server config.
- Adds optional `fullPage`, `buildId`, and `requestTimeout`.
- Converts millisecond request timeout into `URLRequest.timeoutInterval`.
- Sends `buildId` outside `properties`.
- Preserves `fullPage: false` as an intentional value.
- Includes a stable properties object in payloads.
- Handles both current and legacy TDD diff response shapes.

### Swift XCTest helpers

- Centralizes XCTest metadata construction in `VizzlyXCTestMetadata`.
- Adds app/test/element metadata through one merge path.
- Includes platform/device/OS/viewport metadata for app screenshots.
- Includes platform metadata and element type for element screenshots.
- Keeps user-provided properties as the intentional override layer.
- Forwards `buildId` and `requestTimeout` through helper overloads.

### Docs and package surface

- Ruby README examples now show the screenshot-level options where they are actually accepted.
- Swift README and integration docs describe the current API signatures and current `vizzly run "..."` command style.
- Swift package metadata now covers both the client and XCTest helper tests.

## Testing

- Ruby tests cover disabled state, info shape, env/server-config fail-on-diff, current and legacy diff responses, fractional thresholds, nested viewport metadata, aliases, zero values, build ID routing, timeout conversion, and reserved `properties` warnings.
- Swift tests cover info/fail state, payload shape, explicit false full-page behavior, build ID routing, nested viewport metadata, default comparison behavior, and XCTest metadata merging.

The Ruby follow-up for the `properties` contract was re-run after the stack split. The broader real visual-diff E2E matrix is still intentionally left for a focused follow-up so this already-large SDK slice stays reviewable.

## Verification

- Ruby preservation-branch verification: 20 tests / 55 assertions.
- Ruby post-split verification after properties warning work: `bundle exec rake test` in `clients/ruby`: 21 runs, 64 assertions, 0 failures.
- Swift preservation-branch verification: `swift test --filter VizzlyClientTests`: 17 passed.
- Covered by the full preservation branch verification before the stack was split.
- Stack cleanup verification: `git diff --check` and PR file-list checks for #283 through #287.
