### PR TITLE
📝 Document aligned SDK workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ For agent-friendly repos, install the Vizzly skill and add a short project
 vizzly init --agent-guidance
 ```
 
+Use `vizzly init --agent-skill` to install only the local skill, or
+`vizzly init --skip-agent-skill` when you want config without the agent prompt.
+
 ### Start Local TDD
 
 Start the TDD server, run your tests, and open the dashboard at
@@ -54,8 +57,13 @@ Use cloud builds when you want shared baselines, team review, and CI status:
 
 ```bash
 vizzly login
+vizzly project link your-org/your-project
 vizzly run "pnpm test" --wait
 ```
+
+`vizzly login` authenticates your user account. `vizzly project link` creates a
+project-scoped upload credential for this checkout, which `vizzly run` uses for
+cloud uploads.
 
 `--wait` blocks until Vizzly finishes processing the build. It exits with code
 `1` when visual differences need review.
@@ -112,10 +120,18 @@ test('homepage looks correct', async ({ page }) => {
   let screenshot = await page.screenshot();
   await vizzlyScreenshot('homepage', screenshot, {
     browser: 'chrome',
-    viewport: '1920x1080'
+    viewport: { width: 1920, height: 1080 },
+    fullPage: true,
+    requestTimeout: 5000,
   });
 });
 ```
+
+Top-level screenshot options that are not transport-specific are normalized
+into Vizzly metadata, so `browser`, `viewport`, `threshold`,
+`minClusterSize`, and `fullPage` are equivalent to passing them inside
+`properties`. `requestTimeout` stays on the client request, and `buildId`
+is sent with the screenshot request to group it with the correct build.
 
 The client SDK is lightweight. It posts screenshots to the local Vizzly server
 or the cloud build wrapper. It works with any test runner.
@@ -136,8 +152,23 @@ await vizzlyScreenshot('homepage', './screenshots/homepage.png');
 Or upload an existing folder of screenshots:
 
 ```bash
-vizzly upload ./screenshots
+vizzly upload ./screenshots --threshold 2 --min-cluster-size 4 --batch-size 10 --upload-timeout 60000
 ```
+
+`--batch-size` controls how many screenshots are uploaded per request, and
+`--upload-timeout` controls how long `vizzly upload --wait` waits for build
+processing.
+
+CI workflows can force every screenshot through even when the SHA cache says it
+already uploaded, and parallel jobs can share a build with a stable ID:
+
+```bash
+vizzly run "pnpm test" --wait --upload-all --parallel-id "$CI_NODE_INDEX"
+```
+
+For smoke jobs where cloud credentials are intentionally unavailable, add
+`--allow-no-token` to `vizzly run` and Vizzly will keep the local screenshot
+server path working without creating a cloud build.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -158,15 +158,17 @@ Or upload an existing folder of screenshots:
 vizzly upload ./screenshots --threshold 2 --min-cluster-size 4 --batch-size 10 --upload-timeout 60000
 ```
 
-`--batch-size` controls how many screenshots are uploaded per request, and
-`--upload-timeout` controls how long `vizzly upload --wait` waits for build
-processing.
+`--batch-size` controls how many screenshots are uploaded per request.
+`--upload-timeout` controls the upload client's timeout, including how long
+`--wait` polls for build processing.
 
 CI workflows can force every screenshot through even when the SHA cache says it
-already uploaded, and parallel jobs can share a build with a stable ID:
+already uploaded. Parallel jobs should use the same stable ID, then finalize
+that ID after every shard completes:
 
 ```bash
-vizzly run "pnpm test" --wait --upload-all --parallel-id "$CI_NODE_INDEX"
+vizzly run "pnpm test" --upload-all --parallel-id "$GITHUB_RUN_ID"
+vizzly finalize "$GITHUB_RUN_ID"
 ```
 
 For smoke jobs where cloud credentials are intentionally unavailable, add

--- a/README.md
+++ b/README.md
@@ -119,19 +119,22 @@ test('homepage looks correct', async ({ page }) => {
 
   let screenshot = await page.screenshot();
   await vizzlyScreenshot('homepage', screenshot, {
-    browser: 'chrome',
-    viewport: { width: 1920, height: 1080 },
     fullPage: true,
     requestTimeout: 5000,
+    properties: {
+      browser: 'chrome',
+      viewport: { width: 1920, height: 1080 },
+    },
   });
 });
 ```
 
