### PR TITLE
🐛 Fix CLI regressions across JSON, help, and TDD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,9 @@ Keep subjects concise; include issue/PR refs when relevant (example: `(#217)`).
 PRs should include:
 - Why the change is needed.
 - A clear summary of all meaningful diff areas.
-- A test plan with exact commands run.
+- A concise confidence/verification summary without listing commands run.
 - Screenshots or terminal output for UI/reporting changes when helpful.
+- Do not mention private or sibling repo work in public repo PRs.
 
 ## Security & Configuration Tips
 Use Node.js `>=22`. Keep secrets (for example `VIZZLY_TOKEN`) out of git.  

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ pnpm test -- --watch
 The dashboard shows screenshots, baselines, and diffs as they arrive. Accept or
 reject changes right from the UI.
 
+For a one-off local check, wrap the test command with `tdd run`:
+
+```bash
+vizzly tdd run "pnpm test" --no-open
+vizzly context build current --source local --agent
+```
+
+That run writes review data under `.vizzly/` and prints a context command you
+can use for follow-up inspection. If screenshots were captured, Vizzly also
+generates `.vizzly/report/index.html`; omit `--no-open` when you want that
+report opened automatically.
+
 ### Run With Cloud Review
 
 Use cloud builds when you want shared baselines, team review, and CI status:
@@ -211,10 +223,15 @@ export default {
 | `vizzly tdd status` | Check the local TDD server for this project. |
 | `vizzly tdd list` | List running local TDD servers. |
 | `vizzly tdd stop` | Stop the local TDD server for this project. |
-| `vizzly tdd run "cmd"` | Run tests once, generate a static visual report, and open it by default. |
+| `vizzly tdd run "cmd"` | Run tests once and write local review data under `.vizzly/`. |
 | `vizzly run "cmd"` | Run tests with cloud build and review integration. |
 | `vizzly context ...` | Fetch visual context for builds, comparisons, screenshots, and review queues. |
 | `vizzly upload <dir>` | Upload an existing folder of screenshots. |
+| `vizzly preview <dir>` | Upload static build output for in-context review. |
+| `vizzly approve <comparison-id>` | Approve a visual comparison. |
+| `vizzly reject <comparison-id>` | Reject a visual comparison with a reason. |
+| `vizzly comment <build-id>` | Add a build comment. |
+| `vizzly config [key]` | Inspect resolved configuration values. |
 | `vizzly login` | Authenticate through the browser. |
 | `vizzly doctor` | Validate your local setup. |
 

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ Use `vizzly init --agent-skill` to install only the local skill, or
 
 ### Start Local TDD
 
-Start the TDD server, run your tests, and open the dashboard at
-`http://localhost:47392`.
+Start the TDD server, run your tests, and open the dashboard at the URL the
+command prints. Add `--open` when you want Vizzly to open the dashboard for
+you. If the default port is busy, Vizzly picks the next available port; use the
+printed `--port` value with `vizzly tdd status` or `vizzly tdd stop`.
 
 ```bash
-vizzly tdd start
+vizzly tdd start --open
 pnpm test -- --watch
 ```
 
@@ -206,7 +208,10 @@ export default {
 | Command | What it does |
 | --- | --- |
 | `vizzly tdd start` | Start the local TDD server and dashboard. |
-| `vizzly tdd run "cmd"` | Run tests once and generate a static visual report. |
+| `vizzly tdd status` | Check the local TDD server for this project. |
+| `vizzly tdd list` | List running local TDD servers. |
+| `vizzly tdd stop` | Stop the local TDD server for this project. |
+| `vizzly tdd run "cmd"` | Run tests once, generate a static visual report, and open it by default. |
 | `vizzly run "cmd"` | Run tests with cloud build and review integration. |
 | `vizzly context ...` | Fetch visual context for builds, comparisons, screenshots, and review queues. |
 | `vizzly upload <dir>` | Upload an existing folder of screenshots. |

--- a/clients/ember/README.md
+++ b/clients/ember/README.md
@@ -5,11 +5,14 @@ Visual testing SDK for Ember.js projects using Testem. Capture screenshots from 
 ## Installation
 
 ```bash
-pnpm install -D @vizzly-testing/ember
+pnpm install -D @vizzly-testing/cli @vizzly-testing/ember
 
-# Install a Playwright browser
+# Install the Playwright browser you plan to test with
 pnpm exec playwright install chromium
 ```
+
+Chromium, Firefox, and WebKit are supported. Install additional browsers with
+`pnpm exec playwright install firefox` or `pnpm exec playwright install webkit`.
 
 ## Setup
 
@@ -31,7 +34,9 @@ module.exports = configure({
 });
 ```
 
-The `configure()` function replaces standard browser launchers (Chrome, Firefox, Safari) with Playwright-powered launchers that can capture screenshots. Browsers run in **headless mode by default**.
+The `configure()` function maps standard Testem launchers (Chrome, Firefox,
+Safari) to Playwright-powered Chromium, Firefox, and WebKit launchers that can
+capture screenshots. Browsers run in **headless mode by default**.
 
 > **Note for Ember + Vite projects**: The `cwd: 'dist'` option is required because Vite builds test files into the `dist/` directory. Without this, Testem won't find your test assets.
 

--- a/clients/ember/package.json
+++ b/clients/ember/package.json
@@ -51,7 +51,7 @@
     "test:all": "node --test --test-reporter=spec 'tests/**/*.test.js'",
     "test:watch": "node --test --test-reporter=spec --watch 'tests/**/*.test.js'",
     "test:ember": "cd test-app && pnpm install --frozen-lockfile && pnpm run build --mode development && pnpm exec testem ci --file testem.cjs",
-    "test:ember:tdd": "../../bin/vizzly.js tdd run 'pnpm run test:ember'",
+    "test:ember:tdd": "../../bin/vizzly.js tdd run 'pnpm run test:ember' --no-open",
     "test:ember:cloud": "../../bin/vizzly.js run 'pnpm run test:ember'",
     "lint": "biome lint src tests bin",
     "lint:fix": "biome lint --write src tests bin",

--- a/clients/static-site/README.md
+++ b/clients/static-site/README.md
@@ -5,7 +5,7 @@ Seamlessly integrate your static sites (Gatsby, Astro, Jekyll, Next.js static ex
 ## Installation
 
 ```bash
-pnpm install @vizzly-testing/static-site
+pnpm install -D @vizzly-testing/cli @vizzly-testing/static-site
 ```
 
 The plugin is automatically discovered by the Vizzly CLI via the `@vizzly-testing/*` scope.
@@ -29,6 +29,9 @@ vizzly static-site ./dist \
 
 # With concurrency control
 vizzly static-site ./dist --concurrency 5
+
+# With comma-separated browser args
+vizzly static-site ./dist --browser-args "--no-sandbox,--disable-dev-shm-usage"
 ```
 
 ### Programmatic Usage
@@ -151,7 +154,7 @@ Configuration is merged in this order (later overrides earlier):
 - `--browser <type>` - Browser engine to use: `chromium`, `firefox`, or `webkit`
 - `--include <pattern>` - Include page pattern (glob)
 - `--exclude <pattern>` - Exclude page pattern (glob)
-- `--browser-args <args>` - Additional Playwright browser arguments
+- `--browser-args <args>` - Comma-separated Playwright browser arguments
 - `--headless` - Run browser in headless mode (default: true)
 - `--no-headless` - Run browser with a visible window
 - `--full-page` - Capture full page screenshots (default: true)

--- a/clients/storybook/README.md
+++ b/clients/storybook/README.md
@@ -7,7 +7,7 @@ changes with position-based comments and review rules.
 ## Installation
 
 ```bash
-pnpm install @vizzly-testing/storybook
+pnpm install -D @vizzly-testing/cli @vizzly-testing/storybook
 ```
 
 The plugin is automatically discovered by the Vizzly CLI via the `@vizzly-testing/*` scope.
@@ -43,6 +43,9 @@ vizzly storybook ./storybook-static \
 
 # With concurrency control
 vizzly storybook ./storybook-static --concurrency 5
+
+# With comma-separated browser args
+vizzly storybook ./storybook-static --browser-args "--no-sandbox,--disable-dev-shm-usage"
 ```
 
 ### Programmatic Usage
@@ -166,7 +169,7 @@ Configuration is merged in this order (later overrides earlier):
 - `--include <pattern>` - Include story pattern (glob)
 - `--exclude <pattern>` - Exclude story pattern (glob)
 - `--config <path>` - Path to custom config file
-- `--browser-args <args>` - Additional Playwright browser arguments
+- `--browser-args <args>` - Comma-separated Playwright browser arguments
 - `--headless` - Run browser in headless mode (default: true)
 - `--no-headless` - Run browser with a visible window
 - `--full-page` - Capture full page screenshots (default: true)

--- a/clients/swift/INTEGRATION.md
+++ b/clients/swift/INTEGRATION.md
@@ -458,9 +458,11 @@ vizzly tdd start
 **Solution**:
 
 1. Ensure TDD server is running: `vizzly tdd start`
-2. Check `~/.vizzly/server.json` exists in your home directory
-3. Verify the server is reachable: `curl http://localhost:47392/health`
-4. Or explicitly set: `export VIZZLY_SERVER_URL=http://localhost:47392`
+2. Check `.vizzly/server.json` exists in your project checkout
+3. Verify the printed server URL is reachable, for example:
+   `curl http://localhost:47392/health`
+4. Or explicitly set the printed URL:
+   `export VIZZLY_SERVER_URL=http://localhost:47392`
 
 ## Best Practices
 

--- a/clients/swift/INTEGRATION.md
+++ b/clients/swift/INTEGRATION.md
@@ -51,28 +51,43 @@ cd /path/to/MyiOSApp
 Create a `vizzly.config.js` file (optional but recommended):
 
 ```javascript
-export default {
-  // Delta E comparison threshold. Omitted screenshots use server config.
-  threshold: 0,
+import { defineConfig } from '@vizzly-testing/cli/config';
 
-  // TDD server port
-  port: 47392,
-
-  // Baseline directory
-  baselineDir: '.vizzly/baselines'
-}
+export default defineConfig({
+  server: {
+    port: 47392,
+  },
+  comparison: {
+    // Delta E comparison threshold. Omitted screenshots use server config.
+    threshold: 0,
+  },
+});
 ```
 
 ### 4. Start TDD Server
 
 ```bash
-vizzly tdd start
+vizzly tdd start --open
 ```
 
-This starts a local server at `http://localhost:47392` that will:
+This starts a local server that will:
 - Receive screenshots from your tests
 - Compare them against baselines
-- Serve a dashboard at `http://localhost:47392/dashboard`
+- Serve a dashboard at the URL printed by the command
+
+Vizzly uses port `47392` by default. If that port is busy, it auto-assigns
+another free port and prints that URL instead.
+
+For a one-off run, wrap your test command:
+
+```bash
+vizzly tdd run \
+  "xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'" \
+  --no-open
+```
+
+That writes local review data under `.vizzly/` and creates a static report at
+`.vizzly/report/index.html` when screenshots are captured.
 
 ### 5. Write UI Tests with Vizzly
 

--- a/clients/swift/QUICKSTART.md
+++ b/clients/swift/QUICKSTART.md
@@ -20,8 +20,11 @@ pnpm install -g @vizzly-testing/cli
 In your iOS project directory:
 
 ```bash
-vizzly tdd start
+vizzly tdd start --open
 ```
+
+Vizzly uses port `47392` by default. If that port is busy, it prints the
+dashboard URL with the auto-assigned port.
 
 ## 4. Write a Visual Test
 
@@ -58,13 +61,24 @@ xcodebuild test \
 
 ## 6. Review Results
 
-Open dashboard: **http://localhost:47392/dashboard**
+Open the dashboard URL printed by `vizzly tdd start`.
 
 - ✅ Green = Screenshots match baselines
 - ⚠️ Yellow = Visual differences detected
 - 🆕 Blue = New screenshots (first run)
 
 Click any screenshot to see side-by-side comparison and approve/reject changes.
+
+For a one-off local check, wrap the test command instead:
+
+```bash
+vizzly tdd run \
+  "xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'" \
+  --no-open
+```
+
+That writes review data under `.vizzly/` and creates `.vizzly/report/index.html`
+when screenshots are captured.
 
 ## Next Steps
 

--- a/clients/swift/README.md
+++ b/clients/swift/README.md
@@ -52,10 +52,12 @@ for native app integration.
 
 ```bash
 cd /path/to/your/ios/project
-vizzly tdd start
+vizzly tdd start --open
 ```
 
-This starts a local server at `http://localhost:47392` that receives screenshots and performs visual comparisons.
+This starts a local server that receives screenshots and performs visual
+comparisons. Vizzly uses `http://localhost:47392` by default; if that port is
+busy, use the URL printed by the command.
 
 ### 2. Add Vizzly to Your UI Tests
 
@@ -86,7 +88,20 @@ xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 1
 
 ### 4. View Results
 
-Open the dashboard at **http://localhost:47392/dashboard** to see visual comparisons, accept/reject changes, and review differences.
+Open the dashboard URL printed by `vizzly tdd start` to see visual comparisons,
+accept/reject changes, and review differences.
+
+For a one-off local run, wrap your `xcodebuild` command:
+
+```bash
+vizzly tdd run \
+  "xcodebuild test -scheme MyApp -destination 'platform=iOS Simulator,name=iPhone 15'" \
+  --no-open
+```
+
+That writes local review data under `.vizzly/`. If screenshots were captured,
+Vizzly also creates `.vizzly/report/index.html`; omit `--no-open` when you want
+the report opened automatically.
 
 ## Usage Examples
 

--- a/clients/swift/README.md
+++ b/clients/swift/README.md
@@ -303,10 +303,11 @@ The SDK automatically discovers a running Vizzly TDD server using this priority 
 
 1. **VIZZLY_SERVER_URL environment variable** - Explicitly set server URL
 2. **Project server file** - `.vizzly/server.json` in the current directory
-3. **Global server file** - `~/.vizzly/server.json` written by CLI
-4. **Default port health check** - Tests `http://localhost:47392/health`
+3. **Default port health check** - Tests `http://localhost:47392/health`
 
-When you run `vizzly tdd start`, the CLI automatically writes server info to `~/.vizzly/server.json` in your home directory, enabling zero-config discovery from iOS tests.
+When you run `vizzly tdd start`, the CLI writes server info to
+`.vizzly/server.json` in your project. Run UI tests from the project checkout,
+or set `VIZZLY_SERVER_URL` explicitly when your test process starts elsewhere.
 
 ### Environment Variables
 
@@ -479,9 +480,11 @@ override func setUpWithError() throws {
 ### Server Not Found
 
 1. Ensure TDD server is running: `vizzly tdd start`
-2. Check `~/.vizzly/server.json` exists in your home directory
-3. Verify the server is reachable: `curl http://localhost:47392/health`
-4. Or explicitly set: `export VIZZLY_SERVER_URL=http://localhost:47392`
+2. Check `.vizzly/server.json` exists in your project checkout
+3. Verify the printed server URL is reachable, for example:
+   `curl http://localhost:47392/health`
+4. Or explicitly set the printed URL:
+   `export VIZZLY_SERVER_URL=http://localhost:47392`
 
 ### Visual Differences Not Showing
 

--- a/clients/vitest/package.json
+++ b/clients/vitest/package.json
@@ -41,7 +41,7 @@
     "test": "pnpm run test:unit",
     "test:unit": "vitest run --config vitest.config.js",
     "test:e2e": "vitest run --config vitest.e2e.config.js",
-    "test:e2e:tdd": "../../bin/vizzly.js tdd run 'pnpm run test:e2e'",
+    "test:e2e:tdd": "../../bin/vizzly.js tdd run 'pnpm run test:e2e' --no-open",
     "test:e2e:cloud": "../../bin/vizzly.js run 'pnpm run test:e2e'",
     "lint": "biome lint src tests",
     "lint:fix": "biome lint --write src tests",

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -152,6 +152,15 @@ vizzly tdd run "pnpm test" --json
 }
 ```
 
+`tdd run` keeps structured output on stdout. The wrapped test command can still
+print normally; Vizzly forwards that child output to stderr in JSON mode so
+`stdout` stays safe to parse.
+
+When screenshots are captured, Vizzly also writes local review artifacts under
+`.vizzly/`, including `.vizzly/report-data.json` and
+`.vizzly/report/index.html`. Use `contextCommand` when you want a stable
+follow-up command for local review data.
+
 ### `vizzly tdd start`
 
 ```bash
@@ -170,6 +179,11 @@ vizzly tdd start --json
 }
 ```
 
+If this project already has a live TDD server, the command returns
+`status: "already_running"` with the same `port`, `pid`, and `dashboardUrl`
+fields. Use that `port` with `vizzly tdd status --port <port>` or
+`vizzly tdd stop --port <port>` when Vizzly auto-assigned a non-default port.
+
 ### `vizzly tdd stop`
 
 ```bash
@@ -185,6 +199,10 @@ vizzly tdd stop --json
   }
 }
 ```
+
+`stop` also returns parseable non-happy-path states. If no server is registered
+for the current project or port, `data.status` is `"not_running"`. If Vizzly
+finds stale daemon files and cleans them up, `data.status` is `"stale"`.
 
 ### `vizzly tdd status`
 
@@ -205,6 +223,10 @@ vizzly tdd status --json
   }
 }
 ```
+
+When no server is running, `status` still uses the data envelope and returns
+`{ "running": false, "message": "TDD server not running" }`. Stale daemon files
+are reported as `status: "stale"` with `running: false` after cleanup.
 
 ### `vizzly tdd list`
 
@@ -737,6 +759,43 @@ vizzly upload ./screenshots --json
 }
 ```
 
+With `--wait`, the payload includes comparison results after Vizzly finishes
+processing the build:
+
+```bash
+vizzly upload ./screenshots --wait --json
+```
+
+```json
+{
+  "status": "data",
+  "data": {
+    "buildId": "abc123-def456",
+    "status": "failed",
+    "url": "https://app.vizzly.dev/...",
+    "stats": {
+      "total": 20,
+      "uploaded": 15,
+      "skipped": 5,
+      "bytes": 2500000
+    },
+    "git": {
+      "branch": "main",
+      "commit": "abc1234",
+      "message": "Add feature"
+    },
+    "comparisons": {
+      "total": 15,
+      "passed": 12,
+      "failed": 2,
+      "new": 1
+    },
+    "approvalStatus": "pending",
+    "executionTimeMs": 9876
+  }
+}
+```
+
 ### `vizzly preview`
 
 ```bash
@@ -762,6 +821,61 @@ vizzly preview ./dist --json
   }
 }
 ```
+
+### `vizzly approve`
+
+```bash
+vizzly approve <comparison-id> --json
+```
+
+```json
+{
+  "status": "data",
+  "data": {
+    "approved": true,
+    "comparisonId": "comp_123",
+    "comparison": { /* updated comparison */ }
+  }
+}
+```
+
+### `vizzly reject`
+
+```bash
+vizzly reject <comparison-id> --reason "Unexpected regression" --json
+```
+
+```json
+{
+  "status": "data",
+  "data": {
+    "rejected": true,
+    "comparisonId": "comp_123",
+    "reason": "Unexpected regression",
+    "comparison": { /* updated comparison */ }
+  }
+}
+```
+
+### `vizzly comment`
+
+```bash
+vizzly comment <build-id> "Needs design review" --json
+```
+
+```json
+{
+  "status": "data",
+  "data": {
+    "created": true,
+    "buildId": "build_123",
+    "comment": { /* created comment */ }
+  }
+}
+```
+
+Review actions require a user login. Project tokens are intentionally not enough
+to approve, reject, or comment.
 
 ### `vizzly status`
 

--- a/skills/vizzly/SKILL.md
+++ b/skills/vizzly/SKILL.md
@@ -23,16 +23,24 @@ If a task names a screen, component, or screenshot, inspect that screenshot's hi
 vizzly context screenshot "<screenshot-name>" --source local --json
 ```
 
