### PR TITLE
🔧 Harden SDK release workflows

### DIFF
--- a/.github/workflows/release-ember-client.yml
+++ b/.github/workflows/release-ember-client.yml
@@ -18,6 +18,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -77,6 +81,7 @@ jobs:
           echo "tag=ember/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
+        continue-on-error: true
         uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -127,6 +132,14 @@ jobs:
         working-directory: ./clients/ember
         run: pnpm run lint
 
+      - name: Verify package version is unpublished
+        working-directory: ./clients/ember
+        run: |
+          if npm view @vizzly-testing/ember@${{ steps.version.outputs.version }} version >/dev/null 2>&1; then
+            echo "@vizzly-testing/ember@${{ steps.version.outputs.version }} is already published"
+            exit 1
+          fi
+
       - name: Update CHANGELOG.md
         working-directory: ./clients/ember
         run: |
@@ -157,6 +170,13 @@ jobs:
           mv CHANGELOG-NEW.md CHANGELOG.md
           rm CHANGELOG-RELEASE.md
 
+      - name: Pack package
+        id: pack
+        working-directory: ./clients/ember
+        run: |
+          PACK_FILE=$(npm pack --ignore-scripts)
+          echo "file=$PACK_FILE" >> $GITHUB_OUTPUT
+
       - name: Reconfigure git auth
         run: |
           git config --local user.email "${{ secrets.GIT_USER_EMAIL }}"
@@ -175,9 +195,9 @@ jobs:
         working-directory: ./clients/ember
         run: |
           if [ "${{ github.event.inputs.prerelease }}" == "true" ]; then
-            npm publish --provenance --access public --tag beta
+            npm publish "${{ steps.pack.outputs.file }}" --provenance --access public --tag beta
           else
-            npm publish --provenance --access public
+            npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
           fi
 
       - name: Read changelog for release
