### PR TITLE
✨ Expose factual comparison evidence

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -580,15 +580,25 @@ vizzly comparisons --build <id> --status changed --json
       {
         "id": "comp-uuid",
         "name": "button-primary",
-        "status": "changed",
+        "status": "completed",
+        "result": "changed",
         "diffPercentage": 0.042,
         "approvalStatus": "pending",
+        "reviewState": "pending",
+        "visualReview": { "state": "pending" },
         "viewport": { "width": 1920, "height": 1080 },
         "browser": "chromium",
         "urls": {
           "baseline": "https://...",
           "current": "https://...",
           "diff": "https://..."
+        },
+        "honeydiff": {
+          "fingerprintHash": "00000000001ec127",
+          "regionCount": 12,
+          "projection": {
+            "clusters": { "count": 12, "average_density": 0.81 }
+          }
         }
       }
     ],
@@ -601,6 +611,11 @@ vizzly comparisons --build <id> --status changed --json
   }
 }
 ```
+
+`status` preserves the processing value returned by the API. Use `result` for
+the visual outcome (`identical`, `changed`, or `new`) and `reviewState` for the
+current review decision. Older responses that only provide `status` and
+`approvalStatus` keep working with the same fields.
 
 Search by name across builds:
 

--- a/src/commands/comparisons.js
+++ b/src/commands/comparisons.js
@@ -11,6 +11,13 @@ import {
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import * as defaultOutput from '../utils/output.js';
 import { createWildcardMatcher } from '../utils/patterns.js';
+import {
+  getComparisonBrowser,
+  getComparisonName,
+  getComparisonResult,
+  getComparisonViewport,
+  getVisualReviewState,
+} from '../utils/visual-context-normalizers.js';
 
 /**
  * Comparisons command - query comparisons with various filters
@@ -87,13 +94,17 @@ export async function comparisonsCommand(
 
       // Apply status filter if provided
       if (options.status) {
-        comparisons = comparisons.filter(c => c.status === options.status);
+        comparisons = comparisons.filter(
+          comparison => getComparisonResult(comparison) === options.status
+        );
       }
 
       // Apply name filter if provided
       if (options.name) {
         let matchesName = createWildcardMatcher(options.name);
-        comparisons = comparisons.filter(c => matchesName(c.name));
+        comparisons = comparisons.filter(comparison =>
+          matchesName(getComparisonName(comparison))
+        );
       }
 
       if (globalOptions.json) {
@@ -103,9 +114,15 @@ export async function comparisonsCommand(
           comparisons: comparisons.map(formatComparisonForJson),
           summary: {
             total: comparisons.length,
-            passed: comparisons.filter(c => c.status === 'identical').length,
-            failed: comparisons.filter(c => c.status === 'changed').length,
-            new: comparisons.filter(c => c.status === 'new').length,
+            passed: comparisons.filter(
+              comparison => getComparisonResult(comparison) === 'identical'
+            ).length,
+            failed: comparisons.filter(
+              comparison => getComparisonResult(comparison) === 'changed'
+            ).length,
+            new: comparisons.filter(
+              comparison => getComparisonResult(comparison) === 'new'
+            ).length,
           },
         });
         output.cleanup();
@@ -198,23 +215,38 @@ function formatComparisonForJson(comparison) {
   let gmsdScore = comparison.gmsd_score ?? diffImage.gmsd_score ?? null;
   let fingerprintHash =
     comparison.fingerprint_hash || diffImage.fingerprint_hash || null;
+  let projection =
+    comparison.analysis_projection ||
+    comparison.projection ||
+    diffImage.analysis_projection ||
+    diffImage.projection ||
+    null;
+  let diffRegions = comparison.diff_regions ?? diffImage.diff_regions ?? null;
+  let regionCount =
+    comparison.region_count ??
+    diffImage.region_count ??
+    projection?.clusters?.count ??
+    (Array.isArray(diffRegions) ? diffRegions.length : null);
 
   let hasHoneydiff =
     clusterMetadata ||
     ssimScore != null ||
     gmsdScore != null ||
-    fingerprintHash;
+    fingerprintHash ||
+    projection ||
+    regionCount != null;
 
   return {
     id: comparison.id,
-    name: comparison.name,
+    name: getComparisonName(comparison),
     status: comparison.status,
+    result: getComparisonResult(comparison),
     diffPercentage: comparison.diff_percentage ?? null,
     approvalStatus: comparison.approval_status,
-    viewport: comparison.viewport_width
-      ? { width: comparison.viewport_width, height: comparison.viewport_height }
-      : null,
-    browser: comparison.browser || null,
+    reviewState: getVisualReviewState(comparison),
+    visualReview: comparison.visual_review || null,
+    viewport: getComparisonViewport(comparison),
+    browser: getComparisonBrowser(comparison),
     urls: {
       baseline:
         comparison.baseline_screenshot?.original_url ||
@@ -239,8 +271,9 @@ function formatComparisonForJson(comparison) {
           clusterClassification: clusterMetadata?.classification || null,
           clusterMetadata,
           fingerprintHash,
-          diffRegions:
-            comparison.diff_regions ?? diffImage.diff_regions ?? null,
+          regionCount,
+          projection,
+          diffRegions,
           diffLines: comparison.diff_lines ?? diffImage.diff_lines ?? null,
           fingerprintData:
             comparison.fingerprint_data ?? diffImage.fingerprint_data ?? null,
@@ -257,28 +290,29 @@ function formatComparisonForJson(comparison) {
  * Display a single comparison in detail
  */
 function displayComparison(output, comparison, verbose) {
-  output.header('comparison', comparison.status);
+  let formatted = formatComparisonForJson(comparison);
+  output.header('comparison', formatted.result);
 
   output.keyValue({
-    Name: comparison.name,
-    Status: comparison.status?.toUpperCase(),
+    Name: formatted.name,
+    Status: formatted.result?.toUpperCase(),
     'Diff %':
       comparison.diff_percentage != null
         ? `${(comparison.diff_percentage * 100).toFixed(2)}%`
         : 'N/A',
-    Approval: comparison.approval_status || 'pending',
+    Review: formatted.reviewState || 'unknown',
   });
 
   output.blank();
 
-  if (comparison.viewport_width) {
+  if (formatted.viewport) {
     output.labelValue(
       'Viewport',
-      `${comparison.viewport_width}×${comparison.viewport_height}`
+      `${formatted.viewport.width ?? '?'}×${formatted.viewport.height ?? '?'}`
     );
   }
-  if (comparison.browser) {
-    output.labelValue('Browser', comparison.browser);
+  if (formatted.browser) {
+    output.labelValue('Browser', formatted.browser);
   }
 
   output.blank();
@@ -295,45 +329,39 @@ function displayComparison(output, comparison, verbose) {
   }
 
   // Honeydiff analysis in verbose mode
-  if (verbose) {
-    let clusterMetadata =
-      comparison.cluster_metadata || comparison.diff_image?.cluster_metadata;
-    let ssim = comparison.ssim_score ?? comparison.diff_image?.ssim_score;
-    let gmsd = comparison.gmsd_score ?? comparison.diff_image?.gmsd_score;
-    let fingerprint =
-      comparison.fingerprint_hash || comparison.diff_image?.fingerprint_hash;
-
-    if (clusterMetadata || ssim != null || gmsd != null || fingerprint) {
+  if (verbose && formatted.honeydiff) {
+    let honeydiff = formatted.honeydiff;
+    if (
+      honeydiff.clusterMetadata ||
+      honeydiff.ssimScore != null ||
+      honeydiff.gmsdScore != null ||
+      honeydiff.fingerprintHash ||
+      honeydiff.regionCount != null
+    ) {
       output.blank();
-      if (clusterMetadata?.classification) {
-        output.labelValue('Classification', clusterMetadata.classification);
+      if (honeydiff.clusterClassification) {
+        output.labelValue('Classification', honeydiff.clusterClassification);
       }
-      if (ssim != null) {
-        output.labelValue('SSIM', ssim.toFixed(4));
+      if (honeydiff.ssimScore != null) {
+        output.labelValue('SSIM', honeydiff.ssimScore.toFixed(4));
       }
-      if (gmsd != null) {
-        output.labelValue('GMSD', gmsd.toFixed(4));
+      if (honeydiff.gmsdScore != null) {
+        output.labelValue('GMSD', honeydiff.gmsdScore.toFixed(4));
       }
-      if (fingerprint) {
-        output.labelValue('Fingerprint', fingerprint);
+      if (honeydiff.fingerprintHash) {
+        output.labelValue('Fingerprint', honeydiff.fingerprintHash);
+      }
+      if (honeydiff.regionCount != null) {
+        output.labelValue('Regions', String(honeydiff.regionCount));
       }
     }
   }
 
   // URLs in verbose mode
   if (verbose) {
-    let baselineUrl =
-      comparison.baseline_screenshot?.original_url ||
-      comparison.baseline_original_url ||
-      comparison.baseline_screenshot_url;
-    let currentUrl =
-      comparison.current_screenshot?.original_url ||
-      comparison.current_original_url ||
-      comparison.current_screenshot_url;
-    let diffUrl =
-      comparison.diff_image?.url ||
-      comparison.diff_image_url ||
-      comparison.diff_url;
+    let baselineUrl = formatted.urls.baseline;
+    let currentUrl = formatted.urls.current;
+    let diffUrl = formatted.urls.diff;
 
     if (baselineUrl || currentUrl || diffUrl) {
       output.blank();
@@ -367,9 +395,15 @@ function displayBuildComparisons(output, build, comparisons, verbose) {
   }
 
   // Summary
-  let passed = comparisons.filter(c => c.status === 'identical').length;
-  let failed = comparisons.filter(c => c.status === 'changed').length;
-  let newCount = comparisons.filter(c => c.status === 'new').length;
+  let passed = comparisons.filter(
+    comparison => getComparisonResult(comparison) === 'identical'
+  ).length;
+  let failed = comparisons.filter(
+    comparison => getComparisonResult(comparison) === 'changed'
+  ).length;
+  let newCount = comparisons.filter(
+    comparison => getComparisonResult(comparison) === 'new'
+  ).length;
 
   let stats = [];
   if (passed > 0) stats.push(`${colors.brand.success(passed)} identical`);
@@ -381,7 +415,7 @@ function displayBuildComparisons(output, build, comparisons, verbose) {
 
   // List comparisons
   for (let comp of comparisons.slice(0, verbose ? 100 : 20)) {
-    let icon = getStatusIcon(colors, comp.status);
+    let icon = getStatusIcon(colors, getComparisonResult(comp));
     let diffInfo =
       comp.diff_percentage != null
         ? colors.dim(` (${(comp.diff_percentage * 100).toFixed(1)}%)`)
@@ -389,7 +423,9 @@ function displayBuildComparisons(output, build, comparisons, verbose) {
     let classification = verbose
       ? getClassificationLabel(colors, comp.cluster_metadata)
       : '';
-    output.print(`  ${icon} ${comp.name}${diffInfo}${classification}`);
+    output.print(
+      `  ${icon} ${getComparisonName(comp)}${diffInfo}${classification}`
+    );
   }
 
   if (comparisons.length > (verbose ? 100 : 20)) {
@@ -442,14 +478,14 @@ function displaySearchResults(
     }
 
     for (let comp of group.comparisons.slice(0, verbose ? 10 : 3)) {
-      let icon = getStatusIcon(colors, comp.status);
+      let icon = getStatusIcon(colors, getComparisonResult(comp));
       let classification = verbose
         ? getClassificationLabel(
             colors,
             comp.cluster_metadata || comp.diff_image?.cluster_metadata
           )
         : '';
-      output.print(`      ${icon} ${comp.name}${classification}`);
+      output.print(`      ${icon} ${getComparisonName(comp)}${classification}`);
     }
 
     if (group.comparisons.length > (verbose ? 10 : 3)) {

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -1,0 +1,54 @@
+export function getVisualReviewState(record = {}) {
+  return (
+    record.visual_review?.state ||
+    record.review_state ||
+    record.approval_status ||
+    null
+  );
+}
+
+export function getComparisonResult(comparison = {}) {
+  return comparison.result || comparison.status || null;
+}
+
+export function getComparisonName(comparison = {}) {
+  return (
+    comparison.name ||
+    comparison.screenshot_name ||
+    comparison.current_screenshot?.name ||
+    comparison.current_name ||
+    comparison.id ||
+    null
+  );
+}
+
+export function getComparisonViewport(comparison = {}) {
+  let current = comparison.current_screenshot || comparison.screenshot || {};
+  let viewport = comparison.viewport || current.viewport || {};
+  let width =
+    viewport.width ??
+    comparison.viewport_width ??
+    current.viewport_width ??
+    comparison.current_viewport_width ??
+    null;
+  let height =
+    viewport.height ??
+    comparison.viewport_height ??
+    current.viewport_height ??
+    comparison.current_viewport_height ??
+    null;
+
+  return width != null || height != null ? { width, height } : null;
+}
+
+export function getComparisonBrowser(comparison = {}) {
+  return (
+    comparison.browser ||
+    comparison.current_screenshot?.browser ||
+    comparison.screenshot?.browser ||
+    comparison.current_browser ||
+    comparison.current_metadata?.browser ||
+    comparison.current_metadata?.properties?.browser ||
+    null
+  );
+}

--- a/tests/commands/comparisons.test.js
+++ b/tests/commands/comparisons.test.js
@@ -165,6 +165,80 @@ describe('commands/comparisons', () => {
       assert.strictEqual(dataCall.args[0].summary.failed, 1);
     });
 
+    it('preserves existing JSON fields while exposing current comparison evidence', async () => {
+      let output = createMockOutput();
+      let mockBuild = {
+        id: 'build-1',
+        name: 'Build 1',
+        comparisons: [
+          {
+            id: 'comp-1',
+            screenshot_name: 'checkout',
+            status: 'completed',
+            result: 'changed',
+            diff_percentage: 0.025,
+            approval_status: 'approved',
+            visual_review: { state: 'pending', decision: null },
+            current_browser: 'chromium',
+            current_viewport_width: 1440,
+            current_viewport_height: 900,
+            baseline_original_url: 'https://cdn.test/baseline.png',
+            current_original_url: 'https://cdn.test/current.png',
+            diff_image_url: 'https://cdn.test/diff.png',
+            analysis_projection: {
+              clusters: { count: 3, average_density: 0.81 },
+            },
+            fingerprint_hash: 'fp-checkout',
+          },
+        ],
+      };
+
+      await comparisonsCommand(
+        { build: 'build-1' },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'test-token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuild: async () => ({ build: mockBuild }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let data = output.calls.find(call => call.method === 'data').args[0];
+      let comparison = data.comparisons[0];
+
+      assert.strictEqual(data.summary.failed, 1);
+      assert.strictEqual(comparison.id, 'comp-1');
+      assert.strictEqual(comparison.name, 'checkout');
+      assert.strictEqual(comparison.status, 'completed');
+      assert.strictEqual(comparison.result, 'changed');
+      assert.strictEqual(comparison.approvalStatus, 'approved');
+      assert.strictEqual(comparison.reviewState, 'pending');
+      assert.deepStrictEqual(comparison.visualReview, {
+        state: 'pending',
+        decision: null,
+      });
+      assert.strictEqual(comparison.browser, 'chromium');
+      assert.deepStrictEqual(comparison.viewport, {
+        width: 1440,
+        height: 900,
+      });
+      assert.deepStrictEqual(comparison.urls, {
+        baseline: 'https://cdn.test/baseline.png',
+        current: 'https://cdn.test/current.png',
+        diff: 'https://cdn.test/diff.png',
+      });
+      assert.strictEqual(comparison.honeydiff.fingerprintHash, 'fp-checkout');
+      assert.strictEqual(comparison.honeydiff.regionCount, 3);
+      assert.deepStrictEqual(comparison.honeydiff.projection, {
+        clusters: { count: 3, average_density: 0.81 },
+      });
+    });
+
     it('passes include as a string to getBuild, not an object', async () => {
       let output = createMockOutput();
       let capturedInclude = null;
@@ -254,6 +328,36 @@ describe('commands/comparisons', () => {
       assert.strictEqual(
         dataCall.args[0].comparisons[0].name,
         'button-secondary'
+      );
+    });
+
+    it('filters current comparisons by visual result rather than processing status', async () => {
+      let output = createMockOutput();
+      let mockBuild = {
+        id: 'build-1',
+        comparisons: [
+          { id: 'comp-1', status: 'completed', result: 'identical' },
+          { id: 'comp-2', status: 'completed', result: 'changed' },
+        ],
+      };
+
+      await comparisonsCommand(
+        { build: 'build-1', status: 'changed' },
+        { json: true },
+        {
+          loadConfig: async () => ({ apiKey: 'test-token' }),
+          createApiClient: () => ({}),
+          getBuild: async () => ({ build: mockBuild }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let comparisons = output.calls.find(call => call.method === 'data')
+        .args[0].comparisons;
+      assert.deepStrictEqual(
+        comparisons.map(comparison => comparison.id),
+        ['comp-2']
       );
     });
 
@@ -366,6 +470,46 @@ describe('commands/comparisons', () => {
       assert.strictEqual(dataCall.args[0].name, 'button-primary');
     });
 
+    it('shows the visual result and canonical review state for current comparisons', async () => {
+      let output = createMockOutput();
+
+      await comparisonsCommand(
+        { id: 'comp-1' },
+        {},
+        {
+          loadConfig: async () => ({ apiKey: 'test-token' }),
+          createApiClient: () => ({}),
+          getComparison: async () => ({
+            id: 'comp-1',
+            screenshot_name: 'checkout',
+            status: 'completed',
+            result: 'changed',
+            visual_review: { state: 'pending' },
+            current_browser: 'chromium',
+            current_viewport_width: 1440,
+            current_viewport_height: 900,
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let header = output.calls.find(call => call.method === 'header');
+      let details = output.calls.find(call => call.method === 'keyValue');
+      let viewport = output.calls.find(
+        call => call.method === 'labelValue' && call.args[0] === 'Viewport'
+      );
+
+      assert.deepStrictEqual(header.args, ['comparison', 'changed']);
+      assert.deepStrictEqual(details.args[0], {
+        Name: 'checkout',
+        Status: 'CHANGED',
+        'Diff %': 'N/A',
+        Review: 'pending',
+      });
+      assert.strictEqual(viewport.args[1], '1440×900');
+    });
+
     it('includes honeydiff data in JSON output for single comparison', async () => {
       let output = createMockOutput();
       let mockComparison = {
@@ -409,6 +553,7 @@ describe('commands/comparisons', () => {
       assert.deepStrictEqual(result.honeydiff.diffRegions, [
         { x: 10, y: 20, width: 50, height: 30 },
       ]);
+      assert.strictEqual(result.honeydiff.regionCount, 1);
       assert.deepStrictEqual(result.honeydiff.diffLines, [20, 30, 40]);
     });
 


### PR DESCRIPTION
## Why

The comparisons command currently treats the API's processing `status` as the visual outcome. That makes current comparison responses harder for agents and humans to interpret, and hides useful review and Honeydiff evidence the API already returns.

## What changed

- Preserve the existing comparison JSON fields while adding a canonical visual `result`, `reviewState`, and `visualReview`.
- Normalize current and older API response shapes for screenshot names, browser, viewport, and asset URLs.
- Expose API-provided Honeydiff projection and region counts alongside the existing fingerprint and diff evidence.
- Use the visual result for filtering, summaries, icons, and detailed terminal output while retaining the processing status in JSON.
- Document the distinction between processing status, visual result, and review state.

No auth, pagination, grouping, status-command, or dynamic-content behavior changes are included.

## Confidence

The comparison command is covered across current and older response shapes, including preservation of existing fields and filtering by visual result. The full test, lint, build, type-definition, and package checks pass, and the packaged CLI includes the new normalization module.
