### PR TITLE
⬆️ Tune Dependabot update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,7 @@ updates:
       time: "09:00"
       timezone: "UTC"
     commit-message:
-      prefix: "⬆️ build"
-      include: "scope"
+      prefix: "⬆️"
     groups:
       dependencies:
         patterns:
@@ -22,7 +21,7 @@ updates:
           - "*"
         update-types:
           - "major"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     cooldown:
       semver-major-days: 30
       semver-minor-days: 14


### PR DESCRIPTION
## Why

The CLI repo already had the better pnpm-style semver backoff policy, but Dependabot still lacked the gitmoji-only title prefix and had a lower visible PR limit. That made it easier for dependency work to arrive in another wave after one PR was merged.

## Approach

This keeps the existing minor/patch and major grouping plus the 30/14/7 day cooldown policy, adds the plain `⬆️` Dependabot prefix, and raises the open PR limit so the backlog is visible instead of drip-feeding after merges.

## Confidence

This is a config-only change in `.github/dependabot.yml`. I made it from a clean temporary worktree so the unrelated local SDK edits in the main checkout are not part of this PR.