-Top-level screenshot options that are not transport-specific are normalized
-into Vizzly metadata, so `browser`, `viewport`, `threshold`,
-`minClusterSize`, and `fullPage` are equivalent to passing them inside
-`properties`. `requestTimeout` stays on the client request, and `buildId`
-is sent with the screenshot request to group it with the correct build.
+`properties` is your metadata bag for baseline grouping, filtering, and
+debugging. SDK options such as `threshold`, `minClusterSize`, `fullPage`,
+`requestTimeout`, and `buildId` stay at the top level. If one of those reserved
+SDK options is accidentally placed inside `properties`, Vizzly removes it from
+metadata, applies it as an option when possible, and warns so the call site can
+be cleaned up.
 
 The client SDK is lightweight. It posts screenshots to the local Vizzly server
 or the cloud build wrapper. It works with any test runner.

--- a/docs/browser-flags.md
+++ b/docs/browser-flags.md
@@ -1,6 +1,7 @@
 # Chrome Browser Flags
 
 This document covers the Chrome command-line flags used by the Storybook and Static-Site SDKs when launching browsers via Playwright.
+The Ember launcher also uses the same sandbox and CI stability subset.
 
 ## Why Playwright?
 
@@ -23,6 +24,7 @@ When auditing or updating flags, always check these sources. Flags get deprecate
 Located in:
 - `clients/storybook/src/browser.js`
 - `clients/static-site/src/browser.js`
+- `clients/ember/src/launcher/browser.js`
 
 ### Container/CI Requirements
 
@@ -31,6 +33,9 @@ Located in:
 | `--no-sandbox` | Required for running in containers without root |
 | `--disable-setuid-sandbox` | Disable setuid sandbox (Linux only) |
 | `--disable-dev-shm-usage` | Use /tmp instead of /dev/shm (often too small in Docker) |
+
+Ember uses this smaller subset plus `--disable-extensions` in CI because Testem
+owns the rest of the browser lifecycle.
 
 ### Disable Unnecessary Features
 

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -22,15 +22,17 @@ Select specific fields using comma-separated names:
 # Top-level fields
 vizzly status <id> --json buildId,status,branch
 