@@ -198,7 +218,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: 🐹 Ember SDK v${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.notes }}
-          files: ./clients/ember/*.tgz
+          files: ./clients/ember/${{ steps.pack.outputs.file }}
           draft: false
           prerelease: ${{ github.event.inputs.prerelease }}
         env:

--- a/.github/workflows/release-ruby-client.yml
+++ b/.github/workflows/release-ruby-client.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - major
 
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -41,6 +45,11 @@ jobs:
         run: |
           git config --local user.email "${{ secrets.GIT_USER_EMAIL }}"
           git config --local user.name "${{ secrets.GIT_USER_NAME }}"
+
+      - name: Ensure we have latest main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
 
       - name: Get current version
         id: current_version
@@ -78,6 +87,7 @@ jobs:
           echo "tag=ruby/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
+        continue-on-error: true
         uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -114,7 +124,11 @@ jobs:
             ### Fixed
             - Bug fixes
 
-            **Full Changelog**: https://github.com/vizzly-testing/vizzly-cli/compare/ruby/v${{ steps.current_version.outputs.version }}...ruby/v${{ steps.new_version.outputs.version }}
+            **Full Changelog**: https://github.com/vizzly-testing/cli/compare/ruby/v${{ steps.current_version.outputs.version }}...ruby/v${{ steps.new_version.outputs.version }}
+
+      - name: Install dependencies
+        working-directory: ./clients/ruby
+        run: bundle install
 
       - name: Update version in gemspec
         working-directory: ./clients/ruby
@@ -146,6 +160,18 @@ jobs:
           tail -n +2 CHANGELOG.md >> CHANGELOG-NEW.md
           mv CHANGELOG-NEW.md CHANGELOG.md
           rm CHANGELOG-RELEASE.md
+
+      - name: Run tests
+        working-directory: ./clients/ruby
+        run: bundle exec rake
+
+      - name: Verify gem version is unpublished
+        working-directory: ./clients/ruby
+        run: |
+          if gem list --remote --exact vizzly --version "${{ steps.new_version.outputs.version }}" | grep -q '^vizzly '; then
+            echo "vizzly ${{ steps.new_version.outputs.version }} is already published"
+            exit 1
+          fi
 
       - name: Reconfigure git auth
         run: |

--- a/.github/workflows/release-static-site-client.yml
+++ b/.github/workflows/release-static-site-client.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - major
 
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -68,6 +72,7 @@ jobs:
           echo "tag=static-site/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
+        continue-on-error: true
         uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -117,6 +122,14 @@ jobs:
       - name: Run linter
         working-directory: ./clients/static-site
         run: pnpm run lint
+
+      - name: Verify package version is unpublished
+        working-directory: ./clients/static-site
+        run: |
+          if npm view @vizzly-testing/static-site@${{ steps.version.outputs.version }} version >/dev/null 2>&1; then
+            echo "@vizzly-testing/static-site@${{ steps.version.outputs.version }} is already published"
+            exit 1
+          fi
 
       - name: Update CHANGELOG.md
         working-directory: ./clients/static-site
@@ -168,6 +181,13 @@ jobs:
         working-directory: ./clients/static-site
         run: pnpm run build
 
+      - name: Pack package
+        id: pack
+        working-directory: ./clients/static-site
+        run: |
+          PACK_FILE=$(npm pack --ignore-scripts)
+          echo "file=$PACK_FILE" >> $GITHUB_OUTPUT
+
       - name: Reconfigure git auth
         run: |
           git config --local user.email "${{ secrets.GIT_USER_EMAIL }}"
@@ -184,7 +204,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: ./clients/static-site
-        run: npm publish --provenance --access public
+        run: npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
 
       - name: Read changelog for release
         id: release_notes
@@ -204,7 +224,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: 🏗️ Static Site Plugin v${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.notes }}
-          files: ./clients/static-site/*.tgz
+          files: ./clients/static-site/${{ steps.pack.outputs.file }}
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/release-storybook-client.yml
+++ b/.github/workflows/release-storybook-client.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - major
 
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -68,6 +72,7 @@ jobs:
           echo "tag=storybook/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
+        continue-on-error: true
         uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -118,6 +123,14 @@ jobs:
         working-directory: ./clients/storybook
         run: pnpm run lint
 
+      - name: Verify package version is unpublished
+        working-directory: ./clients/storybook
+        run: |
+          if npm view @vizzly-testing/storybook@${{ steps.version.outputs.version }} version >/dev/null 2>&1; then
+            echo "@vizzly-testing/storybook@${{ steps.version.outputs.version }} is already published"
+            exit 1
+          fi
+
       - name: Update CHANGELOG.md
         working-directory: ./clients/storybook
         run: |
@@ -152,6 +165,13 @@ jobs:
         working-directory: ./clients/storybook
         run: pnpm run build
 
+      - name: Pack package
+        id: pack
+        working-directory: ./clients/storybook
+        run: |
+          PACK_FILE=$(npm pack --ignore-scripts)
+          echo "file=$PACK_FILE" >> $GITHUB_OUTPUT
+
       - name: Reconfigure git auth
         run: |
           git config --local user.email "${{ secrets.GIT_USER_EMAIL }}"
@@ -174,7 +194,7 @@ jobs:
           rm -f ~/.npmrc 2>/dev/null || true
           npm config set registry https://registry.npmjs.org/
           echo "npm version: $(npm --version)"
-          npm publish --provenance --access public
+          npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
 
       - name: Read changelog for release
         id: release_notes
@@ -194,7 +214,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: 📚 Storybook Plugin v${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.notes }}
-          files: ./clients/storybook/*.tgz
+          files: ./clients/storybook/${{ steps.pack.outputs.file }}
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/release-swift-client.yml
+++ b/.github/workflows/release-swift-client.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - major
 
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: macos-latest
@@ -40,16 +44,30 @@ jobs:
           git config --local user.email "${{ secrets.GIT_USER_EMAIL }}"
           git config --local user.name "${{ secrets.GIT_USER_NAME }}"
 
+      - name: Ensure we have latest main
+        run: |
+          git fetch origin main
+          git reset --hard origin/main
+
       - name: Get current version
         id: current_version
         working-directory: ./clients/swift
         run: |
-          # Extract version from CHANGELOG.md
-          CURRENT_VERSION=$(grep -m 1 "## \[" CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/')
+          # Extract the latest released semver entry. Ignore [Unreleased].
+          CURRENT_VERSION=$(grep -m 1 -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | sed 's/## \[\(.*\)\].*/\1/' || true)
           if [ -z "$CURRENT_VERSION" ]; then
-            CURRENT_VERSION="0.1.0"
+            CURRENT_VERSION="0.0.0"
           fi
           echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get previous release tag
+        id: previous_tag
+        run: |
+          PREV_TAG=""
+          if git rev-parse "swift/v${{ steps.current_version.outputs.version }}" >/dev/null 2>&1; then
+            PREV_TAG="swift/v${{ steps.current_version.outputs.version }}"
+          fi
+          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
       - name: Calculate new version
         id: new_version
@@ -80,6 +98,7 @@ jobs:
           echo "tag=swift/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
+        continue-on-error: true
         uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -90,12 +109,14 @@ jobs:
 
             Context:
             - Client location: `clients/swift/`
-            - Previous tag: `swift/v${{ steps.current_version.outputs.version }}`
+            - Previous tag: `${{ steps.previous_tag.outputs.tag }}`
             - New version: `${{ steps.new_version.outputs.version }}`
             - This is a monorepo with multiple clients and a CLI.