-When you make or verify UI changes, run the focused user workflow that owns the surface:
+When you make or verify UI changes, use the local TDD server as the active feedback loop:
+
+```bash
+vizzly tdd start &
+npm run test:e2e -- tests/e2e/path.spec.js
+vizzly context build current --source local --agent --json
+```
+
+The user may choose whether the TDD server runs in the foreground or background. Once it is
+running, run tests normally from the repo. The SDK discovers `.vizzly/server.json`, posts
+screenshots to the active TDD server, and refreshes `.vizzly/current`, `.vizzly/diffs`, report
+data, and local context.
+
+Use `vizzly tdd run` for true one-off runs where you want the CLI to own starting the visual
+session and running the command:
 
 ```bash
 vizzly tdd run "<test command>" --no-open
-```
-
-Then inspect what changed:
-
-```bash
-vizzly context build current --source local --agent --json
 ```
 
 For specific evidence, drill in:

--- a/skills/vizzly/references/cli-context.md
+++ b/skills/vizzly/references/cli-context.md
@@ -5,13 +5,19 @@ Use these commands to gather Vizzly evidence before making UI assumptions.
 ## Local TDD
 
 ```bash
-vizzly tdd start
+vizzly tdd start --open
+vizzly tdd status
+vizzly tdd stop
 vizzly tdd run "<test command>" --no-open
 vizzly context build current --source local --agent
 vizzly context build current --source local --agent --json
 ```
 
-Local context reads `.vizzly` state and does not require cloud auth.
+If `tdd start` prints a non-default port, pass that same port to
+`tdd status --port <port>` and `tdd stop --port <port>`.
+
+Local context reads `.vizzly` state and does not require cloud auth. After a
+one-shot `tdd run`, prefer the printed `contextCommand` before editing UI.
 
 ## Cloud Builds
 

--- a/skills/vizzly/references/setup-ci.md
+++ b/skills/vizzly/references/setup-ci.md
@@ -6,11 +6,13 @@ Use Vizzly locally for fast feedback and in CI for shared review.
 
 ```bash
 vizzly init
-vizzly tdd start
+vizzly tdd start --open
 vizzly tdd run "<test command>" --no-open
 ```
 
 The local SDK discovers `.vizzly/server.json` and sends screenshots to the TDD server when it is running.
