### PR TITLE
⬆️ Bump Honeydiff to 0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@vizzly-testing/bear-den": "0.1.2",
-    "@vizzly-testing/honeydiff": "^0.10.3",
+    "@vizzly-testing/honeydiff": "^0.11.0",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 0.1.2
         version: 0.1.2(@heroicons/react@2.2.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@vizzly-testing/honeydiff':
-        specifier: ^0.10.3
-        version: 0.10.3
+        specifier: ^0.11.0
+        version: 0.11.0
       ansis:
         specifier: ^4.2.0
         version: 4.3.1
@@ -2478,6 +2478,10 @@ packages:
 
   '@vizzly-testing/honeydiff@0.10.3':
     resolution: {integrity: sha512-gzcd2Ryr0l9trrNb4PL3oo51HzBFFDQBiXTTF56+3IHi/yHo52qCvKpJQAPZwauWOuBXr53dIa7OelkTxkyeCA==}
+    engines: {node: '>=22.0.0'}
+
+  '@vizzly-testing/honeydiff@0.11.0':
+    resolution: {integrity: sha512-MF6zmBVq4XRNnDSUMkmnvSIxuN4ewLy5Nz0ifrlMSi6n8gZMJOJ22COrTaBExC11SBc/wF150OncTDlYCOFHRg==}
     engines: {node: '>=22.0.0'}
 
   '@warp-drive/build-config@5.8.2':
@@ -9569,6 +9573,8 @@ snapshots:
       - typescript
 
   '@vizzly-testing/honeydiff@0.10.3': {}
+
+  '@vizzly-testing/honeydiff@0.11.0': {}
 
   '@warp-drive/build-config@5.8.2(@babel/core@7.29.7)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude:
   - '@vizzly-testing/bear-den@0.1.2'
-  - '@vizzly-testing/honeydiff@0.10.3'
+  - '@vizzly-testing/honeydiff@0.11.0'
 onlyBuiltDependencies:
   - canvas
   - esbuild


### PR DESCRIPTION
## Why

Honeydiff 0.11.0 is published with release-package fixes and updated comparison behavior, so the CLI should test and package against the same version as the app runtime. This keeps local TDD comparison behavior aligned with the current Honeydiff release.

## Approach

The CLI dependency moves to ^0.11.0 through pnpm, and the workspace keeps the release-age policy intact by swapping the existing first-party Honeydiff exception from 0.10.3 to 0.11.0. That avoids a broad supply-chain bypass while still allowing this freshly published first-party package.

## Evidence

The updated native package imports successfully, CLI linting passes, type assertions pass, and focused command/TDD comparison tests continue to pass with the new dependency.

## Risk

The release-age exception is intentionally version-specific. It should be revisited on the next Honeydiff bump rather than expanded to the whole package scope.