+            - Compare URL when a previous tag exists: `https://github.com/vizzly-testing/cli/compare/${{ steps.previous_tag.outputs.tag }}...swift/v${{ steps.new_version.outputs.version }}`
+            - Release URL when this is the first Swift tag: `https://github.com/vizzly-testing/cli/releases/tag/swift/v${{ steps.new_version.outputs.version }}`
 
             Instructions:
-            1. Use git commands to inspect commits and changed files since the previous Swift tag.
+            1. Use git commands to inspect commits and changed files since the previous Swift tag. If no previous tag is listed, inspect the Swift client history and current files.
             2. Analyze which changes are relevant to `clients/swift/`.
             3. Read relevant code changes when commit messages are not enough.
             4. Generate user-friendly release notes with categories: Added, Changed, Fixed.
@@ -116,7 +137,7 @@ jobs:
             ### Fixed
             - Bug fixes
 
-            **Full Changelog**: https://github.com/vizzly-testing/cli/compare/swift/v${{ steps.current_version.outputs.version }}...swift/v${{ steps.new_version.outputs.version }}
+            **Full Changelog**: <use the compare URL when a previous tag exists, otherwise use the release URL>
 
       - name: Update CHANGELOG.md
         working-directory: ./clients/swift

--- a/.github/workflows/release-vitest-client.yml
+++ b/.github/workflows/release-vitest-client.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - major
 
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -68,6 +72,7 @@ jobs:
           echo "tag=vitest/v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
+        continue-on-error: true
         uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
@@ -118,6 +123,14 @@ jobs:
         working-directory: ./clients/vitest
         run: pnpm run lint
 
+      - name: Verify package version is unpublished
+        working-directory: ./clients/vitest
+        run: |
+          if npm view @vizzly-testing/vitest@${{ steps.version.outputs.version }} version >/dev/null 2>&1; then
+            echo "@vizzly-testing/vitest@${{ steps.version.outputs.version }} is already published"
+            exit 1
+          fi
+
       - name: Update CHANGELOG.md
         working-directory: ./clients/vitest
         run: |
@@ -148,6 +161,13 @@ jobs:
           mv CHANGELOG-NEW.md CHANGELOG.md
           rm CHANGELOG-RELEASE.md
 
+      - name: Pack package
+        id: pack
+        working-directory: ./clients/vitest
+        run: |
+          PACK_FILE=$(npm pack --ignore-scripts)
+          echo "file=$PACK_FILE" >> $GITHUB_OUTPUT
+
       - name: Reconfigure git auth
         run: |
           git config --local user.email "${{ secrets.GIT_USER_EMAIL }}"
@@ -164,7 +184,7 @@ jobs:
 
       - name: Publish to npm
         working-directory: ./clients/vitest
-        run: npm publish --provenance --access public
+        run: npm publish "${{ steps.pack.outputs.file }}" --provenance --access public
 
       - name: Read changelog for release
         id: release_notes
@@ -184,7 +204,7 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: 🧪 Vitest Integration v${{ steps.version.outputs.version }}
           body: ${{ steps.release_notes.outputs.notes }}
-          files: ./clients/vitest/*.tgz
+          files: ./clients/vitest/${{ steps.pack.outputs.file }}
           draft: false
           prerelease: false
         env:


### PR DESCRIPTION
## Why

The CLI release is out, and the SDK releases are next. Before we run those workflows, the SDK release paths need to be a little more defensive so we do not burn a version number, publish without a matching GitHub asset, or trip over the Swift package's first real tag.

This keeps the release process boring: one SDK release at a time, generated notes when available, fallback notes when Codex-action has a bad day, and explicit checks that the target package version is still unpublished before we push tags or publish artifacts.

## What changed

- Queues all SDK release workflows behind a shared sdk-release concurrency group so version commits and tags do not race each other on main.
- Lets SDK changelog generation fall back cleanly if the Codex release-note step fails.
- Verifies npm SDK target versions are unpublished before updating changelogs and publishing.
- Packs npm SDKs with npm pack --ignore-scripts, publishes that exact tarball, and attaches that exact tarball to the GitHub release.
- Adds Ruby release safety checks: refreshes to latest main, installs dependencies, runs bundle exec rake, verifies the gem version is unpublished, and fixes the Ruby changelog compare URL.
- Fixes Swift release version detection so [Unreleased] is ignored and the first real Swift tag can be created from 0.0.0 cleanly.

## Verification

- git diff --check origin/main..HEAD
- Parsed all six changed workflow YAML files with Ruby's YAML loader.
