### PR TITLE
🐛 Surface wrapped test command failures

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -446,7 +446,9 @@ export async function runCommand(
           });
           output.cleanup();
         } else {
-          output.error('Test run failed');
+          output.error(
+            `Test command failed with exit code ${exitCode}. Check the command output above for the original failure.`
+          );
         }
         return { success: false, exitCode };
       } else {

--- a/tests/commands/run.test.js
+++ b/tests/commands/run.test.js
@@ -345,6 +345,14 @@ describe('commands/run', () => {
 
       assert.strictEqual(result.success, false);
       assert.strictEqual(result.exitCode, 2);
+      assert.ok(
+        output.calls.some(
+          c =>
+            c.method === 'error' &&
+            c.args[0].includes('Test command failed with exit code 2') &&
+            c.args[0].includes('Check the command output above')
+        )
+      );
     });
 
     it('handles generic error during test run', async () => {


### PR DESCRIPTION
## Why

When vizzly run wraps a failing test command, the original command output is already streamed above the Vizzly summary. The final CLI message was still just Test run failed, which made CI failures feel like the CLI had swallowed the real error and left reviewers without a clear next step.

## Approach

This keeps the existing streaming behavior intact and makes the final wrapper message explicit: the wrapped test command failed, which exit code it returned, and that the original failure is in the command output above.

That avoids adding buffering or replay behavior around child process output, which would be riskier for interactive test runners and TTY-sensitive tools.

## Confidence

The focused run-command test covers the new failure message, and Biome passes on the touched CLI files.