+For one-off checks, `vizzly tdd run` writes local review data under `.vizzly/`
+and prints a context command for follow-up inspection.
 
 ## Cloud Setup
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import 'dotenv/config';
-import { program } from 'commander';
+import { existsSync, statSync } from 'node:fs';
+import { Option, program } from 'commander';
 import { apiCommand, validateApiOptions } from './commands/api.js';
 import {
   baselinesCommand,
@@ -95,7 +96,7 @@ const formatHelp = (cmd, helper) => {
     lines.push(`   ${c.gray('Visual regression testing from your terminal')}`);
   } else {
     // Compact header for subcommands
-    lines.push(`  ${c.brand.amber(c.bold('vizzly'))} ${c.white(cmd.name())}`);
+    lines.push(`  ${c.brand.amber(c.bold(commandPath(cmd)))}`);
     let desc = cmd.description();
     if (desc) {
       lines.push(`  ${c.gray(desc)}`);
@@ -141,7 +142,7 @@ const formatHelp = (cmd, helper) => {
           key: 'setup',
           icon: '▸',
           title: 'Setup',
-          names: ['init', 'doctor', 'config', 'baselines'],
+          names: ['init', 'doctor', 'config', 'baselines', 'project'],
         },
         { key: 'advanced', icon: '▸', title: 'Advanced', names: ['api'] },
         {
@@ -234,7 +235,7 @@ const formatHelp = (cmd, helper) => {
     lines.push(`  ${c.brand.amber('▸')} ${c.bold('Quick Start')}`);
     lines.push('');
     lines.push(`      ${c.dim('# Local visual review')}`);
-    lines.push(`      ${c.gray('$')} ${c.white('vizzly tdd start')}`);
+    lines.push(`      ${c.gray('$')} ${c.white('vizzly tdd start --open')}`);
     lines.push('');
     lines.push(`      ${c.dim('# CI pipeline')}`);
     lines.push(
@@ -276,6 +277,21 @@ const formatHelp = (cmd, helper) => {
 
   return lines.join('\n');
 };
+
+function commandPath(cmd) {
+  let names = [];
+  let current = cmd;
+
+  while (current) {
+    let name = current.name();
+    if (name) {
+      names.unshift(name);
+    }
+    current = current.parent;
+  }
+
+  return names.join(' ');
+}
 
 function extractGlobalOptionsFromArgv(argv, commandNames = null) {
   let configPath = null;
@@ -337,6 +353,162 @@ function normalizeJsonArgv(argv, commandNames) {
   return normalizedArgv;
 }
 
+function findNestedCommandRequest(
+  args,
+  startIndex,
+  subcommandNames,
+  parentName
+) {
+  if (!subcommandNames?.size) {
+    return null;
+  }
+
+  let valueOptions = new Set(['-c', '--config', '--token', '--log-level']);
+
+  for (let i = startIndex; i < args.length; i++) {
+    let arg = args[i];
+
+    if (arg === '--') {
+      return null;
+    }
+
+    if (valueOptions.has(arg)) {
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      continue;
+    }
+
+    return {
+      name: arg,
+      known: subcommandNames.has(arg),
+      helpCommand: `vizzly ${parentName} --help`,
+    };
+  }
+
+  return null;
+}
+
+function findRequestedCommand(
+  argv,
+  commandNames,
+  nestedCommandNames = new Map()
+) {
+  let valueOptions = new Set(['-c', '--config', '--token', '--log-level']);
+  let args = argv.slice(2);
+  let jsonValueCandidate = null;
+
+  for (let i = 0; i < args.length; i++) {
+    let arg = args[i];
+
+    if (arg === '--') {
+      return null;
+    }
+
+    if (arg === '--json') {
+      let nextArg = args[i + 1];
+      if (nextArg && !nextArg.startsWith('-') && !commandNames.has(nextArg)) {
+        jsonValueCandidate = jsonValueCandidate || nextArg;
+        i++;
+      }
+      continue;
+    }
+
+    if (valueOptions.has(arg)) {
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith('--json=')) {
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      continue;
+    }
+
+    if (arg.startsWith('-')) {
+      continue;
+    }
+
+    let known = commandNames.has(arg);
+    if (known) {
+      let nestedRequest = findNestedCommandRequest(
+        args,
+        i + 1,
+        nestedCommandNames.get(arg),
+        arg
+      );
+      if (nestedRequest && !nestedRequest.known) {
+        return nestedRequest;
+      }
+    }
+
+    return {
+      name: arg,
+      known,
+    };
+  }
+
+  if (jsonValueCandidate) {
+    return {
+      name: jsonValueCandidate,
+      known: false,
+    };
+  }
+
+  return null;
+}
+
+function getGlobalOptions() {
+  let options = program.opts();
+  return {
+    ...options,
+    noColor: options.noColor || options.color === false,
+  };
+}
+
+function reportValidationErrors(errors) {
+  if (output.isJson()) {
+    output.error('Validation errors', null, { errors });
+  } else {
+    output.error('Validation errors:');
+    for (let error of errors) {
+      output.printErr(`  - ${error}`);
+    }
+  }
+  process.exit(1);
+}
+
+function formatCommanderError(message) {
+  return message.replace(/^error:\s*/, '').trim();
+}
+
+function writeCommanderError(text) {
+  let message = formatCommanderError(text);
+  if (!message) {
+    return;
+  }
+
+  if (output.isJson()) {
+    if (message.startsWith('(')) {
+      return;
+    }
+    output.error(message);
+  } else {
+    process.stderr.write(text);
+    if (!text.endsWith('\n')) {
+      process.stderr.write('\n');
+    }
+  }
+}
+
 program
   .name('vizzly')
   .description('Vizzly CLI for visual regression testing')
@@ -359,6 +531,14 @@ program
     'Fail on any error (default: be resilient, warn on non-critical issues)'
   )
   .configureHelp({ formatHelp });
+
+program.configureOutput({
+  writeErr: writeCommanderError,
+});
+
+program.showHelpAfterError('(Run vizzly --help for available commands)');
+program.showSuggestionAfterError();
+program.exitOverride();
 
 // Load plugins before defining commands
 // We need to manually parse to get the config option early
@@ -424,7 +604,7 @@ program
   )
   .option('--skip-agent-skill', 'Skip the Vizzly agent skill prompt')
   .action(async options => {
-    let globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     await init({ ...globalOptions, ...options, plugins });
   });
 
@@ -451,15 +631,21 @@ program
   .option('--upload-all', 'Upload all screenshots without SHA deduplication')
   .option('--parallel-id <id>', 'Unique identifier for parallel test execution')
   .action(async (path, options) => {
-    let globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateUploadOptions(path, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
+      reportValidationErrors(validationErrors);
+    }
+
+    if (!existsSync(path)) {
+      output.error(`Path does not exist: ${path}`);
+      process.exit(1);
+    }
+
+    if (!statSync(path).isDirectory()) {
+      output.error(`Path is not a directory: ${path}`);
       process.exit(1);
     }
 
@@ -472,13 +658,15 @@ program
 // TDD command with subcommands - local visual review with an interactive dashboard
 const tddCmd = program
   .command('tdd')
-  .description('Run tests in TDD mode with local visual review');
+  .description('Run tests in TDD mode with local visual review')
+  .showHelpAfterError('(Run vizzly tdd --help for available commands)')
+  .showSuggestionAfterError();
 
 // TDD Start - Background server
 tddCmd
   .command('start')
   .description('Start background TDD server with dashboard')
-  .option('--port <port>', 'Port for TDD server', '47392')
+  .option('--port <port>', 'Port for TDD server')
   .option('--open', 'Open dashboard in browser')
   .option('--baseline-build <id>', 'Use specific build as baseline')
   .option('--baseline-comparison <id>', 'Use specific comparison as baseline')
@@ -492,9 +680,14 @@ tddCmd
   .option('--timeout <ms>', 'Server timeout in milliseconds', '30000')
   .option('--fail-on-diff', 'Fail tests when visual differences are detected')
   .option('--token <token>', 'API token override')
-  .option('--daemon-child', 'Internal: run as daemon child process')
+  .addOption(
+    new Option(
+      '--daemon-child',
+      'Internal: run as daemon child process'
+    ).hideHelp()
+  )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // If this is a daemon child process, run the server directly
     if (options.daemonChild) {
@@ -504,11 +697,7 @@ tddCmd
 
     let validationErrors = validateTddStartOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await tddStartCommand(options, globalOptions);
@@ -518,8 +707,13 @@ tddCmd
 tddCmd
   .command('stop')
   .description('Stop background TDD server')
+  .option('--port <port>', 'Port for TDD server')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
+    let validationErrors = validateTddStartOptions(options);
+    if (validationErrors.length > 0) {
+      reportValidationErrors(validationErrors);
+    }
     await tddStopCommand(options, globalOptions);
   });
 
@@ -527,8 +721,13 @@ tddCmd
 tddCmd
   .command('status')
   .description('Check TDD server status')
+  .option('--port <port>', 'Port for TDD server')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
+    let validationErrors = validateTddStartOptions(options);
+    if (validationErrors.length > 0) {
+      reportValidationErrors(validationErrors);
+    }
     await tddStatusCommand(options, globalOptions);
   });
 
@@ -537,7 +736,7 @@ tddCmd
   .command('list')
   .description('List all running TDD servers')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     await tddListCommand(options, globalOptions);
   });
 
@@ -545,7 +744,7 @@ tddCmd
 tddCmd
   .command('run <command>')
   .description('Run tests once in TDD mode with local visual review')
-  .option('--port <port>', 'Port for TDD server', '47392')
+  .option('--port <port>', 'Port for TDD server')
   .option('--branch <branch>', 'Git branch override')
   .option('--environment <env>', 'Environment name', 'test')
   .option('--threshold <number>', 'Comparison threshold', Number)
@@ -565,16 +764,12 @@ tddCmd
   .option('--fail-on-diff', 'Fail tests when visual differences are detected')
   .option('--no-open', 'Skip opening report in browser')
   .action(async (command, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateTddOptions(command, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     const { result, cleanup } = await tddCommand(
@@ -602,8 +797,11 @@ tddCmd
     process.once('SIGINT', sigintHandler);
     process.once('SIGTERM', sigtermHandler);
 
-    // If there are comparisons, generate static report
-    const hasComparisons = result?.comparisons?.length > 0;
+    // If the run captured screenshots, generate a static report for review.
+    let hasComparisons =
+      result?.screenshotsCaptured > 0 ||
+      result?.comparisons?.length > 0 ||
+      result?.summary?.total > 0;
     if (hasComparisons) {
       // Note: Tests have completed at this point, so report-data.json is stable.
       // The report reflects the final state of all comparisons.
@@ -658,16 +856,12 @@ program
   .option('--upload-all', 'Upload all screenshots without SHA deduplication')
   .option('--parallel-id <id>', 'Unique identifier for parallel test execution')
   .action(async (command, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateRunOptions(command, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     try {
@@ -686,16 +880,12 @@ program
   .description('Check the status of a build')
   .argument('<build-id>', 'Build ID to check status for')
   .action(async (buildId, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateStatusOptions(buildId, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await statusCommand(buildId, options, globalOptions);
@@ -731,16 +921,12 @@ Examples:
 `
   )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateBuildsOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await buildsCommand(options, globalOptions);
@@ -772,16 +958,12 @@ Examples:
 `
   )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateComparisonsOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await comparisonsCommand(options, globalOptions);
@@ -789,7 +971,9 @@ Examples:
 
 let contextCmd = program
   .command('context')
-  .description('Fetch build and diff context');
+  .description('Fetch build and diff context')
+  .showHelpAfterError('(Run vizzly context --help for available commands)')
+  .showSuggestionAfterError();
 
 contextCmd
   .command('build')
@@ -815,14 +999,10 @@ Examples:
 `
   )
   .action(async (buildId, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     const validationErrors = validateContextBuildOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await contextBuildCommand(buildId, options, globalOptions);
@@ -859,14 +1039,10 @@ Examples:
 `
   )
   .action(async (comparisonId, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     const validationErrors = validateContextComparisonOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await contextComparisonCommand(comparisonId, options, globalOptions);
@@ -900,14 +1076,10 @@ Examples:
 `
   )
   .action(async (name, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     const validationErrors = validateContextScreenshotOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await contextScreenshotCommand(name, options, globalOptions);
@@ -931,14 +1103,10 @@ Examples:
 `
   )
   .action(async (fingerprintHash, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     const validationErrors = validateContextSimilarOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await contextSimilarCommand(fingerprintHash, options, globalOptions);
@@ -963,14 +1131,10 @@ Examples:
 `
   )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
     const validationErrors = validateContextReviewQueueOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await contextReviewQueueCommand(options, globalOptions);
@@ -984,16 +1148,12 @@ program
     'Specific config key to get (dot notation, e.g., comparison.threshold)'
   )
   .action(async (key, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateConfigOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await configCommand(key, options, globalOptions);
@@ -1017,16 +1177,12 @@ Note: Baselines are stored locally in .vizzly/baselines/ during TDD mode.
 `
   )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateBaselinesOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await baselinesCommand(options, globalOptions);
@@ -1067,16 +1223,12 @@ Most operations have dedicated commands (builds, comparisons, approve, etc.).
 `
   )
   .action(async (endpoint, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateApiOptions(endpoint, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await apiCommand(endpoint, options, globalOptions);
@@ -1085,7 +1237,7 @@ Most operations have dedicated commands (builds, comparisons, approve, etc.).
 program
   .command('approve')
   .description('Approve a comparison')
-  .argument('<comparison-id>', 'Comparison ID to approve (UUID format)')
+  .argument('<comparison-id>', 'Comparison ID to approve')
   .option('-m, --comment <message>', 'Optional comment explaining the approval')
   .addHelpText(
     'after',
@@ -1102,15 +1254,11 @@ Workflow:
 `
   )
   .action(async (comparisonId, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     const validationErrors = validateApproveOptions(comparisonId, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await approveCommand(comparisonId, options, globalOptions);
@@ -1119,7 +1267,7 @@ Workflow:
 program
   .command('reject')
   .description('Reject a comparison')
-  .argument('<comparison-id>', 'Comparison ID to reject (UUID format)')
+  .argument('<comparison-id>', 'Comparison ID to reject')
   .option('-r, --reason <message>', 'Required reason for rejection')
   .addHelpText(
     'after',
@@ -1136,15 +1284,11 @@ Workflow:
 `
   )
   .action(async (comparisonId, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     const validationErrors = validateRejectOptions(comparisonId, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await rejectCommand(comparisonId, options, globalOptions);
@@ -1153,7 +1297,7 @@ Workflow:
 program
   .command('comment')
   .description('Add a comment to a build')
-  .argument('<build-id>', 'Build ID to comment on (UUID format)')
+  .argument('<build-id>', 'Build ID to comment on')
   .argument('<message>', 'Comment message')
   .option(
     '-t, --type <type>',
@@ -1175,15 +1319,11 @@ Workflow:
 `
   )
   .action(async (buildId, message, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     const validationErrors = validateCommentOptions(buildId, message, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await commentCommand(buildId, message, options, globalOptions);
@@ -1204,15 +1344,11 @@ or the single organization for a project token.
 `
   )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     const validationErrors = validateOrgsOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await orgsCommand(options, globalOptions);
@@ -1239,15 +1375,11 @@ Workflow:
 `
   )
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     const validationErrors = validateProjectsOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await projectsCommand(options, globalOptions);
@@ -1255,7 +1387,9 @@ Workflow:
 
 let projectCommand = program
   .command('project')
-  .description('Manage the project linked to this local checkout');
+  .description('Manage the project linked to this local checkout')
+  .showHelpAfterError('(Run vizzly project --help for available commands)')
+  .showSuggestionAfterError();
 
 projectCommand
   .command('link [selector]')
@@ -1276,15 +1410,11 @@ used for cloud uploads; your user login remains separate for review actions.
 `
   )
   .action(async (selector, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     const validationErrors = validateProjectLinkOptions(selector, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await projectLinkCommand(selector, options, globalOptions);
@@ -1295,16 +1425,12 @@ program
   .description('Finalize a parallel build after all shards complete')
   .argument('<parallel-id>', 'Parallel ID to finalize')
   .action(async (parallelId, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateFinalizeOptions(parallelId, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await finalizeCommand(parallelId, options, globalOptions);
@@ -1333,29 +1459,27 @@ program
     (val, prev) => (prev ? [...prev, val] : [val])
   )
   .action(async (path, options) => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Show helpful error if path is missing
     if (!path) {
       output.error('Path to static files is required');
-      output.blank();
-      output.print('  Upload your build output directory:');
-      output.blank();
-      output.print('    vizzly preview ./dist');
-      output.print('    vizzly preview ./build');
-      output.print('    vizzly preview ./out');
-      output.blank();
+      if (!globalOptions.json) {
+        output.blank();
+        output.print('  Upload your build output directory:');
+        output.blank();
+        output.print('    vizzly preview ./dist');
+        output.print('    vizzly preview ./build');
+        output.print('    vizzly preview ./out');
+        output.blank();
+      }
       process.exit(1);
     }
 
     // Validate options
     const validationErrors = validatePreviewOptions(path, options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await previewCommand(path, options, globalOptions);
@@ -1366,16 +1490,12 @@ program
   .description('Run diagnostics to check your environment and configuration')
   .option('--api', 'Include API connectivity checks')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateDoctorOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await doctorCommand(options, globalOptions);
@@ -1386,16 +1506,12 @@ program
   .description('Authenticate with your Vizzly account')
   .option('--api-url <url>', 'API URL override')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateLoginOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await loginCommand(options, globalOptions);
@@ -1406,16 +1522,12 @@ program
   .description('Clear stored authentication tokens')
   .option('--api-url <url>', 'API URL override')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateLogoutOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await logoutCommand(options, globalOptions);
@@ -1426,16 +1538,12 @@ program
   .description('Show current authentication status and user information')
   .option('--api-url <url>', 'API URL override')
   .action(async options => {
-    const globalOptions = program.opts();
+    let globalOptions = getGlobalOptions();
 
     // Validate options
     const validationErrors = validateWhoamiOptions(options);
     if (validationErrors.length > 0) {
-      output.error('Validation errors:');
-      for (let error of validationErrors) {
-        output.printErr(`  - ${error}`);
-      }
-      process.exit(1);
+      reportValidationErrors(validationErrors);
     }
 
     await whoamiCommand(options, globalOptions);
@@ -1446,6 +1554,12 @@ program
 saveUserPath().catch(() => {});
 
 let commandNames = new Set(program.commands.map(command => command.name()));
+let nestedCommandNames = new Map(
+  program.commands.map(command => [
+    command.name(),
+    new Set(command.commands.map(subcommand => subcommand.name())),
+  ])
+);
 let normalizedArgv = normalizeJsonArgv(process.argv, commandNames);
 let normalizedGlobals = extractGlobalOptionsFromArgv(
   normalizedArgv,
@@ -1460,4 +1574,26 @@ output.configure({
   resetTimer: false,
 });
 
-program.parse(normalizedArgv);
+let requestedCommand = findRequestedCommand(
+  normalizedArgv,
+  commandNames,
+  nestedCommandNames
+);
+if (requestedCommand && !requestedCommand.known) {
+  output.error(`unknown command '${requestedCommand.name}'`);
+  if (!output.isJson() && requestedCommand.helpCommand) {
+    output.printErr(
+      `(Run ${requestedCommand.helpCommand} for available commands)`
+    );
+  }
+  process.exit(1);
+}
+
+try {
+  program.parse(normalizedArgv);
+} catch (error) {
+  if (error.exitCode == null) {
+    output.error('Unexpected CLI error', error);
+  }
+  process.exit(error.exitCode ?? 1);
+}

--- a/src/commands/preview.js
+++ b/src/commands/preview.js
@@ -337,22 +337,10 @@ export async function previewCommand(
   });
 
   try {
-    // Load configuration
-    let allOptions = { ...globalOptions, ...options };
-    let config = await loadConfig(globalOptions.config, allOptions);
-
-    // Validate API token (skip for dry-run)
-    if (!options.dryRun && !config.apiKey) {
-      output.error(
-        'API token required. Use --token or set VIZZLY_TOKEN environment variable'
-      );
-      exit(1);
-      return { success: false, reason: 'no-api-key' };
-    }
-
     let uploadPath = options.base ? resolve(path, options.base) : path;
 
-    // Validate path exists and is a directory
+    // Validate path exists and is a directory before auth so local input
+    // mistakes are visible without requiring credentials.
     if (!existsSync(uploadPath)) {
       output.error(`Path does not exist: ${uploadPath}`);
       exit(1);
@@ -364,6 +352,19 @@ export async function previewCommand(
       output.error(`Path is not a directory: ${uploadPath}`);
       exit(1);
       return { success: false, reason: 'not-a-directory' };
+    }
+
+    // Load configuration
+    let allOptions = { ...globalOptions, ...options };
+    let config = await loadConfig(globalOptions.config, allOptions);
+
+    // Validate API token (skip for dry-run)
+    if (!options.dryRun && !config.apiKey) {
+      output.error(
+        'API token required. Use --token or set VIZZLY_TOKEN environment variable'
+      );
+      exit(1);
+      return { success: false, reason: 'no-api-key' };
     }
 
     // Resolve build ID

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -291,6 +291,7 @@ export async function runCommand(
       uploadAll: options.uploadAll || false,
       pullRequestNumber,
       parallelId: config.parallelId,
+      json: globalOptions.json,
     };
 
     // Start test run
@@ -386,10 +387,12 @@ export async function runCommand(
         return { success: true, result };
       }
 
-      output.complete('Test run completed');
+      if (!globalOptions.json) {
+        output.complete('Test run completed');
+      }
 
       // Show Vizzly summary with link to results
-      if (result.buildId) {
+      if (result.buildId && !globalOptions.json) {
         output.blank();
         let colors = output.getColors();
         output.print(
@@ -446,7 +449,7 @@ export async function runCommand(
           });
           output.cleanup();
         } else {
-          output.error('Test run failed');
+          output.error('Test run failed', error);
         }
         return { success: false, exitCode };
       } else {

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -41,6 +41,21 @@ function createStatusClient({ createApiClient, config }) {
   });
 }
 
+function isMissingPreviewError(error) {
+  return error.context?.status === 404;
+}
+
+async function fetchOptionalPreviewInfo(getPreviewInfo, client, buildId) {
+  try {
+    return await getPreviewInfo(client, buildId);
+  } catch (error) {
+    if (isMissingPreviewError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 export function normalizeBuildStatus(buildStatus) {
   return buildStatus.build || buildStatus;
 }
@@ -297,7 +312,11 @@ export async function statusCommand(
     let buildStatus = await getBuild(client, buildId);
 
     // Also fetch preview info (if exists)
-    let previewInfo = await getPreviewInfo(client, buildId);
+    let previewInfo = await fetchOptionalPreviewInfo(
+      getPreviewInfo,
+      client,
+      buildId
+    );
     output.stopSpinner();
 
     // Extract build data from API response

--- a/src/commands/tdd-daemon-process.js
+++ b/src/commands/tdd-daemon-process.js
@@ -19,7 +19,7 @@ function isProcessRunning(pid) {
   }
 }
 
-function parsePositiveInteger(value) {
+export function parsePositiveInteger(value) {
   let text = String(value).trim();
   if (!/^\d+$/.test(text)) {
     return null;
@@ -80,11 +80,16 @@ export async function resolveDaemonPid({
   pidFile = join(process.cwd(), '.vizzly', 'server.pid'),
   readPid = readDaemonPidFile,
   findByPort = findDaemonPidByPort,
+  allowPortFallback = false,
   fileDeps = {},
 } = {}) {
   let pid = readPid(pidFile, fileDeps);
   if (pid) {
     return pid;
+  }
+
+  if (!allowPortFallback) {
+    return null;
   }
 
   return await findByPort(port);

--- a/src/commands/tdd-daemon.js
+++ b/src/commands/tdd-daemon.js
@@ -7,12 +7,17 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { getServerRegistry } from '../tdd/server-registry.js';
 import { withTimeout } from '../utils/async-utils.js';
 import * as output from '../utils/output.js';
 import { tddCommand } from './tdd.js';
-import { resolveDaemonPid, waitForProcessExit } from './tdd-daemon-process.js';
+import {
+  parsePositiveInteger,
+  readDaemonPidFile,
+  resolveDaemonPid,
+  waitForProcessExit,
+} from './tdd-daemon-process.js';
 
 export {
   findDaemonPidByPort,
@@ -53,6 +58,34 @@ export function cleanupLocalDaemonFiles(directory = process.cwd(), deps = {}) {
   };
 }
 
+export function readLocalDaemonInfo(directory = process.cwd(), deps = {}) {
+  let { serverFile } = getLocalDaemonFiles(directory);
+  let fileExists = deps.existsSync || existsSync;
+  let readFile = deps.readFileSync || readFileSync;
+
+  if (!fileExists(serverFile)) {
+    return null;
+  }
+
+  try {
+    let info = JSON.parse(readFile(serverFile, 'utf8'));
+    let port = parsePositiveInteger(info.port);
+    let pid = parsePositiveInteger(info.pid);
+
+    if (!port) {
+      return null;
+    }
+
+    return {
+      ...info,
+      port,
+      pid,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function buildLegacyServerInfo({
   pid,
   port,
@@ -67,22 +100,34 @@ export function buildLegacyServerInfo({
   };
 }
 
+function getLegacyGlobalServerFile({
+  home = homedir,
+  vizzlyHome = process.env.VIZZLY_HOME,
+} = {}) {
+  if (vizzlyHome) {
+    return join(vizzlyHome, 'server.json');
+  }
+
+  return join(home(), '.vizzly', 'server.json');
+}
+
 export function writeLegacyGlobalServerFile(
   { pid, port, failOnDiff = false },
   {
     home = homedir,
+    vizzlyHome = process.env.VIZZLY_HOME,
     exists = existsSync,
     mkdir = mkdirSync,
     writeFile = writeFileSync,
     now = Date.now,
   } = {}
 ) {
-  let globalVizzlyDir = join(home(), '.vizzly');
+  let globalServerFile = getLegacyGlobalServerFile({ home, vizzlyHome });
+  let globalVizzlyDir = dirname(globalServerFile);
   if (!exists(globalVizzlyDir)) {
     mkdir(globalVizzlyDir, { recursive: true });
   }
 
-  let globalServerFile = join(globalVizzlyDir, 'server.json');
   let serverInfo = buildLegacyServerInfo({ pid, port, failOnDiff, now });
   writeFile(globalServerFile, JSON.stringify(serverInfo, null, 2));
   return { path: globalServerFile, serverInfo };
@@ -90,10 +135,11 @@ export function writeLegacyGlobalServerFile(
 
 export function cleanupLegacyGlobalServerFile({
   home = homedir,
+  vizzlyHome = process.env.VIZZLY_HOME,
   exists = existsSync,
   unlink = unlinkSync,
 } = {}) {
-  let globalServerFile = join(home(), '.vizzly', 'server.json');
+  let globalServerFile = getLegacyGlobalServerFile({ home, vizzlyHome });
   return removeFileIfExists(globalServerFile, {
     existsSync: exists,
     unlinkSync: unlink,
@@ -114,8 +160,14 @@ export function cleanupDaemonState({
   registry = getServerRegistry(),
   localFileDeps = {},
   legacyFileDeps = {},
+  cleanLocalFiles = true,
 } = {}) {
-  let localFiles = cleanupLocalDaemonFiles(directory, localFileDeps);
+  let localFiles = cleanLocalFiles
+    ? cleanupLocalDaemonFiles(directory, localFileDeps)
+    : {
+        pidFileRemoved: false,
+        serverFileRemoved: false,
+      };
   let legacyGlobalServerFileRemoved =
     cleanupLegacyGlobalServerFile(legacyFileDeps);
 
@@ -133,6 +185,44 @@ export function cleanupDaemonState({
     ...localFiles,
     legacyGlobalServerFileRemoved,
   };
+}
+
+function resolveDaemonTarget(options = {}, directory = process.cwd()) {
+  let registry = getServerRegistry();
+  let requestedPort = options.port ? Number(options.port) : null;
+  let localInfo = readLocalDaemonInfo(directory);
+  let localInfoMatches =
+    !requestedPort || localInfo?.port === requestedPort ? localInfo : null;
+  let registryServer = requestedPort
+    ? registry.find({ port: requestedPort })
+    : registry.find({ directory });
+  let serverInfo =
+    localInfoMatches ||
+    registryServer ||
+    (requestedPort ? { port: requestedPort } : null);
+  let port = requestedPort || serverInfo?.port || 47392;
+
+  return {
+    registry,
+    requestedPort,
+    localInfo: localInfoMatches,
+    registryServer,
+    serverInfo,
+    port,
+    directory: registryServer?.directory || directory,
+    useLocalPidFile: !requestedPort || Boolean(localInfoMatches),
+    cleanLocalFiles:
+      !requestedPort || Boolean(localInfoMatches || registryServer),
+  };
+}
+
+function cleanupDaemonTarget(target) {
+  return cleanupDaemonState({
+    port: target.port,
+    directory: target.directory,
+    registry: target.registry,
+    cleanLocalFiles: target.cleanLocalFiles,
+  });
 }
 
 export function buildDashboardUrl(port = 47392) {
@@ -234,33 +324,71 @@ export async function waitForDaemonChildInit(
   { timeoutMs = 30000, timers = defaultTimers } = {}
 ) {
   let cleanup = () => {};
+  let stderrOutput = '';
   let initPromise = new Promise(resolve => {
+    let handleStderr = data => {
+      stderrOutput += data.toString();
+    };
+
+    let handleMessage = message => {
+      if (message?.type !== 'error') {
+        return;
+      }
+
+      let error = new Error(message.message || 'Daemon child failed to start');
+      if (message.code) {
+        error.code = message.code;
+      }
+      if (message.stack) {
+        error.stack = message.stack;
+      }
+
+      cleanup();
+      resolve({
+        ok: false,
+        reason: 'error',
+        error,
+      });
+    };
+
     let handleDisconnect = () => {
       cleanup();
       resolve({ ok: true });
     };
 
-    let handleExit = () => {
+    let handleExit = (code, signal) => {
+      let error = new Error(
+        stderrOutput.trim() || 'Daemon child exited before startup'
+      );
+      error.code = code ?? signal ?? null;
       cleanup();
-      resolve({ ok: false, reason: 'exit' });
+      resolve({ ok: false, reason: 'exit', error });
     };
 
     cleanup = () => {
+      child.stderr?.off?.('data', handleStderr);
+      child.off('message', handleMessage);
       child.off('disconnect', handleDisconnect);
       child.off('exit', handleExit);
     };
 
+    child.stderr?.on?.('data', handleStderr);
+    child.on('message', handleMessage);
     child.on('disconnect', handleDisconnect);
     child.on('exit', handleExit);
   });
 
   try {
-    return await withTimeout(
+    let result = await withTimeout(
       initPromise,
       timeoutMs,
       'TDD server initialization timed out',
       timers
     );
+    if (result.ok) {
+      child.stderr?.unref?.();
+    }
+    return result;
   } catch (error) {
     cleanup();
     return { ok: false, reason: 'timeout', error };
@@ -349,7 +477,7 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
 
   if (options.port) {
     // User specified a port - use it (will fail if busy)
-    port = options.port;
+    port = Number(options.port);
 
     // Check if user-specified port is in use
     if (await isServerRunning(port)) {
@@ -388,13 +516,14 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
       );
     }
 
-    // Spawn child process with stdio inherited during init for direct error visibility
+    // Keep daemon stdio detached so callers that capture output do not hang
+    // waiting for the long-lived child to close inherited pipes.
     let child = spawn(
       process.execPath,
       buildDaemonChildArgs({ port, options, globalOptions }),
       {
         detached: true,
-        stdio: ['ignore', 'inherit', 'inherit', 'ipc'],
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
         cwd: process.cwd(),
       }
     );
@@ -405,7 +534,7 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
       if (options.baselineBuild && !globalOptions.verbose) {
         output.stopSpinner();
       }
-      output.error('TDD server failed to start');
+      output.error(initResult.error?.message || 'TDD server failed to start');
       process.exit(1);
     }
 
@@ -504,7 +633,9 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
 
     // Always show stop hint
     output.blank();
-    output.hint('Stop with: vizzly tdd stop');
+    let stopCommand =
+      port === 47392 ? 'vizzly tdd stop' : `vizzly tdd stop --port ${port}`;
+    output.hint(`Stop with: ${stopCommand}`);
 
     if (options.open) {
       openDashboard(port);
@@ -534,7 +665,7 @@ export async function runDaemonChild(options = {}, globalOptions = {}) {
 
   try {
     // Use existing tddCommand but with daemon mode
-    let { cleanup } = await tddCommand(
+    let { result, cleanup } = await tddCommand(
       null, // No test command - server only
       {
         ...options,
@@ -542,6 +673,10 @@ export async function runDaemonChild(options = {}, globalOptions = {}) {
       },
       globalOptions
     );
+
+    if (result?.success === false) {
+      throw new Error(result.error || 'TDD server failed to start');
+    }
 
     // Disconnect IPC after successful initialization to signal parent
     if (process.send) {
@@ -581,10 +716,31 @@ export async function runDaemonChild(options = {}, globalOptions = {}) {
     // Keep process alive
     process.stdin.resume();
   } catch (error) {
-    // Most errors shown via inherited stdio, but catch any that weren't
+    await sendDaemonChildError(error);
     console.error(`Fatal error: ${error.message}`);
     process.exit(1);
   }
+}
+
+async function sendDaemonChildError(error) {
+  if (!process.send) {
+    return;
+  }
+
+  let message = {
+    type: 'error',
+    message: error.message,
+    code: error.code || null,
+    stack: error.stack || null,
+  };
+
+  await new Promise(resolve => {
+    try {
+      process.send(message, () => resolve());
+    } catch {
+      resolve();
+    }
+  });
 }
 
 /**
@@ -599,8 +755,16 @@ export async function tddStopCommand(options = {}, globalOptions = {}) {
     color: !globalOptions.noColor,
   });
 
-  let port = options.port || 47392;
-  let pid = await resolveDaemonPid({ port });
+  let target = resolveDaemonTarget(options);
+  let pid = target.useLocalPidFile
+    ? await resolveDaemonPid({ port: target.port })
+    : null;
+
+  // Stop is intentionally file/registry-driven. Do not rediscover arbitrary
+  // processes by port here; a non-Vizzly server may be using that port.
+  if (!pid) {
+    pid = target.serverInfo?.pid || null;
+  }
 
   if (!pid) {
     // JSON output for not running
@@ -614,7 +778,7 @@ export async function tddStopCommand(options = {}, globalOptions = {}) {
     }
 
     // Clean up any stale files
-    cleanupDaemonState({ port });
+    cleanupDaemonTarget(target);
     return;
   }
 
@@ -637,14 +801,14 @@ export async function tddStopCommand(options = {}, globalOptions = {}) {
     }
 
     // Clean up files
-    cleanupDaemonState({ port });
+    cleanupDaemonTarget(target);
 
     // JSON output for successful stop
     if (globalOptions.json) {
       output.data({
         status: 'stopped',
         pid,
-        port,
+        port: target.port,
       });
       return;
     }
@@ -653,8 +817,16 @@ export async function tddStopCommand(options = {}, globalOptions = {}) {
   } catch (error) {
     if (error.code === 'ESRCH') {
       // Process not found - clean up stale files
+      cleanupDaemonTarget(target);
+      if (globalOptions.json) {
+        output.data({
+          status: 'stale',
+          stopped: false,
+          message: 'TDD server was not running; cleaned up stale files',
+        });
+        return;
+      }
       output.warn('TDD server was not running (cleaning up stale files)');
-      cleanupDaemonState({ port });
     } else {
       output.error('Error stopping TDD server', error);
     }
@@ -666,16 +838,62 @@ export async function tddStopCommand(options = {}, globalOptions = {}) {
  * @param {Object} options - Command options
  * @param {Object} globalOptions - Global CLI options
  */
-export async function tddStatusCommand(_options, globalOptions = {}) {
+function printRunningStatus({
+  serverInfo,
+  port,
+  pid,
+  uptimeMs = null,
+  uptimeStr = '',
+  dashboardUrl = buildDashboardUrl(port),
+  globalOptions = {},
+}) {
+  if (globalOptions.json) {
+    output.data({
+      running: true,
+      port,
+      pid,
+      uptimeMs,
+      uptime: uptimeStr || null,
+      dashboardUrl,
+    });
+    return;
+  }
+
+  let colors = output.getColors();
+
+  output.header('tdd', 'local');
+  output.print(
+    `  ${output.statusDot('success')} Running ${uptimeStr ? colors.brand.textTertiary(`· ${uptimeStr}`) : ''}`
+  );
+  output.blank();
+  output.printBox(colors.brand.info(colors.underline(dashboardUrl)), {
+    title: 'Dashboard',
+    style: 'branded',
+  });
+
+  if (globalOptions.verbose && pid) {
+    output.blank();
+    output.print(`  ${colors.brand.textTertiary('PID:')} ${pid}`);
+  }
+
+  if (globalOptions.verbose && serverInfo?.logFile) {
+    output.print(
+      `  ${colors.brand.textTertiary('Log:')} ${serverInfo.logFile}`
+    );
+  }
+}
+
+export async function tddStatusCommand(options = {}, globalOptions = {}) {
   output.configure({
     json: globalOptions.json,
     verbose: globalOptions.verbose,
     color: !globalOptions.noColor,
   });
 
-  let { pidFile, serverFile } = getLocalDaemonFiles();
+  let { pidFile } = getLocalDaemonFiles();
+  let target = resolveDaemonTarget(options);
 
-  if (!existsSync(pidFile)) {
+  if (!target.serverInfo && !existsSync(pidFile)) {
     // JSON output for not running
     if (globalOptions.json) {
       output.data({
@@ -689,30 +907,28 @@ export async function tddStatusCommand(_options, globalOptions = {}) {
   }
 
   try {
-    let pid = parsePositiveInteger(readFileSync(pidFile, 'utf8'));
+    let pid = target.useLocalPidFile ? readDaemonPidFile(pidFile) : null;
     if (!pid) {
-      output.warn('TDD server pid file is invalid (cleaning up stale files)');
-      cleanupDaemonState();
+      pid = target.serverInfo?.pid || null;
+    }
+    if (!pid) {
+      output.warn('TDD server not running (cleaning up stale files)');
+      cleanupDaemonTarget(target);
       return;
     }
 
     // Check if process is actually running
     process.kill(pid, 0); // Signal 0 just checks if process exists
 
-    let serverInfo = { port: 47392 };
-    if (existsSync(serverFile)) {
-      serverInfo = JSON.parse(readFileSync(serverFile, 'utf8'));
-    }
-
     // Try to check health endpoint
-    let health = await checkServerHealth(serverInfo.port);
+    let health = await checkServerHealth(target.port);
 
     if (health.running) {
       // Calculate uptime
       let uptimeMs = null;
       let uptimeStr = '';
-      if (serverInfo.startTime) {
-        uptimeMs = Date.now() - serverInfo.startTime;
+      if (target.serverInfo?.startTime) {
+        uptimeMs = Date.now() - target.serverInfo.startTime;
         let uptime = Math.floor(uptimeMs / 1000);
         let hours = Math.floor(uptime / 3600);
         let minutes = Math.floor((uptime % 3600) / 60);
@@ -722,43 +938,17 @@ export async function tddStatusCommand(_options, globalOptions = {}) {
         uptimeStr += `${seconds}s`;
       }
 
-      let dashboardUrl = buildDashboardUrl(serverInfo.port);
+      let dashboardUrl = buildDashboardUrl(target.port);
 
-      // JSON output for running status
-      if (globalOptions.json) {
-        output.data({
-          running: true,
-          port: serverInfo.port,
-          pid,
-          uptimeMs,
-          uptime: uptimeStr || null,
-          dashboardUrl,
-        });
-        return;
-      }
-
-      let colors = output.getColors();
-
-      // Show header
-      output.header('tdd', 'local');
-
-      // Show running status with uptime
-      output.print(
-        `  ${output.statusDot('success')} Running ${uptimeStr ? colors.brand.textTertiary(`· ${uptimeStr}`) : ''}`
-      );
-      output.blank();
-
-      // Show dashboard URL in a branded box
-      output.printBox(colors.brand.info(colors.underline(dashboardUrl)), {
-        title: 'Dashboard',
-        style: 'branded',
+      printRunningStatus({
+        serverInfo: target.serverInfo,
+        port: target.port,
+        pid,
+        uptimeMs,
+        uptimeStr,
+        dashboardUrl,
+        globalOptions,
       });
-
-      // Verbose mode: show PID
-      if (globalOptions.verbose) {
-        output.blank();
-        output.print(`  ${colors.brand.textTertiary('PID:')} ${pid}`);
-      }
     } else {
       output.warn(
         'TDD server process exists but not responding to health checks'
@@ -766,8 +956,16 @@ export async function tddStatusCommand(_options, globalOptions = {}) {
     }
   } catch (error) {
     if (error.code === 'ESRCH') {
+      cleanupDaemonTarget(target);
+      if (globalOptions.json) {
+        output.data({
+          status: 'stale',
+          running: false,
+          message: 'TDD server process not found; cleaned up stale files',
+        });
+        return;
+      }
       output.warn('TDD server process not found (cleaning up stale files)');
-      cleanupDaemonState();
     } else {
       output.error('Error checking TDD server status', error);
     }

--- a/src/commands/tdd-daemon.js
+++ b/src/commands/tdd-daemon.js
@@ -6,8 +6,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { homedir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { basename, join } from 'node:path';
 import { getServerRegistry } from '../tdd/server-registry.js';
 import { withTimeout } from '../utils/async-utils.js';
 import * as output from '../utils/output.js';
@@ -86,66 +85,6 @@ export function readLocalDaemonInfo(directory = process.cwd(), deps = {}) {
   }
 }
 
-export function buildLegacyServerInfo({
-  pid,
-  port,
-  failOnDiff = false,
-  now = Date.now,
-}) {
-  return {
-    pid,
-    port: port.toString(),
-    startTime: now(),
-    failOnDiff,
-  };
-}
-
-function getLegacyGlobalServerFile({
-  home = homedir,
-  vizzlyHome = process.env.VIZZLY_HOME,
-} = {}) {
-  if (vizzlyHome) {
-    return join(vizzlyHome, 'server.json');
-  }
-
-  return join(home(), '.vizzly', 'server.json');
-}
-
-export function writeLegacyGlobalServerFile(
-  { pid, port, failOnDiff = false },
-  {
-    home = homedir,
-    vizzlyHome = process.env.VIZZLY_HOME,
-    exists = existsSync,
-    mkdir = mkdirSync,
-    writeFile = writeFileSync,
-    now = Date.now,
-  } = {}
-) {
-  let globalServerFile = getLegacyGlobalServerFile({ home, vizzlyHome });
-  let globalVizzlyDir = dirname(globalServerFile);
-  if (!exists(globalVizzlyDir)) {
-    mkdir(globalVizzlyDir, { recursive: true });
-  }
-
-  let serverInfo = buildLegacyServerInfo({ pid, port, failOnDiff, now });
-  writeFile(globalServerFile, JSON.stringify(serverInfo, null, 2));
-  return { path: globalServerFile, serverInfo };
-}
-
-export function cleanupLegacyGlobalServerFile({
-  home = homedir,
-  vizzlyHome = process.env.VIZZLY_HOME,
-  exists = existsSync,
-  unlink = unlinkSync,
-} = {}) {
-  let globalServerFile = getLegacyGlobalServerFile({ home, vizzlyHome });
-  return removeFileIfExists(globalServerFile, {
-    existsSync: exists,
-    unlinkSync: unlink,
-  });
-}
-
 export function unregisterDaemonServer({
   port,
   directory = process.cwd(),
@@ -159,17 +98,14 @@ export function cleanupDaemonState({
   directory = process.cwd(),
   registry = getServerRegistry(),
   localFileDeps = {},
-  legacyFileDeps = {},
   cleanLocalFiles = true,
 } = {}) {
-  let localFiles = cleanLocalFiles
+  let cleanupResult = cleanLocalFiles
     ? cleanupLocalDaemonFiles(directory, localFileDeps)
     : {
         pidFileRemoved: false,
         serverFileRemoved: false,
       };
-  let legacyGlobalServerFileRemoved =
-    cleanupLegacyGlobalServerFile(legacyFileDeps);
 
   try {
     if (port !== undefined) {
@@ -181,10 +117,7 @@ export function cleanupDaemonState({
     // Non-fatal; stale file cleanup is still useful on its own.
   }
 
-  return {
-    ...localFiles,
-    legacyGlobalServerFileRemoved,
-  };
+  return cleanupResult;
 }
 
 function resolveDaemonTarget(options = {}, directory = process.cwd()) {
@@ -574,17 +507,6 @@ export async function tddStartCommand(options = {}, globalOptions = {}) {
       });
     } catch {
       // Non-fatal
-    }
-
-    // Also write legacy server.json for SDK discovery (backwards compatibility)
-    try {
-      writeLegacyGlobalServerFile({
-        pid: child.pid,
-        port,
-        failOnDiff: options.failOnDiff || false,
-      });
-    } catch {
-      // Non-fatal, SDK can still use health check
     }
 
     // JSON output for successful start

--- a/src/commands/tdd.js
+++ b/src/commands/tdd.js
@@ -195,6 +195,7 @@ export async function tddCommand(
       baselineBuildId: config.baselineBuildId,
       baselineComparisonId: config.baselineComparisonId,
       wait: false,
+      json: globalOptions.json,
     };
 
     // In daemon mode, just start the server without running tests

--- a/src/tdd/tdd-service.js
+++ b/src/tdd/tdd-service.js
@@ -1492,6 +1492,10 @@ export class TddService {
     );
     let hasChanges = failedComparisons.length > 0 || newComparisons.length > 0;
 
+    if (output.isJson?.()) {
+      return results;
+    }
+
     // Header with summary - use bear emoji as Vizzly mascot
     output.blank();
     output.print(
@@ -1579,10 +1583,11 @@ export class TddService {
       let serverFile = `${this.workingDir}/.vizzly/server.json`;
       let serverRunning = false;
       let serverPort = 47392;
+      let serverInfo = {};
 
       try {
         if (existsSync(serverFile)) {
-          let serverInfo = JSON.parse(readFileSync(serverFile, 'utf8'));
+          serverInfo = JSON.parse(readFileSync(serverFile, 'utf8'));
           if (serverInfo.port) {
             serverPort = serverInfo.port;
             serverRunning = true;
@@ -1592,7 +1597,7 @@ export class TddService {
         // Ignore errors reading server file
       }
 
-      if (serverRunning) {
+      if (serverRunning && !serverInfo.buildId) {
         // Server is running - show the dashboard URL
         output.print(
           `  ${textTertiary('→')} Review changes: ${infoColor(colors.underline(`http://localhost:${serverPort}`))}`

--- a/src/test-runner/core.js
+++ b/src/test-runner/core.js
@@ -223,12 +223,14 @@ export function hasApiKey(config) {
 /**
  * Build spawn options for test command execution
  * @param {Object} env - Environment variables
+ * @param {Object} [options] - Spawn display options
+ * @param {boolean} [options.json] - Keep stdout reserved for CLI JSON output
  * @returns {Object} Spawn options
  */
-export function buildSpawnOptions(env) {
+export function buildSpawnOptions(env, options = {}) {
   return {
     env,
-    stdio: 'inherit',
+    stdio: options.json ? ['inherit', 'pipe', 'pipe'] : 'inherit',
     shell: true,
   };
 }

--- a/src/test-runner/operations.js
+++ b/src/test-runner/operations.js
@@ -178,12 +178,21 @@ export async function finalizeBuild({
  * @param {Function} options.deps.createError - Error factory
  * @returns {Promise<{ process: Object }>} Spawned process reference
  */
-export function executeTestCommand({ command, env, deps }) {
+export function executeTestCommand({ command, env, json = false, deps }) {
   let { spawn, createError } = deps;
 
   return new Promise((resolve, reject) => {
-    let spawnOptions = buildSpawnOptions(env);
+    let spawnOptions = buildSpawnOptions(env, { json });
     let testProcess = spawn(command, spawnOptions);
+
+    if (json) {
+      testProcess.stdout?.on('data', data => {
+        process.stderr.write(data);
+      });
+      testProcess.stderr?.on('data', data => {
+        process.stderr.write(data);
+      });
+    }
 
     testProcess.on('error', error => {
       reject(
@@ -264,6 +273,7 @@ export async function runTests({ runOptions, config, deps }) {
     await executeTestCommand({
       command: testCommand,
       env,
+      json: runOptions.json,
       deps: { spawn, createError },
     });
     return buildDisabledRunResult();
@@ -320,6 +330,7 @@ export async function runTests({ runOptions, config, deps }) {
       await executeTestCommand({
         command: testCommand,
         env,
+        json: runOptions.json,
         deps: { spawn, createError },
       });
       testSuccess = true;
@@ -384,7 +395,9 @@ export async function runTests({ runOptions, config, deps }) {
 
   // Throw test error after cleanup
   if (testError) {
-    output.error('Test run failed:', testError);
+    if (!runOptions.json) {
+      output.error('Test run failed:', testError);
+    }
     throw testError;
   }
 

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -92,6 +92,8 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
     output.debug('config', 'using user login for user-authenticated commands');
   }
 
+  config._configPath = result?.filepath || null;
+
   return config;
 }
 

--- a/src/utils/output.js
+++ b/src/utils/output.js
@@ -239,6 +239,10 @@ export function isVerbose() {
   return config.logLevel === 'debug';
 }
 
+export function isJson() {
+  return config.json;
+}
+
 /**
  * Show command header with distinctive branding
  * Uses BearDen's signature amber color for "vizzly"

--- a/tests/cli/command-routing.test.js
+++ b/tests/cli/command-routing.test.js
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+function parseJsonLines(output) {
+  return output
+    .split('\n')
+    .filter(line => line.trim())
+    .map(line => JSON.parse(line));
+}
+
+describe('cli command routing', () => {
+  it('rejects unknown command help instead of showing root help as success', async () => {
+    let result = await runCLI([
+      '--no-color',
+      'definitely-not-a-command',
+      '--help',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /unknown command 'definitely-not-a-command'/);
+    assert.doesNotMatch(result.stdout, /Quick Start/);
+  });
+
+  it('rejects unknown root commands in JSON mode without dumping help', async () => {
+    let result = await runCLI([
+      '--no-color',
+      '--json',
+      'definitely-not-a-command',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(result.stdout, '');
+    assert.doesNotMatch(result.stderr, /Quick Start/);
+
+    let messages = parseJsonLines(result.stderr);
+    assert.deepStrictEqual(messages, [
+      {
+        status: 'error',
+        message: "unknown command 'definitely-not-a-command'",
+      },
+    ]);
+  });
+
+  it('rejects unknown root commands in JSON mode even when help is requested', async () => {
+    let result = await runCLI([
+      '--no-color',
+      '--json',
+      'definitely-not-a-command',
+      '--help',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(result.stdout, '');
+    assert.doesNotMatch(result.stderr, /Quick Start/);
+
+    let messages = parseJsonLines(result.stderr);
+    assert.deepStrictEqual(messages, [
+      {
+        status: 'error',
+        message: "unknown command 'definitely-not-a-command'",
+      },
+    ]);
+  });
+
+  it('gives nested unknown subcommands a recovery hint', async () => {
+    let result = await runCLI([
+      '--no-color',
+      'tdd',
+      'definitely-not-a-command',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /unknown command 'definitely-not-a-command'/);
+    assert.match(result.stderr, /Run vizzly tdd --help/);
+  });
+
+  it('rejects nested unknown subcommands in JSON mode even when help is requested', async () => {
+    let result = await runCLI([
+      '--no-color',
+      '--json',
+      'tdd',
+      'definitely-not-a-command',
+      '--help',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(result.stdout, '');
+    assert.doesNotMatch(result.stderr, /vizzly tdd \[options\]/);
+
+    let messages = parseJsonLines(result.stderr);
+    assert.deepStrictEqual(messages, [
+      {
+        status: 'error',
+        message: "unknown command 'definitely-not-a-command'",
+      },
+    ]);
+  });
+
+  it('points unknown context subcommands to context help', async () => {
+    let result = await runCLI([
+      '--no-color',
+      'context',
+      'definitely-not-a-command',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /unknown command 'definitely-not-a-command'/);
+    assert.match(result.stderr, /Run vizzly context --help/);
+  });
+
+  it('points unknown project subcommands to project help', async () => {
+    let result = await runCLI([
+      '--no-color',
+      'project',
+      'definitely-not-a-command',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /unknown command 'definitely-not-a-command'/);
+    assert.match(result.stderr, /Run vizzly project --help/);
+  });
+});

--- a/tests/cli/json-output.test.js
+++ b/tests/cli/json-output.test.js
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { parseJSONOutput, runCLI } from '../helpers/cli-runner.js';
+import { runCLI } from '../helpers/cli-runner.js';
+
+function parseJsonLines(output) {
+  return output
+    .split('\n')
+    .filter(line => line.trim())
+    .map(line => JSON.parse(line));
+}
 
 describe('cli json output', () => {
   it('wraps command payloads in the standard data envelope', async () => {
@@ -9,7 +16,7 @@ describe('cli json output', () => {
     assert.equal(result.code, 0);
     assert.equal(result.stderr, '');
 
-    let messages = parseJSONOutput(result.stdout);
+    let messages = parseJsonLines(result.stdout);
     assert.deepEqual(messages, [
       {
         status: 'data',
@@ -27,7 +34,7 @@ describe('cli json output', () => {
     assert.equal(result.code, 0);
     assert.equal(result.stderr, '');
 
-    let messages = parseJSONOutput(result.stdout);
+    let messages = parseJsonLines(result.stdout);
     assert.deepEqual(messages, [
       {
         status: 'data',
@@ -44,13 +51,44 @@ describe('cli json output', () => {
     assert.equal(result.code, 0);
     assert.equal(result.stderr, '');
 
-    let messages = parseJSONOutput(result.stdout);
+    let messages = parseJsonLines(result.stdout);
     assert.deepEqual(messages, [
       {
         status: 'data',
         data: {
           servers: [],
         },
+      },
+    ]);
+  });
+
+  it('emits JSON errors for missing required arguments', async () => {
+    let result = await runCLI(['--json', 'status']);
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, '');
+
+    let messages = parseJsonLines(result.stderr);
+    assert.deepEqual(messages, [
+      {
+        status: 'error',
+        message: "missing required argument 'build-id'",
+      },
+    ]);
+  });
+
+  it('keeps validation errors machine-readable in JSON mode', async () => {
+    let result = await runCLI(['--json', 'tdd', 'start', '--port', '99999']);
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, '');
+
+    let messages = parseJsonLines(result.stderr);
+    assert.deepEqual(messages, [
+      {
+        status: 'error',
+        message: 'Validation errors',
+        errors: ['Port must be a valid number between 1 and 65535'],
       },
     ]);
   });

--- a/tests/cli/root-help.test.js
+++ b/tests/cli/root-help.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+describe('cli root help', () => {
+  it('does not categorize the built-in project command as a plugin', async () => {
+    let result = await runCLI(['--no-color', '--help']);
+
+    assert.strictEqual(result.code, 0);
+    assert.match(
+      result.stdout,
+      /Setup[\s\S]*project\s+Manage the project linked to this local checkout/
+    );
+    assert.doesNotMatch(
+      result.stdout,
+      /Plugins[\s\S]*project\s+Manage the project linked to this local checkout/
+    );
+  });
+});

--- a/tests/cli/tdd-help.test.js
+++ b/tests/cli/tdd-help.test.js
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+describe('cli/tdd help', () => {
+  it('shows the full nested command path for TDD subcommands', async () => {
+    let result = await runCLI(['--no-color', 'tdd', 'start', '--help']);
+
+    assert.strictEqual(result.code, 0);
+    assert.match(result.stdout, /vizzly tdd start/);
+    assert.doesNotMatch(result.stdout, /vizzly start\n/);
+  });
+
+  it('hides internal daemon child flag from user-facing help', async () => {
+    let result = await runCLI(['--no-color', 'tdd', 'start', '--help']);
+
+    assert.strictEqual(result.code, 0);
+    assert.doesNotMatch(result.stdout, /daemon-child/);
+  });
+
+  it('documents port flags for lifecycle commands', async () => {
+    let stop = await runCLI(['--no-color', 'tdd', 'stop', '--help']);
+    let status = await runCLI(['--no-color', 'tdd', 'status', '--help']);
+
+    assert.strictEqual(stop.code, 0);
+    assert.strictEqual(status.code, 0);
+    assert.match(stop.stdout, /--port <port>/);
+    assert.match(status.stdout, /--port <port>/);
+  });
+
+  it('honors --no-color for TDD help output', async () => {
+    let result = await runCLI(['--no-color', 'tdd', 'list']);
+    let ansiMarker = `${String.fromCharCode(27)}[`;
+
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout.includes(ansiMarker), false);
+    assert.strictEqual(result.stderr.includes(ansiMarker), false);
+  });
+});

--- a/tests/cli/tdd-lifecycle.test.js
+++ b/tests/cli/tdd-lifecycle.test.js
@@ -1,0 +1,427 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+async function withServer(callback) {
+  let server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('not-vizzly');
+  });
+
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    let address = server.address();
+    return await callback({ server, port: address.port });
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+async function withHealthServer(callback) {
+  let server = createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ port: server.address().port, uptime: 1000 }));
+      return;
+    }
+
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('not-vizzly');
+  });
+
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    let address = server.address();
+    return await callback({ server, port: address.port });
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+async function getFreePort() {
+  return await withServer(({ port }) => port);
+}
+
+async function getTwoFreePorts() {
+  let first = await getFreePort();
+  let second = await getFreePort();
+
+  while (second === first) {
+    second = await getFreePort();
+  }
+
+  return [first, second];
+}
+
+function createWorkspace() {
+  return mkdtempSync(join(tmpdir(), 'vizzly-cli-tdd-'));
+}
+
+function parseSingleJson(stdout) {
+  let parsed = JSON.parse(stdout);
+  assert.strictEqual(typeof parsed, 'object');
+  return parsed;
+}
+
+function screenshotCommand(name) {
+  let imagePath = join(
+    process.cwd(),
+    'tests/reporter/fixtures/images/screenshots/homepage-desktop.png'
+  );
+  let code = [
+    "let fs = await import('node:fs');",
+    `let image = fs.readFileSync(${JSON.stringify(imagePath)}, 'base64');`,
+    `let payload = { name: ${JSON.stringify(name)}, image, type: 'base64', properties: { viewport_width: 1280, viewport_height: 720, browser: 'chromium' } };`,
+    "let response = await fetch(process.env.VIZZLY_SERVER_URL + '/screenshot', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });",
+    'console.log(response.status, await response.text());',
+  ].join(' ');
+
+  return `node --input-type=module -e ${JSON.stringify(code)}`;
+}
+
+describe('cli/tdd lifecycle', () => {
+  it('keeps JSON TDD run output parseable on stdout', async () => {
+    let cwd = createWorkspace();
+    let port = await getFreePort();
+    let result = await runCLI(
+      [
+        '--no-color',
+        '--json',
+        'tdd',
+        'run',
+        'node -p process.env.VIZZLY_SERVER_URL',
+        '--port',
+        String(port),
+        '--no-open',
+      ],
+      { cwd }
+    );
+
+    assert.strictEqual(
+      result.code,
+      0,
+      `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+    assert.match(result.stderr, new RegExp(`http://localhost:${port}`));
+
+    let payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.status, 'data');
+    assert.strictEqual(payload.data.status, 'completed');
+    assert.strictEqual(payload.data.summary.total, 0);
+  });
+
+  it('keeps JSON TDD run failures parseable while forwarding child output to stderr', async () => {
+    let cwd = createWorkspace();
+    let port = await getFreePort();
+    let command = [
+      "console.log('child stdout noise');",
+      "console.error('child stderr noise');",
+      'process.exit(7);',
+    ].join(' ');
+    let result = await runCLI(
+      [
+        '--no-color',
+        '--json',
+        'tdd',
+        'run',
+        `node -e ${JSON.stringify(command)}`,
+        '--port',
+        String(port),
+        '--no-open',
+      ],
+      { cwd }
+    );
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /child stdout noise/);
+    assert.match(result.stderr, /child stderr noise/);
+
+    let payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.status, 'data');
+    assert.strictEqual(payload.data.status, 'failed');
+    assert.strictEqual(payload.data.exitCode, 1);
+  });
+
+  it('runs the screenshot workflow and leaves users with reviewable results', async () => {
+    let cwd = createWorkspace();
+    let port = await getFreePort();
+    let result = await runCLI(
+      [
+        '--no-color',
+        'tdd',
+        'run',
+        screenshotCommand('cli-lifecycle-homepage'),
+        '--port',
+        String(port),
+        '--no-open',
+      ],
+      { cwd }
+    );
+
+    assert.strictEqual(
+      result.code,
+      0,
+      `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+    assert.match(result.stdout, /"status":"new"/);
+    assert.match(result.stdout, /1 screenshot compared/);
+    assert.match(result.stdout, /Review changes: vizzly tdd start --open/);
+    assert.doesNotMatch(result.stdout, /Review changes: http:\/\/localhost/);
+
+    let reportDataPath = join(cwd, '.vizzly', 'report-data.json');
+    assert.ok(existsSync(reportDataPath));
+
+    let reportData = JSON.parse(readFileSync(reportDataPath, 'utf8'));
+    assert.strictEqual(reportData.summary.total, 1);
+    assert.strictEqual(
+      reportData.comparisons[0].name,
+      'cli-lifecycle-homepage'
+    );
+    assert.strictEqual(reportData.comparisons[0].status, 'new');
+  });
+
+  it('starts, reports, lists, and stops a daemon on an explicit port', async () => {
+    let cwd = createWorkspace();
+    let port = await getFreePort();
+
+    try {
+      let start = await runCLI(
+        ['--no-color', 'tdd', 'start', '--port', String(port)],
+        { cwd, timeout: 30000 }
+      );
+      assert.strictEqual(start.code, 0);
+      let startOutput = `${start.stdout}\n${start.stderr}`;
+      assert.match(startOutput, new RegExp(`http://localhost:${port}`));
+      assert.match(
+        startOutput,
+        new RegExp(`Stop with: vizzly tdd stop --port ${port}`)
+      );
+
+      let status = await runCLI(['--no-color', 'tdd', 'status'], {
+        cwd,
+        timeout: 30000,
+      });
+      assert.strictEqual(status.code, 0);
+      let statusOutput = `${status.stdout}\n${status.stderr}`;
+      assert.match(statusOutput, /Running/);
+      assert.match(statusOutput, new RegExp(`http://localhost:${port}`));
+
+      let list = await runCLI(['--no-color', 'tdd', 'list'], {
+        cwd,
+        timeout: 30000,
+      });
+      assert.strictEqual(list.code, 0);
+      assert.match(list.stdout, new RegExp(`:${port}`));
+    } finally {
+      let stop = await runCLI(
+        ['--no-color', 'tdd', 'stop', '--port', String(port)],
+        { cwd, timeout: 30000 }
+      );
+      assert.strictEqual(stop.code, 0);
+    }
+  });
+
+  it('returns a numeric port from tdd start --json', async () => {
+    let cwd = createWorkspace();
+    let port = await getFreePort();
+
+    try {
+      let start = await runCLI(
+        ['--no-color', '--json', 'tdd', 'start', '--port', String(port)],
+        { cwd, timeout: 30000 }
+      );
+
+      assert.strictEqual(start.code, 0);
+      assert.strictEqual(start.stderr, '');
+
+      let payload = parseSingleJson(start.stdout);
+      assert.strictEqual(payload.status, 'data');
+      assert.strictEqual(payload.data.status, 'started');
+      assert.strictEqual(payload.data.port, port);
+    } finally {
+      let stop = await runCLI(
+        ['--no-color', 'tdd', 'stop', '--port', String(port)],
+        { cwd, timeout: 30000 }
+      );
+      assert.strictEqual(stop.code, 0);
+    }
+  });
+
+  it('does not stop an unrelated process that happens to use the requested port', async () => {
+    await withServer(async ({ port }) => {
+      let cwd = createWorkspace();
+      let result = await runCLI(
+        ['--no-color', 'tdd', 'stop', '--port', String(port)],
+        { cwd }
+      );
+
+      assert.strictEqual(result.code, 0);
+      assert.match(result.stderr, /No TDD server running/);
+
+      let response = await fetch(`http://127.0.0.1:${port}`);
+      assert.strictEqual(await response.text(), 'not-vizzly');
+    });
+  });
+
+  it('does not report an unrelated healthy service as a TDD daemon', async () => {
+    await withHealthServer(async ({ port }) => {
+      let cwd = createWorkspace();
+      let vizzlyDir = join(cwd, '.vizzly');
+      mkdirSync(vizzlyDir, { recursive: true });
+      writeFileSync(join(vizzlyDir, 'server.json'), JSON.stringify({ port }));
+
+      let result = await runCLI(
+        ['--no-color', 'tdd', 'status', '--port', String(port)],
+        { cwd }
+      );
+
+      assert.strictEqual(result.code, 0);
+      assert.doesNotMatch(result.stdout, /Running/);
+      assert.match(result.stderr, /TDD server not running/);
+
+      let response = await fetch(`http://127.0.0.1:${port}/health`);
+      assert.strictEqual(response.status, 200);
+    });
+  });
+
+  it('does not stop the workspace daemon when a different port is requested', async () => {
+    let cwd = createWorkspace();
+    let [daemonPort, otherPort] = await getTwoFreePorts();
+
+    try {
+      let start = await runCLI(
+        ['--no-color', 'tdd', 'start', '--port', String(daemonPort)],
+        { cwd, timeout: 30000 }
+      );
+      assert.strictEqual(start.code, 0);
+
+      let wrongStop = await runCLI(
+        ['--no-color', 'tdd', 'stop', '--port', String(otherPort)],
+        { cwd, timeout: 30000 }
+      );
+      assert.strictEqual(wrongStop.code, 0);
+      assert.match(wrongStop.stderr, /No TDD server running/);
+      assert.strictEqual(existsSync(join(cwd, '.vizzly/server.pid')), true);
+      assert.strictEqual(existsSync(join(cwd, '.vizzly/server.json')), true);
+
+      let registry = JSON.parse(
+        readFileSync(join(cwd, '.vizzly-home/servers.json'), 'utf8')
+      );
+      let workspacePath = realpathSync(cwd);
+      assert.strictEqual(
+        registry.servers.some(
+          server =>
+            server.port === daemonPort && server.directory === workspacePath
+        ),
+        true
+      );
+
+      let status = await runCLI(['--no-color', 'tdd', 'status'], {
+        cwd,
+        timeout: 30000,
+      });
+      assert.strictEqual(status.code, 0);
+      let statusOutput = `${status.stdout}\n${status.stderr}`;
+      assert.match(statusOutput, new RegExp(`http://localhost:${daemonPort}`));
+    } finally {
+      let stop = await runCLI(
+        ['--no-color', 'tdd', 'stop', '--port', String(daemonPort)],
+        { cwd, timeout: 30000 }
+      );
+      assert.strictEqual(stop.code, 0);
+    }
+  });
+
+  it('does not clean legacy daemon files from HOME when VIZZLY_HOME is isolated', async () => {
+    let cwd = createWorkspace();
+    let home = mkdtempSync(join(tmpdir(), 'vizzly-cli-home-'));
+    let vizzlyHome = join(cwd, '.isolated-vizzly-home');
+    let legacyDir = join(home, '.vizzly');
+    let legacyFile = join(legacyDir, 'server.json');
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(legacyFile, JSON.stringify({ pid: 1234, port: 47392 }));
+
+    let result = await runCLI(
+      ['--no-color', 'tdd', 'stop', '--port', '47393'],
+      {
+        cwd,
+        env: {
+          HOME: home,
+          VIZZLY_HOME: vizzlyHome,
+        },
+      }
+    );
+
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(existsSync(legacyFile), true);
+    assert.deepStrictEqual(JSON.parse(readFileSync(legacyFile, 'utf8')), {
+      pid: 1234,
+      port: 47392,
+    });
+  });
+
+  it('keeps stale-file status and stop responses machine-readable in JSON mode', async () => {
+    let cwd = createWorkspace();
+    let vizzlyDir = join(cwd, '.vizzly');
+    mkdirSync(vizzlyDir, { recursive: true });
+    writeFileSync(join(vizzlyDir, 'server.pid'), '999999');
+    writeFileSync(
+      join(vizzlyDir, 'server.json'),
+      JSON.stringify({ pid: 999999, port: 47392 })
+    );
+
+    let status = await runCLI(['--no-color', '--json', 'tdd', 'status'], {
+      cwd,
+    });
+
+    assert.strictEqual(status.code, 0);
+    assert.strictEqual(status.stderr, '');
+    assert.deepStrictEqual(parseSingleJson(status.stdout), {
+      status: 'data',
+      data: {
+        status: 'stale',
+        running: false,
+        message: 'TDD server process not found; cleaned up stale files',
+      },
+    });
+
+    mkdirSync(vizzlyDir, { recursive: true });
+    writeFileSync(join(vizzlyDir, 'server.pid'), '999999');
+    writeFileSync(
+      join(vizzlyDir, 'server.json'),
+      JSON.stringify({ pid: 999999, port: 47392 })
+    );
+
+    let stop = await runCLI(['--no-color', '--json', 'tdd', 'stop'], {
+      cwd,
+    });
+
+    assert.strictEqual(stop.code, 0);
+    assert.strictEqual(stop.stderr, '');
+    assert.deepStrictEqual(parseSingleJson(stop.stdout), {
+      status: 'data',
+      data: {
+        status: 'stale',
+        stopped: false,
+        message: 'TDD server was not running; cleaned up stale files',
+      },
+    });
+  });
+});

--- a/tests/cli/tdd-lifecycle.test.js
+++ b/tests/cli/tdd-lifecycle.test.js
@@ -349,14 +349,14 @@ describe('cli/tdd lifecycle', () => {
     }
   });
 
-  it('does not clean legacy daemon files from HOME when VIZZLY_HOME is isolated', async () => {
+  it('does not touch unrelated HOME server files when VIZZLY_HOME is isolated', async () => {
     let cwd = createWorkspace();
     let home = mkdtempSync(join(tmpdir(), 'vizzly-cli-home-'));
     let vizzlyHome = join(cwd, '.isolated-vizzly-home');
-    let legacyDir = join(home, '.vizzly');
-    let legacyFile = join(legacyDir, 'server.json');
-    mkdirSync(legacyDir, { recursive: true });
-    writeFileSync(legacyFile, JSON.stringify({ pid: 1234, port: 47392 }));
+    let unrelatedDir = join(home, '.vizzly');
+    let unrelatedFile = join(unrelatedDir, 'server.json');
+    mkdirSync(unrelatedDir, { recursive: true });
+    writeFileSync(unrelatedFile, JSON.stringify({ pid: 1234, port: 47392 }));
 
     let result = await runCLI(
       ['--no-color', 'tdd', 'stop', '--port', '47393'],
@@ -370,8 +370,8 @@ describe('cli/tdd lifecycle', () => {
     );
 
     assert.strictEqual(result.code, 0);
-    assert.strictEqual(existsSync(legacyFile), true);
-    assert.deepStrictEqual(JSON.parse(readFileSync(legacyFile, 'utf8')), {
+    assert.strictEqual(existsSync(unrelatedFile), true);
+    assert.deepStrictEqual(JSON.parse(readFileSync(unrelatedFile, 'utf8')), {
       pid: 1234,
       port: 47392,
     });

--- a/tests/commands/config-cli.test.js
+++ b/tests/commands/config-cli.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+function createWorkspace() {
+  return mkdtempSync(join(tmpdir(), 'vizzly-cli-config-'));
+}
+
+function parseSingleJson(stdout) {
+  let parsed = JSON.parse(stdout);
+  assert.strictEqual(typeof parsed, 'object');
+  return parsed;
+}
+
+describe('commands/config CLI', () => {
+  it('reports the loaded config file when a config file is applied', async () => {
+    let cwd = createWorkspace();
+    let configPath = join(cwd, '.vizzlyrc.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          server: { port: 9999 },
+          comparison: { threshold: 7 },
+        },
+        null,
+        2
+      )
+    );
+
+    let result = await runCLI(['--no-color', '--json', 'config'], { cwd });
+
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stderr, '');
+
+    let payload = parseSingleJson(result.stdout);
+    assert.strictEqual(payload.data.configFile, realpathSync(configPath));
+    assert.strictEqual(payload.data.config.server.port, 9999);
+    assert.strictEqual(payload.data.config.comparison.threshold, 7);
+  });
+});

--- a/tests/commands/preview-cli.test.js
+++ b/tests/commands/preview-cli.test.js
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseJSONOutput, runCLI } from '../helpers/cli-runner.js';
+
+describe('commands/preview CLI', () => {
+  it('keeps --json missing-path output machine-readable', async () => {
+    let result = await runCLI(['--no-color', '--json', 'preview']);
+
+    assert.strictEqual(result.code, 1);
+    assert.strictEqual(result.stdout, '');
+
+    let messages = parseJSONOutput(result.stderr);
+    assert.deepStrictEqual(messages, [
+      {
+        status: 'error',
+        message: 'Path to static files is required',
+      },
+    ]);
+    assert.doesNotMatch(result.stderr, /vizzly preview \.\/dist/);
+  });
+
+  it('reports a missing preview directory before auth errors', async () => {
+    let result = await runCLI([
+      '--no-color',
+      'preview',
+      './missing-preview-dir',
+      '--build',
+      'build-123',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /does not exist/);
+    assert.doesNotMatch(result.stderr, /API token required/);
+  });
+});

--- a/tests/commands/review-cli.test.js
+++ b/tests/commands/review-cli.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+describe('commands/review CLI help', () => {
+  it('does not overstate review identifier formats', async () => {
+    let approve = await runCLI(['--no-color', 'approve', '--help']);
+    let reject = await runCLI(['--no-color', 'reject', '--help']);
+    let comment = await runCLI(['--no-color', 'comment', '--help']);
+
+    assert.strictEqual(approve.code, 0);
+    assert.strictEqual(reject.code, 0);
+    assert.strictEqual(comment.code, 0);
+
+    assert.doesNotMatch(approve.stdout, /UUID format/);
+    assert.doesNotMatch(reject.stdout, /UUID format/);
+    assert.doesNotMatch(comment.stdout, /UUID format/);
+  });
+});

--- a/tests/commands/run-cli.test.js
+++ b/tests/commands/run-cli.test.js
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+function createWorkspace() {
+  return mkdtempSync(join(tmpdir(), 'vizzly-cli-run-'));
+}
+
+function parseSingleJson(stdout) {
+  let parsed = JSON.parse(stdout);
+  assert.strictEqual(typeof parsed, 'object');
+  return parsed;
+}
+
+async function withApiServer(callback) {
+  let buildId = 'build-123';
+  let buildUrl = 'http://app.test/org/project/builds/build-123';
+  let requests = [];
+  let server = createServer((req, res) => {
+    requests.push({ method: req.method, url: req.url });
+    res.setHeader('content-type', 'application/json');
+
+    if (req.method === 'POST' && req.url === '/api/sdk/builds') {
+      res.end(JSON.stringify({ id: buildId, url: buildUrl }));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === `/api/sdk/builds/${buildId}`) {
+      res.end(
+        JSON.stringify({
+          build: {
+            id: buildId,
+            status: 'completed',
+            url: buildUrl,
+            total_comparisons: 0,
+            new_comparisons: 0,
+            failed_comparisons: 0,
+            identical_comparisons: 0,
+            approval_status: 'pending',
+          },
+        })
+      );
+      return;
+    }
+
+    if (
+      req.method === 'PUT' &&
+      req.url === `/api/sdk/builds/${buildId}/status`
+    ) {
+      res.end(JSON.stringify({ id: buildId, status: 'completed' }));
+      return;
+    }
+
+    if (req.method === 'GET' && req.url === '/api/sdk/token/context') {
+      res.end(
+        JSON.stringify({
+          organization: { slug: 'org' },
+          project: { slug: 'project' },
+        })
+      );
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    let address = server.address();
+    return await callback({
+      apiUrl: `http://127.0.0.1:${address.port}`,
+      requests,
+    });
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+describe('commands/run CLI', () => {
+  it('keeps --json stdout parseable when the child command prints output', async () => {
+    let cwd = createWorkspace();
+    let command = [
+      "console.log('child stdout noise');",
+      "console.error('child stderr noise');",
+    ].join(' ');
+
+    let result = await runCLI(
+      [
+        '--no-color',
+        '--json',
+        'run',
+        `node -e ${JSON.stringify(command)}`,
+        '--allow-no-token',
+      ],
+      { cwd }
+    );
+
+    assert.strictEqual(result.code, 0);
+    assert.match(result.stderr, /child stdout noise/);
+    assert.match(result.stderr, /child stderr noise/);
+
+    let payload = parseSingleJson(result.stdout);
+    assert.strictEqual(payload.status, 'data');
+    assert.strictEqual(payload.data.status, 'completed');
+  });
+
+  it('keeps --json --wait stdout parseable after a real API build completes', async () => {
+    await withApiServer(async ({ apiUrl, requests }) => {
+      let cwd = createWorkspace();
+      let command = [
+        "console.log('child stdout noise');",
+        "console.error('child stderr noise');",
+      ].join(' ');
+
+      let result = await runCLI(
+        [
+          '--no-color',
+          '--json',
+          'run',
+          `node -e ${JSON.stringify(command)}`,
+          '--wait',
+        ],
+        {
+          cwd,
+          env: {
+            VIZZLY_API_URL: apiUrl,
+            VIZZLY_TOKEN: 'vzt_test_token',
+          },
+        }
+      );
+
+      assert.strictEqual(result.code, 0);
+      assert.match(result.stderr, /child stdout noise/);
+      assert.match(result.stderr, /child stderr noise/);
+      assert.doesNotMatch(result.stdout, /Screenshots/);
+      assert.doesNotMatch(result.stdout, /Results/);
+      assert.doesNotMatch(result.stdout, /Context/);
+
+      let payload = parseSingleJson(result.stdout);
+      assert.strictEqual(payload.status, 'data');
+      assert.strictEqual(payload.data.status, 'completed');
+      assert.strictEqual(payload.data.buildId, 'build-123');
+      assert.strictEqual(payload.data.comparisons.total, 0);
+      assert.deepStrictEqual(
+        requests.map(request => `${request.method} ${request.url}`),
+        [
+          'POST /api/sdk/builds',
+          'GET /api/sdk/builds/build-123',
+          'PUT /api/sdk/builds/build-123/status',
+          'GET /api/sdk/builds/build-123',
+          'GET /api/sdk/token/context',
+        ]
+      );
+    });
+  });
+
+  it('keeps --json failures parseable when the child command prints output', async () => {
+    let cwd = createWorkspace();
+    let command = [
+      "console.log('child stdout noise');",
+      "console.error('child stderr noise');",
+      'process.exit(7);',
+    ].join(' ');
+
+    let result = await runCLI(
+      [
+        '--no-color',
+        '--json',
+        'run',
+        `node -e ${JSON.stringify(command)}`,
+        '--allow-no-token',
+      ],
+      { cwd }
+    );
+
+    assert.strictEqual(result.code, 7);
+    assert.match(result.stderr, /child stdout noise/);
+    assert.match(result.stderr, /child stderr noise/);
+
+    let payload = parseSingleJson(result.stdout);
+    assert.strictEqual(payload.status, 'data');
+    assert.strictEqual(payload.data.status, 'failed');
+    assert.strictEqual(payload.data.exitCode, 7);
+  });
+
+  it('keeps failure details visible in normal terminal output', async () => {
+    let cwd = createWorkspace();
+    let command = [
+      "console.error('child failure details');",
+      'process.exit(7);',
+    ].join(' ');
+
+    let result = await runCLI(
+      [
+        '--no-color',
+        'run',
+        `node -e ${JSON.stringify(command)}`,
+        '--allow-no-token',
+      ],
+      { cwd }
+    );
+
+    assert.strictEqual(result.code, 7);
+    assert.match(result.stderr, /child failure details/);
+    assert.match(result.stderr, /Test command exited with code 7/);
+    assert.match(result.stderr, /Test run failed/);
+  });
+});

--- a/tests/commands/status-cli.test.js
+++ b/tests/commands/status-cli.test.js
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+function createWorkspace() {
+  return mkdtempSync(join(tmpdir(), 'vizzly-cli-status-'));
+}
+
+async function withApiServer(callback) {
+  let requests = [];
+  let server = createServer((req, res) => {
+    requests.push({ method: req.method, url: req.url });
+    res.setHeader('content-type', 'application/json');
+
+    if (req.method === 'GET' && req.url === '/api/sdk/builds/build-123') {
+      res.end(
+        JSON.stringify({
+          build: {
+            id: 'build-123',
+            status: 'completed',
+            name: 'No Preview Build',
+            created_at: '2026-06-11T21:00:00.000Z',
+            updated_at: '2026-06-11T21:01:00.000Z',
+            completed_at: '2026-06-11T21:02:00.000Z',
+            environment: 'local-dogfood',
+            branch: 'main',
+            commit_sha: 'abcdef1234567890',
+            commit_message: 'Dogfood status',
+            screenshot_count: 1,
+            total_comparisons: 1,
+            new_comparisons: 1,
+            changed_comparisons: 0,
+            identical_comparisons: 0,
+            approval_status: 'pending',
+            execution_time_ms: 100,
+            is_baseline: false,
+            user_agent: 'vizzly-test',
+          },
+        })
+      );
+      return;
+    }
+
+    if (
+      req.method === 'GET' &&
+      req.url === '/api/sdk/builds/build-123/preview'
+    ) {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: 'Preview not found for this build' }));
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+
+  await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    let address = server.address();
+    return await callback({
+      apiUrl: `http://127.0.0.1:${address.port}`,
+      requests,
+    });
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+describe('commands/status CLI', () => {
+  it('reports build status when the build has no preview', async () => {
+    await withApiServer(async ({ apiUrl, requests }) => {
+      let result = await runCLI(
+        ['--no-color', '--json', 'status', 'build-123'],
+        {
+          cwd: createWorkspace(),
+          env: {
+            VIZZLY_API_URL: apiUrl,
+            VIZZLY_TOKEN: 'vzt_test_token',
+          },
+        }
+      );
+
+      assert.strictEqual(result.code, 0);
+      assert.strictEqual(result.stderr, '');
+
+      let payload = JSON.parse(result.stdout);
+      assert.strictEqual(payload.status, 'data');
+      assert.strictEqual(payload.data.buildId, 'build-123');
+      assert.strictEqual(payload.data.status, 'completed');
+      assert.strictEqual(payload.data.preview, null);
+      assert.deepStrictEqual(
+        requests.map(request => `${request.method} ${request.url}`),
+        [
+          'GET /api/sdk/builds/build-123',
+          'GET /api/sdk/builds/build-123/preview',
+        ]
+      );
+    });
+  });
+});

--- a/tests/commands/tdd-daemon.test.js
+++ b/tests/commands/tdd-daemon.test.js
@@ -4,10 +4,8 @@ import { describe, it } from 'node:test';
 import {
   buildDaemonChildArgs,
   buildDashboardUrl,
-  buildLegacyServerInfo,
   buildOpenDashboardCommand,
   cleanupDaemonState,
-  cleanupLegacyGlobalServerFile,
   cleanupLocalDaemonFiles,
   findDaemonPidByPort,
   getLocalDaemonFiles,
@@ -19,7 +17,6 @@ import {
   waitForDaemonChildInit,
   waitForProcessExit,
   waitForServerRunning,
-  writeLegacyGlobalServerFile,
 } from '../../src/commands/tdd-daemon.js';
 
 function createManualTimers() {
@@ -134,70 +131,13 @@ describe('commands/tdd-daemon helpers', () => {
       ]);
     });
 
-    it('writes the legacy global server file for SDK discovery', () => {
-      let createdDirectories = [];
-      let writes = [];
-
-      let result = writeLegacyGlobalServerFile(
-        { pid: 1234, port: 47400, failOnDiff: true },
-        {
-          home: () => '/home/test',
-          exists: () => false,
-          mkdir: (path, options) => {
-            createdDirectories.push({ path, options });
-          },
-          writeFile: (path, contents) => {
-            writes.push({ path, contents: JSON.parse(contents) });
-          },
-          now: () => 987654321,
-        }
-      );
-
-      assert.deepStrictEqual(createdDirectories, [
-        { path: '/home/test/.vizzly', options: { recursive: true } },
-      ]);
-      assert.deepStrictEqual(writes, [
-        {
-          path: '/home/test/.vizzly/server.json',
-          contents: {
-            pid: 1234,
-            port: '47400',
-            startTime: 987654321,
-            failOnDiff: true,
-          },
-        },
-      ]);
-      assert.deepStrictEqual(result, {
-        path: '/home/test/.vizzly/server.json',
-        serverInfo: buildLegacyServerInfo({
-          pid: 1234,
-          port: 47400,
-          failOnDiff: true,
-          now: () => 987654321,
-        }),
-      });
-    });
-
-    it('cleans the legacy global server file when present', () => {
-      let removed = [];
-      let didRemove = cleanupLegacyGlobalServerFile({
-        home: () => '/home/test',
-        exists: path => path === '/home/test/.vizzly/server.json',
-        unlink: path => removed.push(path),
-      });
-
-      assert.strictEqual(didRemove, true);
-      assert.deepStrictEqual(removed, ['/home/test/.vizzly/server.json']);
-    });
-
-    it('cleans local files, legacy global state, and registry entries together', () => {
+    it('cleans local files and registry entries together', () => {
       let removed = [];
       let registryCalls = [];
       let localFiles = new Set([
         '/repo/app/.vizzly/server.pid',
         '/repo/app/.vizzly/server.json',
       ]);
-      let legacyFiles = new Set(['/home/test/.vizzly/server.json']);
 
       let result = cleanupDaemonState({
         port: 47400,
@@ -209,22 +149,15 @@ describe('commands/tdd-daemon helpers', () => {
           existsSync: path => localFiles.has(path),
           unlinkSync: path => removed.push(path),
         },
-        legacyFileDeps: {
-          home: () => '/home/test',
-          exists: path => legacyFiles.has(path),
-          unlink: path => removed.push(path),
-        },
       });
 
       assert.deepStrictEqual(result, {
         pidFileRemoved: true,
         serverFileRemoved: true,
-        legacyGlobalServerFileRemoved: true,
       });
       assert.deepStrictEqual(removed, [
         '/repo/app/.vizzly/server.pid',
         '/repo/app/.vizzly/server.json',
-        '/home/test/.vizzly/server.json',
       ]);
       assert.deepStrictEqual(registryCalls, [
         { port: 47400, directory: '/repo/app' },
@@ -245,17 +178,11 @@ describe('commands/tdd-daemon helpers', () => {
           existsSync: path => path === '/repo/app/.vizzly/server.pid',
           unlinkSync: path => removed.push(path),
         },
-        legacyFileDeps: {
-          home: () => '/home/test',
-          exists: () => false,
-          unlink: path => removed.push(path),
-        },
       });
 
       assert.deepStrictEqual(result, {
         pidFileRemoved: true,
         serverFileRemoved: false,
-        legacyGlobalServerFileRemoved: false,
       });
       assert.deepStrictEqual(removed, ['/repo/app/.vizzly/server.pid']);
     });

--- a/tests/commands/tdd-daemon.test.js
+++ b/tests/commands/tdd-daemon.test.js
@@ -12,6 +12,7 @@ import {
   findDaemonPidByPort,
   getLocalDaemonFiles,
   readDaemonPidFile,
+  readLocalDaemonInfo,
   removeFileIfExists,
   resolveDaemonPid,
   validateTddStartOptions,
@@ -383,10 +384,26 @@ describe('commands/tdd-daemon helpers', () => {
       assert.strictEqual(findByPortCalls, 0);
     });
 
-    it('falls back to port discovery when the pid file is stale', async () => {
+    it('does not fall back to port discovery by default when the pid file is stale', async () => {
+      let findByPortCalls = 0;
       let pid = await resolveDaemonPid({
         port: 47400,
         readPid: () => null,
+        findByPort: () => {
+          findByPortCalls++;
+          return 4321;
+        },
+      });
+
+      assert.strictEqual(pid, null);
+      assert.strictEqual(findByPortCalls, 0);
+    });
+
+    it('falls back to port discovery only when explicitly requested', async () => {
+      let pid = await resolveDaemonPid({
+        port: 47400,
+        readPid: () => null,
+        allowPortFallback: true,
         findByPort: port => {
           assert.strictEqual(port, 47400);
           return 4321;
@@ -394,6 +411,52 @@ describe('commands/tdd-daemon helpers', () => {
       });
 
       assert.strictEqual(pid, 4321);
+    });
+  });
+
+  describe('readLocalDaemonInfo', () => {
+    it('normalizes local daemon server info', () => {
+      let info = readLocalDaemonInfo('/repo/app', {
+        existsSync: path => path === '/repo/app/.vizzly/server.json',
+        readFileSync: () =>
+          JSON.stringify({
+            pid: '1234',
+            port: '47400',
+            startTime: 987654321,
+            logFile: '/repo/app/.vizzly/server.log',
+          }),
+      });
+
+      assert.deepStrictEqual(info, {
+        pid: 1234,
+        port: 47400,
+        startTime: 987654321,
+        logFile: '/repo/app/.vizzly/server.log',
+      });
+    });
+
+    it('returns null for missing, invalid, or portless server info', () => {
+      assert.strictEqual(
+        readLocalDaemonInfo('/repo/app', {
+          existsSync: () => false,
+          readFileSync: () => '{}',
+        }),
+        null
+      );
+      assert.strictEqual(
+        readLocalDaemonInfo('/repo/app', {
+          existsSync: () => true,
+          readFileSync: () => 'not-json',
+        }),
+        null
+      );
+      assert.strictEqual(
+        readLocalDaemonInfo('/repo/app', {
+          existsSync: () => true,
+          readFileSync: () => JSON.stringify({ pid: 1234 }),
+        }),
+        null
+      );
     });
   });
 
@@ -524,6 +587,31 @@ describe('commands/tdd-daemon helpers', () => {
       assert.strictEqual(child.listenerCount('exit'), 0);
     });
 
+    it('returns a child error message when daemon initialization fails', async () => {
+      let timers = createManualTimers();
+      let child = new EventEmitter();
+
+      let promise = waitForDaemonChildInit(child, { timers });
+      child.emit('message', {
+        type: 'error',
+        message: 'Port is already in use',
+        code: 'EADDRINUSE',
+        stack: 'Error: Port is already in use\n    at startServer',
+      });
+
+      let result = await promise;
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.reason, 'error');
+      assert.match(result.error.message, /Port is already in use/);
+      assert.strictEqual(result.error.code, 'EADDRINUSE');
+      assert.match(result.error.stack, /startServer/);
+      assert.strictEqual(timers.get(1), undefined);
+      assert.strictEqual(child.listenerCount('message'), 0);
+      assert.strictEqual(child.listenerCount('disconnect'), 0);
+      assert.strictEqual(child.listenerCount('exit'), 0);
+    });
+
     it('returns an exit result when the daemon child exits first', async () => {
       let timers = createManualTimers();
       let child = new EventEmitter();
@@ -533,10 +621,30 @@ describe('commands/tdd-daemon helpers', () => {
 
       let result = await promise;
 
-      assert.deepStrictEqual(result, { ok: false, reason: 'exit' });
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.reason, 'exit');
+      assert.match(result.error.message, /Daemon child exited before startup/);
       assert.strictEqual(timers.get(1), undefined);
       assert.strictEqual(child.listenerCount('disconnect'), 0);
       assert.strictEqual(child.listenerCount('exit'), 0);
+    });
+
+    it('returns stderr when the daemon child exits before IPC setup', async () => {
+      let timers = createManualTimers();
+      let child = new EventEmitter();
+      child.stderr = new EventEmitter();
+
+      let promise = waitForDaemonChildInit(child, { timers });
+      child.stderr.emit('data', 'Cannot find module tdd-daemon.js\n');
+      child.emit('exit', 1, null);
+
+      let result = await promise;
+
+      assert.strictEqual(result.ok, false);
+      assert.strictEqual(result.reason, 'exit');
+      assert.match(result.error.message, /Cannot find module/);
+      assert.strictEqual(result.error.code, 1);
+      assert.strictEqual(child.stderr.listenerCount('data'), 0);
     });
 
     it('returns a timeout result and removes listeners', async () => {

--- a/tests/commands/upload-cli.test.js
+++ b/tests/commands/upload-cli.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+describe('commands/upload CLI', () => {
+  it('reports a missing screenshots path before auth errors', async () => {
+    let result = await runCLI([
+      '--no-color',
+      'upload',
+      './missing-screenshots-dir',
+    ]);
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /does not exist/);
+    assert.doesNotMatch(result.stderr, /API token required/);
+  });
+});

--- a/tests/test-runner/core.test.js
+++ b/tests/test-runner/core.test.js
@@ -457,6 +457,17 @@ describe('test-runner/core', () => {
         shell: true,
       });
     });
+
+    it('pipes child output in JSON mode so CLI stdout stays machine readable', () => {
+      let env = { NODE_ENV: 'test' };
+      let options = buildSpawnOptions(env, { json: true });
+
+      assert.deepStrictEqual(options, {
+        env,
+        stdio: ['inherit', 'pipe', 'pipe'],
+        shell: true,
+      });
+    });
   });
 
   describe('normalizeSetBaseline', () => {


### PR DESCRIPTION
## Why

The CLI had several rough edges at the boundaries users rely on most: command errors could show misleading help, JSON mode could mix machine-readable output with human text, TDD lifecycle commands were not careful enough around explicit ports, and some commands hid local validation failures behind auth or optional API state.

That makes the CLI feel unreliable in automation and confusing in local workflows. This PR tightens those paths so exposed commands fail clearly, preserve their output contracts, and avoid touching unrelated local processes or config state.

It also removes the old global TDD `server.json` compatibility path. Local TDD discovery is now project-local or explicit, which matches the current daemon registry model and avoids carrying forward a second server-discovery contract.

## What Changed

- Fixed command routing and help behavior so unknown root and nested commands fail with the right recovery hints.
- Cleaned up root/TDD help output, including full nested command paths, documented lifecycle `--port` flags, and hidden internal daemon-only flags.
- Preserved JSON-mode contracts for validation errors, commander errors, TDD commands, noisy child processes, `run --json --wait`, `upload --wait --json`, review actions, and `status --json`.
- Made TDD daemon `start`, `status`, `stop`, and `list` safer around explicit ports, isolated `VIZZLY_HOME`, stale files, registry entries, and wrong-port no-ops.
- Removed the legacy global TDD `server.json` write/cleanup path so daemon state is no longer mirrored into the user home directory.
- Validated preview/upload local paths before requiring auth so local mistakes are reported immediately.
- Made `status` tolerate builds without preview metadata by returning `preview: null` instead of failing.
- Updated in-repo docs, Swift SDK docs, Vizzly skill references, and the JSON output reference so the documented workflows match the CLI behavior.
- Added CLI-boundary regression tests that run the real command entrypoint against local workspaces and local HTTP API servers.

## Impact

This should make the CLI more predictable for both local use and automation. JSON stdout stays parseable, help/error output points users to the right command, TDD lifecycle commands avoid unrelated processes, local validation errors are surfaced before network/auth concerns, and SDK server discovery no longer depends on a stale global file.
