### PR TITLE
🔧 Restore Node after SDK release notes

### DIFF
--- a/.github/workflows/release-ember-client.yml
+++ b/.github/workflows/release-ember-client.yml
@@ -120,6 +120,12 @@ jobs:
 
             **Full Changelog**: https://github.com/vizzly-testing/cli/compare/ember/v${{ steps.current_version.outputs.version }}...ember/v${{ steps.version.outputs.version }}
 
+      - name: Set Node.js back to release version
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.13.1'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         working-directory: ./clients/ember
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-static-site-client.yml
+++ b/.github/workflows/release-static-site-client.yml
@@ -111,6 +111,12 @@ jobs:
 
             **Full Changelog**: https://github.com/vizzly-testing/cli/compare/static-site/v${{ steps.current_version.outputs.version }}...static-site/v${{ steps.version.outputs.version }}
 
+      - name: Set Node.js back to release version
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.13.1'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         working-directory: ./clients/static-site
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-storybook-client.yml
+++ b/.github/workflows/release-storybook-client.yml
@@ -111,6 +111,12 @@ jobs:
 
             **Full Changelog**: https://github.com/vizzly-testing/cli/compare/storybook/v${{ steps.current_version.outputs.version }}...storybook/v${{ steps.version.outputs.version }}
 
+      - name: Set Node.js back to release version
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.13.1'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         working-directory: ./clients/storybook
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-vitest-client.yml
+++ b/.github/workflows/release-vitest-client.yml
@@ -111,6 +111,12 @@ jobs:
 
             **Full Changelog**: https://github.com/vizzly-testing/cli/compare/vitest/v${{ steps.current_version.outputs.version }}...vitest/v${{ steps.version.outputs.version }}
 
+      - name: Set Node.js back to release version
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.13.1'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies
         working-directory: ./clients/vitest
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Why

The static-site SDK release failed before tests/publish because the Codex changelog action switches the active job runtime back to Node 20. Our SDK release workflows install pnpm 11, which requires Node 22+, so the next pnpm command crashed before the package could test or publish.

The warning points at `actions/setup-node@49933...` because that setup-node call lives inside `openai/codex-action`, not in these workflows. This PR fixes the breakage by setting the release job runtime back to our supported Node version immediately after Codex runs.

## What changed

- Adds a post-Codex `actions/setup-node@v6` step in the Storybook, Static Site, Vitest, and Ember SDK release workflows.
- Resets those jobs to Node 22.13.1 before `pnpm install`, tests, build, pack, and publish.
- Keeps the release workflows single-job and avoids extra changelog plumbing.
- Leaves Ruby and Swift unchanged because they do not run pnpm/npm after Codex in their release flows.

## Verification

- `git diff --check HEAD^ HEAD`
- Parsed all six SDK release workflow YAML files with Ruby.