### PR TITLE
⬆️ Bump Honeydiff to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@vizzly-testing/bear-den": "0.1.2",
-    "@vizzly-testing/honeydiff": "^0.11.0",
+    "@vizzly-testing/honeydiff": "^0.11.1",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@vizzly-testing/bear-den": "0.1.2",
-    "@vizzly-testing/honeydiff": "^0.10.3",
+    "@vizzly-testing/honeydiff": "^0.11.0",
     "ansis": "^4.2.0",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 0.1.2
         version: 0.1.2(@heroicons/react@2.2.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@vizzly-testing/honeydiff':
-        specifier: ^0.10.3
-        version: 0.10.3
+        specifier: ^0.11.0
+        version: 0.11.0
       ansis:
         specifier: ^4.2.0
         version: 4.3.1
@@ -2478,6 +2478,10 @@ packages:
 
   '@vizzly-testing/honeydiff@0.10.3':
     resolution: {integrity: sha512-gzcd2Ryr0l9trrNb4PL3oo51HzBFFDQBiXTTF56+3IHi/yHo52qCvKpJQAPZwauWOuBXr53dIa7OelkTxkyeCA==}
+    engines: {node: '>=22.0.0'}
+
+  '@vizzly-testing/honeydiff@0.11.0':
+    resolution: {integrity: sha512-MF6zmBVq4XRNnDSUMkmnvSIxuN4ewLy5Nz0ifrlMSi6n8gZMJOJ22COrTaBExC11SBc/wF150OncTDlYCOFHRg==}
     engines: {node: '>=22.0.0'}
 
   '@warp-drive/build-config@5.8.2':
@@ -9569,6 +9573,8 @@ snapshots:
       - typescript
 
   '@vizzly-testing/honeydiff@0.10.3': {}
+
+  '@vizzly-testing/honeydiff@0.11.0': {}
 
   '@warp-drive/build-config@5.8.2(@babel/core@7.29.7)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 0.1.2
         version: 0.1.2(@heroicons/react@2.2.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
       '@vizzly-testing/honeydiff':
-        specifier: ^0.11.0
-        version: 0.11.0
+        specifier: ^0.11.1
+        version: 0.11.1
       ansis:
         specifier: ^4.2.0
         version: 4.3.1
@@ -2480,8 +2480,8 @@ packages:
     resolution: {integrity: sha512-gzcd2Ryr0l9trrNb4PL3oo51HzBFFDQBiXTTF56+3IHi/yHo52qCvKpJQAPZwauWOuBXr53dIa7OelkTxkyeCA==}
     engines: {node: '>=22.0.0'}
 
-  '@vizzly-testing/honeydiff@0.11.0':
-    resolution: {integrity: sha512-MF6zmBVq4XRNnDSUMkmnvSIxuN4ewLy5Nz0ifrlMSi6n8gZMJOJ22COrTaBExC11SBc/wF150OncTDlYCOFHRg==}
+  '@vizzly-testing/honeydiff@0.11.1':
+    resolution: {integrity: sha512-GwKuoTz/rj/a49/uROmECGrCpsxb95mLrbP0or+zyX8oOqdtBgA1c3TOl7sD2+FFPafZ+geFc1c2lSrhZ3sImA==}
     engines: {node: '>=22.0.0'}
 
   '@warp-drive/build-config@5.8.2':
@@ -9574,7 +9574,7 @@ snapshots:
 
   '@vizzly-testing/honeydiff@0.10.3': {}
 
-  '@vizzly-testing/honeydiff@0.11.0': {}
+  '@vizzly-testing/honeydiff@0.11.1': {}
 
   '@warp-drive/build-config@5.8.2(@babel/core@7.29.7)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude:
   - '@vizzly-testing/bear-den@0.1.2'
-  - '@vizzly-testing/honeydiff@0.10.3'
+  - '@vizzly-testing/honeydiff@0.11.0'
 onlyBuiltDependencies:
   - canvas
   - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
 minimumReleaseAgeExclude:
   - '@vizzly-testing/bear-den@0.1.2'
-  - '@vizzly-testing/honeydiff@0.11.0'
+  - '@vizzly-testing/honeydiff@0.11.1'
 onlyBuiltDependencies:
   - canvas
   - esbuild


### PR DESCRIPTION
## Why

The CLI should move to the same Honeydiff release Vizzly is consuming so local comparisons use the corrected 0.11 metric semantics plus the 0.11.1 hot-path recovery. This also avoids leaving the CLI on the older 0.10.3 package after the recovered release is public.

## Approach

This updates the root dependency and pnpm lockfile to @vizzly-testing/honeydiff@0.11.1. The workspace release-age exemption moves to the exact fresh Honeydiff version so frozen installs can pass without relaxing the repo-wide supply-chain policy.

## Evidence

The published package loads locally as 0.11.1 and exposes quickCompareSync. Pnpm accepts the frozen lockfile under the active supply-chain policy, and the CLI lint, type, comparison-service, comparisons command, and builds command coverage all still pass.