-# Nested fields with dot notation
-vizzly status <id> --json buildId,comparisons.total,comparisons.changed
+# Preview fields with dot notation
+vizzly status <id> --json buildId,status,preview.url
 ```
 
-Field selection works on all commands. If a field doesn't exist, it's omitted from the output.
+Field selection works on the command payload before it is wrapped in the
+standard `{ status, data }` envelope. If a field doesn't exist, it's omitted
+from the output.
 
 ## Output Format
 
-All JSON output follows this structure:
+Successful command payloads are wrapped in this structure:
 
 ```json
 {
@@ -39,7 +41,7 @@ All JSON output follows this structure:
 }
 ```
 
-Errors look like this:
+Errors emitted through `output.error(...)` look like this:
 
 ```json
 {
@@ -49,7 +51,13 @@ Errors look like this:
 }
 ```
 
+Some commands return a `data` envelope with their own payload `status`
+(`completed`, `failed`, or `skipped`) instead of using the error envelope.
+
 ## Command Reference
+
+The shorter command examples below show the full `--json` envelope. Very large
+context examples show the command-specific payload that appears inside `data`.
 
 ### `vizzly run`
 
@@ -59,17 +67,20 @@ vizzly run "pnpm test" --json
 
 ```json
 {
-  "buildId": "abc123-def456",
-  "status": "completed",
-  "url": "https://app.vizzly.dev/org/project/builds/abc123",
-  "screenshotsCaptured": 15,
-  "executionTimeMs": 4500,
-  "git": {
-    "branch": "main",
-    "commit": "abc1234",
-    "message": "Add new feature"
-  },
-  "exitCode": 0
+  "status": "data",
+  "data": {
+    "buildId": "abc123-def456",
+    "status": "completed",
+    "contextCommand": "vizzly context build abc123-def456 --agent",
+    "screenshotsCaptured": 15,
+    "executionTimeMs": 4821,
+    "git": {
+      "branch": "main",
+      "commit": "abc1234",
+      "message": "Add feature"
+    },
+    "exitCode": 0
+  }
 }
 ```
 
@@ -77,16 +88,27 @@ With `--wait`, includes comparison results:
 
 ```json
 {
-  "buildId": "abc123-def456",
-  "status": "completed",
-  "comparisons": {
-    "total": 15,
-    "new": 2,
-    "changed": 1,
-    "identical": 12
-  },
-  "approvalStatus": "pending",
-  "exitCode": 1
+  "status": "data",
+  "data": {
+    "buildId": "abc123-def456",
+    "status": "failed",
+    "screenshotsCaptured": 15,
+    "executionTimeMs": 9876,
+    "git": {
+      "branch": "main",
+      "commit": "abc1234",
+      "message": "Add feature"
+    },
+    "comparisons": {
+      "total": 15,
+      "new": 2,
+      "changed": 1,
+      "identical": 12
+    },
+    "approvalStatus": "pending",
+    "contextCommand": "vizzly context build abc123-def456 --agent",
+    "exitCode": 1
+  }
 }
 ```
 
@@ -98,31 +120,35 @@ vizzly tdd run "pnpm test" --json
 
 ```json
 {
-  "status": "completed",
-  "exitCode": 0,
-  "comparisons": [
-    {
-      "name": "button-primary",
-      "status": "failed",
-      "signature": "button-primary|1920|chromium",
-      "diffPercentage": 4.2,
-      "threshold": 2.0,
-      "paths": {
-        "baseline": ".vizzly/baselines/button-primary_abc123.png",
-        "current": ".vizzly/current/button-primary_abc123.png",
-        "diff": ".vizzly/diffs/button-primary_abc123.png"
-      },
-      "viewport": { "width": 1920, "height": 1080 },
-      "browser": "chromium"
-    }
-  ],
-  "summary": {
-    "total": 10,
-    "passed": 8,
-    "failed": 1,
-    "new": 1
-  },
-  "reportPath": ".vizzly/report/index.html"
+  "status": "data",
+  "data": {
+    "status": "failed",
+    "exitCode": 1,
+    "comparisons": [
+      {
+        "name": "button-primary",
+        "status": "failed",
+        "signature": "button-primary|1920|chromium",
+        "diffPercentage": 4.2,
+        "threshold": 2.0,
+        "paths": {
+          "baseline": ".vizzly/baselines/button-primary.png",
+          "current": ".vizzly/current/button-primary.png",
+          "diff": ".vizzly/diff/button-primary.png"
+        },
+        "viewport": { "width": 1920, "height": 1080 },
+        "browser": "chromium"
+      }
+    ],
+    "summary": {
+      "total": 1,
+      "passed": 0,
+      "failed": 1,
+      "new": 0
+    },
+    "reportPath": ".vizzly/report/index.html",
+    "contextCommand": "vizzly context build current --source local --agent"
+  }
 }
 ```
 
@@ -134,10 +160,13 @@ vizzly tdd start --json
 
 ```json
 {
-  "status": "started",
-  "port": 47392,
-  "pid": 12345,
-  "dashboardUrl": "http://localhost:47392"
+  "status": "data",
+  "data": {
+    "status": "started",
+    "port": 47392,
+    "pid": 12345,
+    "dashboardUrl": "http://localhost:47392"
+  }
 }
 ```
 
@@ -149,8 +178,11 @@ vizzly tdd stop --json
 
 ```json
 {
-  "status": "stopped",
-  "pid": 12345
+  "status": "data",
+  "data": {
+    "status": "stopped",
+    "pid": 12345
+  }
 }
 ```
 
@@ -162,12 +194,15 @@ vizzly tdd status --json
 
 ```json
 {
-  "running": true,
-  "port": 47392,
-  "pid": 12345,
-  "uptimeMs": 5025000,
-  "uptime": "1h 23m 45s",
-  "dashboardUrl": "http://localhost:47392"
+  "status": "data",
+  "data": {
+    "running": true,
+    "port": 47392,
+    "pid": 12345,
+    "uptimeMs": 5025000,
+    "uptime": "1h 23m 45s",
+    "dashboardUrl": "http://localhost:47392"
+  }
 }
 ```
 
@@ -179,14 +214,17 @@ vizzly tdd list --json
 
 ```json
 {
-  "servers": [
-    {
-      "directory": "/path/to/project",
-      "port": 47392,
-      "pid": 12345,
-      "isCurrent": true
-    }
-  ]
+  "status": "data",
+  "data": {
+    "servers": [
+      {
+        "directory": "/path/to/project",
+        "port": 47392,
+        "pid": 12345,
+        "isCurrent": true
+      }
+    ]
+  }
 }
 ```
 
@@ -461,32 +499,35 @@ vizzly builds --branch main --status completed --limit 10 --json
 
 ```json
 {
-  "builds": [
-    {
-      "id": "abc123-def456",
-      "name": "Build #123",
-      "status": "completed",
-      "branch": "main",
-      "commit": "abc1234",
-      "commitMessage": "Add feature",
-      "environment": "test",
-      "screenshotCount": 15,
-      "comparisons": {
-        "total": 15,
-        "new": 2,
-        "changed": 1,
-        "identical": 12
-      },
-      "approvalStatus": "approved",
-      "createdAt": "2025-01-15T10:30:00Z",
-      "completedAt": "2025-01-15T10:32:00Z"
+  "status": "data",
+  "data": {
+    "builds": [
+      {
+        "id": "abc123-def456",
+        "name": "Build #123",
+        "status": "completed",
+        "branch": "main",
+        "commit": "abc1234",
+        "commitMessage": "Add feature",
+        "environment": "test",
+        "screenshotCount": 15,
+        "comparisons": {
+          "total": 15,
+          "new": 2,
+          "changed": 1,
+          "identical": 12
+        },
+        "approvalStatus": "approved",
+        "createdAt": "2025-01-15T10:30:00Z",
+        "completedAt": "2025-01-15T10:32:00Z"
+      }
+    ],
+    "pagination": {
+      "total": 100,
+      "limit": 20,
+      "offset": 0,
+      "hasMore": true
     }
-  ],
-  "pagination": {
-    "total": 100,
-    "limit": 20,
-    "offset": 0,
-    "hasMore": true
   }
 }
 ```
@@ -509,29 +550,32 @@ vizzly comparisons --build <id> --status changed --json
 
 ```json
 {
-  "buildId": "abc123-def456",
-  "buildName": "Build #123",
-  "comparisons": [
-    {
-      "id": "comp-uuid",
-      "name": "button-primary",
-      "status": "changed",
-      "diffPercentage": 0.042,
-      "approvalStatus": "pending",
-      "viewport": { "width": 1920, "height": 1080 },
-      "browser": "chromium",
-      "urls": {
-        "baseline": "https://...",
-        "current": "https://...",
-        "diff": "https://..."
+  "status": "data",
+  "data": {
+    "buildId": "abc123-def456",
+    "buildName": "Build #123",
+    "comparisons": [
+      {
+        "id": "comp-uuid",
+        "name": "button-primary",
+        "status": "changed",
+        "diffPercentage": 0.042,
+        "approvalStatus": "pending",
+        "viewport": { "width": 1920, "height": 1080 },
+        "browser": "chromium",
+        "urls": {
+          "baseline": "https://...",
+          "current": "https://...",
+          "diff": "https://..."
+        }
       }
+    ],
+    "summary": {
+      "total": 15,
+      "passed": 12,
+      "failed": 2,
+      "new": 1
     }
-  ],
-  "summary": {
-    "total": 15,
-    "passed": 12,
-    "failed": 2,
-    "new": 1
   }
 }
 ```
@@ -557,21 +601,28 @@ vizzly config --json
 
 ```json
 {
-  "configFile": "/path/to/vizzly.config.js",
-  "config": {
-    "server": { "port": 47392, "timeout": 30000 },
-    "comparison": { "threshold": 2.0, "minClusterSize": 2 },
-    "tdd": { "openReport": false },
-    "api": {
-      "url": "https://app.vizzly.dev",
-      "tokenConfigured": true,
-      "tokenPrefix": "vzt_abc1..."
+  "status": "data",
+  "data": {
+    "configFile": "/path/to/vizzly.config.js",
+    "config": {
+      "server": { "port": 47392, "timeout": 30000 },
+      "build": {},
+      "upload": {},
+      "comparison": { "threshold": 2.0, "minClusterSize": 2 },
+      "tdd": { "openReport": false },
+      "api": {
+        "url": "https://app.vizzly.dev",
+        "tokenConfigured": true,
+        "tokenPrefix": "vzt_abc1..."
+      },
+      "linkedProject": {
+        "organization": "my-org",
+        "project": "my-project",
+        "tokenPrefix": "vzt_abc",
+        "storage": "keychain",
+        "expiresAt": null
+      }
     }
-  },
-  "project": {
-    "name": "My Project",
-    "slug": "my-project",
-    "organization": "my-org"
   }
 }
 ```
@@ -584,8 +635,11 @@ vizzly config comparison.threshold --json
 
 ```json
 {
-  "key": "comparison.threshold",
-  "value": 2.0
+  "status": "data",
+  "data": {
+    "key": "comparison.threshold",
+    "value": 2.0
+  }
 }
 ```
 
@@ -599,26 +653,29 @@ vizzly baselines --json
 
 ```json
 {
-  "baselines": [
-    {
-      "name": "button-primary",
-      "signature": "button-primary|1920|chromium",
-      "filename": "button-primary_abc123.png",
-      "path": "/path/to/.vizzly/baselines/button-primary_abc123.png",
-      "sha256": "abc123...",
-      "viewport": { "width": 1920, "height": 1080 },
-      "browser": "chromium",
-      "createdAt": "2025-01-15T10:00:00Z",
-      "fileSize": 45678
+  "status": "data",
+  "data": {
+    "baselines": [
+      {
+        "name": "button-primary",
+        "signature": "button-primary|1920|chromium",
+        "filename": "button-primary_abc123.png",
+        "path": "/path/to/.vizzly/baselines/button-primary_abc123.png",
+        "sha256": "abc123...",
+        "viewport": { "width": 1920, "height": 1080 },
+        "browser": "chromium",
+        "createdAt": "2025-01-15T10:00:00Z",
+        "fileSize": 45678
+      }
+    ],
+    "count": 45,
+    "metadata": {
+      "buildId": "local-baseline",
+      "buildName": "Local TDD Baseline",
+      "branch": "local",
+      "threshold": 2.0,
+      "createdAt": "2025-01-15T10:00:00Z"
     }
-  ],
-  "count": 45,
-  "metadata": {
-    "buildId": "local-baseline",
-    "buildName": "Local TDD Baseline",
-    "branch": "local",
-    "threshold": 2.0,
-    "createdAt": "2025-01-15T10:00:00Z"
   }
 }
 ```
@@ -643,9 +700,12 @@ vizzly api /sdk/builds -q limit=10 -q branch=main --json
 
 ```json
 {
-  "endpoint": "/api/sdk/builds",
-  "method": "GET",
-  "response": { /* raw API response */ }
+  "status": "data",
+  "data": {
+    "endpoint": "/api/sdk/builds",
+    "method": "GET",
+    "response": { /* raw API response */ }
+  }
 }
 ```
 
@@ -657,17 +717,22 @@ vizzly upload ./screenshots --json
 
 ```json
 {
-  "buildId": "abc123-def456",
-  "url": "https://app.vizzly.dev/...",
-  "stats": {
-    "total": 20,
-    "uploaded": 15,
-    "skipped": 5,
-    "bytes": 2500000
-  },
-  "git": {
-    "branch": "main",
-    "commit": "abc1234"
+  "status": "data",
+  "data": {
+    "buildId": "abc123-def456",
+    "url": "https://app.vizzly.dev/...",
+    "stats": {
+      "total": 20,
+      "uploaded": 15,
+      "skipped": 5,
+      "bytes": 2500000
+    },
+    "git": {
+      "branch": "main",
+      "commit": "abc1234",
+      "message": "Add feature"
+    },
+    "executionTimeMs": 6241
   }
 }
 ```
@@ -680,14 +745,21 @@ vizzly preview ./dist --json
 
 ```json
 {
-  "success": true,
-  "buildId": "abc123-def456",
-  "previewUrl": "https://preview.vizzly.dev/abc123",
-  "files": 150,
-  "bytes": 5000000,
-  "compressedBytes": 1200000,
-  "compressionRatio": "76%",
-  "expiresAt": "2025-03-01T00:00:00Z"
+  "status": "data",
+  "data": {
+    "success": true,
+    "buildId": "abc123-def456",
+    "previewUrl": "https://preview.vizzly.dev/abc123",
+    "files": 150,
+    "bytes": 5000000,
+    "compressedBytes": 1200000,
+    "compressionRatio": "76%",
+    "newBytes": 320000,
+    "reusedBlobs": 12,
+    "deduplicationRatio": 0.42,
+    "basePath": null,
+    "expiresAt": "2025-03-01T00:00:00Z"
+  }
 }
 ```
 
@@ -699,27 +771,30 @@ vizzly status <build-id> --json
 
 ```json
 {
-  "buildId": "abc123-def456",
-  "status": "completed",
-  "name": "Build #123",
-  "createdAt": "2025-01-15T10:30:00Z",
-  "completedAt": "2025-01-15T10:32:00Z",
-  "environment": "test",
-  "branch": "main",
-  "commit": "abc1234",
-  "commitMessage": "Add feature",
-  "screenshotsTotal": 15,
-  "comparisonsTotal": 15,
-  "newComparisons": 2,
-  "changedComparisons": 1,
-  "identicalComparisons": 12,
-  "approvalStatus": "pending",
-  "executionTime": 4500,
-  "preview": {
-    "url": "https://preview.vizzly.dev/...",
-    "status": "ready",
-    "fileCount": 150,
-    "expiresAt": "2025-03-01T00:00:00Z"
+  "status": "data",
+  "data": {
+    "buildId": "abc123-def456",
+    "status": "completed",
+    "name": "Build #123",
+    "createdAt": "2025-01-15T10:30:00Z",
+    "completedAt": "2025-01-15T10:32:00Z",
+    "environment": "test",
+    "branch": "main",
+    "commit": "abc1234",
+    "commitMessage": "Add feature",
+    "screenshotsTotal": 15,
+    "comparisonsTotal": 15,
+    "newComparisons": 2,
+    "changedComparisons": 1,
+    "identicalComparisons": 12,
+    "approvalStatus": "pending",
+    "executionTime": 4500,
+    "preview": {
+      "url": "https://preview.vizzly.dev/...",
+      "status": "ready",
+      "fileCount": 150,
+      "expiresAt": "2025-03-01T00:00:00Z"
+    }
   }
 }
 ```
@@ -732,8 +807,11 @@ vizzly init --json
 
 ```json
 {
-  "status": "created",
-  "configPath": "/path/to/vizzly.config.js"
+  "status": "data",
+  "data": {
+    "status": "created",
+    "configPath": "/path/to/vizzly.config.js"
+  }
 }
 ```
 
@@ -745,17 +823,20 @@ vizzly init --agent-guidance --json
 
 ```json
 {
-  "status": "created",
-  "configPath": "/path/to/vizzly.config.js",
-  "plugins": [],
-  "agentSkill": {
-    "status": "installed",
-    "sourcePath": "/path/to/cli/skills/vizzly",
-    "targetPath": "/path/to/project/.agents/skills/vizzly"
-  },
-  "agentGuidance": {
+  "status": "data",
+  "data": {
     "status": "created",
-    "agentsPath": "/path/to/project/AGENTS.md"
+    "configPath": "/path/to/vizzly.config.js",
+    "plugins": [],
+    "agentSkill": {
+      "status": "installed",
+      "sourcePath": "/path/to/cli/skills/vizzly",
+      "targetPath": "/path/to/project/.agents/skills/vizzly"
+    },
+    "agentGuidance": {
+      "status": "created",
+      "agentsPath": "/path/to/project/AGENTS.md"
+    }
   }
 }
 ```
@@ -768,81 +849,51 @@ vizzly project link my-org/my-project --json
 
 ```json
 {
-  "linked": true,
-  "organizationSlug": "my-org",
-  "projectSlug": "my-project",
-  "tokenPrefix": "vzt_abc",
-  "storage": "keychain"
-}
-```
-
-### `vizzly project:list`
-
-```bash
-vizzly project:list --json
-```
-
-```json
-{
-  "projects": [
-    {
-      "directory": "/path/to/project",
-      "isCurrent": true,
-      "project": {
-        "name": "My Project",
-        "slug": "my-project"
-      },
-      "organization": "my-org",
-      "createdAt": "2025-01-15T10:00:00Z"
-    }
-  ],
-  "current": {
-    "directory": "/path/to/project",
-    "isCurrent": true,
-    "project": { "name": "My Project", "slug": "my-project" },
-    "organization": "my-org",
-    "createdAt": "2025-01-15T10:00:00Z"
+  "status": "data",
+  "data": {
+    "linked": true,
+    "organizationSlug": "my-org",
+    "projectSlug": "my-project",
+    "tokenPrefix": "vzt_abc",
+    "storage": "keychain"
   }
 }
 ```
 
-### `vizzly project:token`
+### `vizzly projects`
 
 ```bash
-vizzly project:token --json
+vizzly projects --json
 ```
 
 ```json
 {
-  "token": "vzt_abc123...",
-  "directory": "/path/to/project",
-  "project": {
-    "name": "My Project",
-    "slug": "my-project"
-  },
-  "organization": "my-org",
-  "createdAt": "2025-01-15T10:00:00Z"
+  "status": "data",
+  "data": {
+    "projects": [
+      {
+        "id": "project-123",
+        "name": "My Project",
+        "slug": "my-project",
+        "organizationName": "My Org",
+        "organizationSlug": "my-org",
+        "buildCount": 42,
+        "createdAt": "2025-01-15T10:00:00Z",
+        "updatedAt": "2025-01-20T10:00:00Z"
+      }
+    ],
+    "pagination": {
+      "total": 1,
+      "hasMore": false
+    }
+  }
 }
 ```
 
-### `vizzly project:remove`
+Filter by organization:
 
 ```bash
-vizzly project:remove --json
-```
-
-In JSON mode, skips confirmation and removes immediately:
-
-```json
-{
-  "removed": true,
-  "directory": "/path/to/project",
-  "project": {
-    "name": "My Project",
-    "slug": "my-project"
-  },
-  "organization": "my-org"
-}
+vizzly projects --org my-org --json
 ```
 
 ## Scripting Examples


### PR DESCRIPTION
## Why

This PR is the docs polish slice for the SDK alignment stack. The code PRs make the option contract real; this one makes sure the public docs describe the product users actually get.

The docs had fallen behind in a few important ways. They did not clearly show the current cloud setup flow. JSON output examples were stale. Browser flag docs did not include Ember. Some command examples still used older names or older payload shapes. And, most importantly after the latest cleanup, the screenshot options docs did not clearly separate user metadata from SDK/config options.

That separation matters. `properties` is the user key/value metadata bag. Options like `threshold`, `minClusterSize`, `fullPage`, `buildId`, and `requestTimeout` are behavior/request options and should stay top-level. If docs blur that line, users copy the wrong shape and the SDK has to guess what they meant.

## What changed

### README

- Adds split agent-init flags so users can install only the agent skill or skip it when they only want config.
- Clarifies the cloud path: `vizzly login`, `vizzly project link`, then `vizzly run "..." --wait`.
- Updates the JS client screenshot example to show structured viewport metadata, `fullPage`, and `requestTimeout`.
- Clarifies that `properties` is user metadata.
- Clarifies that SDK/config options stay top-level and that transport/request fields like `requestTimeout` and `buildId` are not stored as screenshot metadata.
- Expands upload examples with `--threshold`, `--min-cluster-size`, `--batch-size`, `--upload-timeout`, `--upload-all`, `--parallel-id`, and `--allow-no-token`.

### JSON output reference

- Reworks command examples to show the standard `{ status, data }` wrapper.
- Updates `run`, `run --wait`, TDD commands, builds, comparisons, config, baselines, API, upload, preview, status, init, and project examples to match current payload shapes.
- Clarifies that field selection applies before the standard output envelope is wrapped.
- Updates project command docs from stale `project:*` examples to current `project link` and `projects` flows.
- Adds current preview fields such as new bytes, reused blob count, dedupe ratio, and base path.

### Browser flags

- Documents that Ember uses the same sandbox and CI-stability subset as the browser-based SDKs.
- Adds the Ember launcher path to the source list reviewers should check when browser flags change.
- Clarifies why Ember uses a smaller subset because Testem owns the rest of the browser lifecycle.

## Testing and confidence

This is docs-only, so the useful verification is consistency against the code PRs and diff hygiene. The docs now say the same thing the core/Ruby changes enforce: user metadata belongs in `properties`; options that change behavior stay top-level.

The remaining testing gap is not in this docs PR but in the broader product stack: we still want a focused follow-up with real E2E visual-diff tests that exercise the CLI/API/dashboard path with an intentionally changed fixture.

## Review guide

1. Start with `README.md` and check the screenshot/options examples against #283 and #286.
2. Review `docs/json-output.md` against the JSON output work in #283.
3. Check `docs/browser-flags.md` against the Storybook/static-site/Ember browser launchers from the SDK PRs.

## Verification

- Docs-only slice.
- `git diff --check` passed after stack cleanup.
- Final stacked branch differs from the original preservation branch only by intentional docs/code split changes and the removed custom plugin example.
