### PR TITLE
✨ Normalize grouped build context

### DIFF
--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -15,6 +15,7 @@ import { resolveContextSource as defaultResolveContextSource } from '../context/
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
 import * as defaultOutput from '../utils/output.js';
 import { readSession as defaultReadSession } from '../utils/session.js';
+import { normalizeBuildContext } from '../utils/visual-context-normalizers.js';
 
 function buildAuthErrorMessage() {
   return 'Authentication required. Use --token, set VIZZLY_TOKEN, run "vizzly login", or link a project.';
@@ -532,14 +533,19 @@ function formatNeedsReview(status = {}) {
     return null;
   }
 
-  let pending = status.pending_comparisons || 0;
-  let unresolved = status.unresolved_comments || 0;
-
   if (!status.needs_review) {
     return 'no';
   }
 
-  return `yes · ${pending} comparisons · ${unresolved} unresolved comments`;
+  let details = [];
+  if (status.pending_comparisons != null) {
+    details.push(`${status.pending_comparisons} comparisons`);
+  }
+  if (status.unresolved_comments != null) {
+    details.push(`${status.unresolved_comments} unresolved comments`);
+  }
+
+  return details.length > 0 ? `yes · ${details.join(' · ')}` : 'yes';
 }
 
 function formatConfirmedRegionLabels(regions = []) {
@@ -588,64 +594,207 @@ function printComparisonList(output, comparisons = [], { limit = 5 } = {}) {
   }
 }
 
+function getGroupDisplayState(group = {}) {
+  let aggregate = group.aggregate_status || {};
+
+  if ((aggregate.failed_count ?? 0) > 0) return 'failed';
+  if (aggregate.has_rejected === true) return 'rejected';
+  if (aggregate.has_changes === true) return 'changed';
+  if (aggregate.has_new === true) return 'new';
+  if (aggregate.needs_review === true) return 'needs review';
+  if (aggregate.all_approved === true) return 'approved';
+  return null;
+}
+
+function formatViewport(viewport) {
+  if (!viewport) {
+    return null;
+  }
+
+  return `${viewport.width ?? '?'}×${viewport.height ?? '?'}`;
+}
+
+function printScreenshotGroups(output, groups = [], { limit = 8 } = {}) {
+  let colors = output.getColors();
+  let visibleGroups = groups.slice(0, limit);
+
+  output.print('  Screenshot groups');
+
+  for (let group of visibleGroups) {
+    let displayState = getGroupDisplayState(group);
+    let tone = getStatusTone(colors, displayState);
+    let aggregate = group.aggregate_status || {};
+    let details = [];
+
+    if (group.variant_count != null) {
+      details.push(`${group.variant_count} variants`);
+    }
+
+    if (aggregate.needs_review_count != null) {
+      details.push(`${aggregate.needs_review_count} needs review`);
+    }
+    if (aggregate.failed_count != null && aggregate.failed_count > 0) {
+      details.push(`${aggregate.failed_count} failed`);
+    }
+    if (aggregate.max_diff_percentage != null) {
+      details.push(`${aggregate.max_diff_percentage}% max diff`);
+    }
+
+    output.print(
+      `  ${colors.bold(group.name)}${displayState ? ` ${tone(displayState.toUpperCase())}` : ''}`
+    );
+    if (details.length > 0) {
+      output.print(`    ${colors.dim(details.join(' · '))}`);
+    }
+
+    for (let variant of group.variants.slice(0, 3)) {
+      let variantDetails = [
+        variant.review_state,
+        variant.browser,
+        formatViewport(variant.viewport),
+      ].filter(Boolean);
+      output.print(
+        `    ${getStatusTone(colors, variant.result)((variant.result || 'unknown').toUpperCase())}${variantDetails.length > 0 ? ` · ${colors.dim(variantDetails.join(' · '))}` : ''}`
+      );
+    }
+  }
+
+  if (groups.length > visibleGroups.length) {
+    output.print(
+      `    ${colors.dim(`...${groups.length - visibleGroups.length} more groups`)}`
+    );
+  }
+}
+
+function printFailedCaptures(output, captures = []) {
+  let colors = output.getColors();
+
+  output.print('  Failed captures');
+  for (let capture of captures.slice(0, 8)) {
+    let details = [
+      capture.error_message,
+      capture.browser,
+      formatViewport(capture.viewport),
+      capture.screenshot.url,
+    ].filter(Boolean);
+    output.print(
+      `  ${colors.bold(capture.name)} ${colors.brand.error('FAILED')}`
+    );
+    if (details.length > 0) {
+      output.print(`    ${colors.dim(details.join(' · '))}`);
+    }
+  }
+}
+
+function formatReviewSummary(review = {}) {
+  let details = [
+    review.pending != null ? `${review.pending} pending` : null,
+    review.approved != null ? `${review.approved} approved` : null,
+    review.rejected != null ? `${review.rejected} rejected` : null,
+  ].filter(Boolean);
+
+  return details.length > 0 ? details.join(' · ') : null;
+}
+
 function displayBuildContext(output, context) {
   output.header('context', 'build');
 
+  let normalizedContext = normalizeBuildContext(context);
   let colors = output.getColors();
-  let buildTone = getStatusTone(colors, context.build.status);
-  let comparisons = context.comparisons || [];
-  let screenshots = context.screenshots || [];
-  let reviewSummary = context.summary?.review || {};
-  let commentsSummary = context.summary?.comments || {};
-  let needsReview = formatNeedsReview(context.status);
-  let baseline = context.baseline?.selected || null;
+  let build = normalizedContext.build || {};
+  let buildTone = getStatusTone(colors, build.status);
+  let comparisons = normalizedContext.comparisons;
+  let groups = normalizedContext.groups;
+  let screenshots = normalizedContext.screenshots || [];
+  let failedCaptures = normalizedContext.failed_captures;
+  let reviewSummary = formatReviewSummary(normalizedContext.summary?.review);
+  let commentsSummary = normalizedContext.summary?.comments || {};
+  let needsReview = formatNeedsReview(normalizedContext.status);
+  let baseline = normalizedContext.baseline?.selected || null;
+  let comparisonCount =
+    normalizedContext.summary?.comparisons?.total ??
+    normalizedContext.total_comparisons ??
+    (Array.isArray(context.comparisons) ? comparisons.length : null);
+  let screenshotCount =
+    normalizedContext.summary?.screenshots?.total ??
+    normalizedContext.screenshot_count ??
+    (Array.isArray(context.screenshots) ? screenshots.length : null);
 
   output.print(
-    `  ${colors.bold(context.build.name || context.build.id)} ${buildTone((context.build.status || 'unknown').toUpperCase())}`
+    `  ${colors.bold(build.name || build.id || 'unknown build')} ${buildTone((build.status || 'unknown').toUpperCase())}`
   );
   output.print(
-    `  ${colors.dim(`@${context.scope.organization.slug}/${context.scope.project.slug}`)}`
+    `  ${colors.dim(`@${normalizedContext.scope?.organization?.slug || 'unknown'}/${normalizedContext.scope?.project?.slug || 'unknown'}`)}`
   );
   output.blank();
 
-  output.labelValue('Comparisons', String(comparisons.length));
-  if (screenshots.length > 0) {
-    output.labelValue('Screenshots', String(screenshots.length));
+  if (comparisonCount != null) {
+    output.labelValue('Comparisons', String(comparisonCount));
+  }
+  if (groups.length > 0) {
+    output.labelValue('Screenshot Groups', String(groups.length));
+  }
+  if (screenshotCount != null) {
+    output.labelValue('Screenshots', String(screenshotCount));
   }
   if (baseline) {
     output.labelValue(
       'Baseline',
-      `${baseline.name || baseline.id || 'selected'}${context.baseline.selection_reason ? ` · ${context.baseline.selection_reason}` : ''}`
+      `${baseline.name || baseline.id || 'selected'}${normalizedContext.baseline.selection_reason ? ` · ${normalizedContext.baseline.selection_reason}` : ''}`
     );
   }
   if (needsReview) {
     output.labelValue('Needs Review', needsReview);
   }
-  output.labelValue(
-    'Review',
-    `${reviewSummary.pending || 0} pending · ${reviewSummary.approved || 0} approved · ${reviewSummary.rejected || 0} rejected`
-  );
-  output.labelValue(
-    'Memory',
-    `${commentsSummary.build ?? getBuildCommentsCount(context)} build comments · ${commentsSummary.screenshot ?? getScreenshotCommentsCount(context)} screenshot comments · ${getReviewAssignmentsCount(context)} assignments`
-  );
+  if (reviewSummary) {
+    output.labelValue('Review', reviewSummary);
+  }
 
-  if (context.preview) {
-    let previewUrl = context.preview.preview_url || context.preview.url;
+  let buildComments =
+    commentsSummary.build ??
+    (Array.isArray(normalizedContext.comments?.build)
+      ? getBuildCommentsCount(normalizedContext)
+      : null);
+  let screenshotComments =
+    commentsSummary.screenshot ??
+    (Number.isInteger(normalizedContext.comments?.screenshot_count)
+      ? getScreenshotCommentsCount(normalizedContext)
+      : null);
+  let assignments = Array.isArray(normalizedContext.review?.assignments)
+    ? getReviewAssignmentsCount(normalizedContext)
+    : null;
+  let memory = [
+    buildComments != null ? `${buildComments} build comments` : null,
+    screenshotComments != null
+      ? `${screenshotComments} screenshot comments`
+      : null,
+    assignments != null ? `${assignments} assignments` : null,
+  ].filter(Boolean);
+  if (memory.length > 0) {
+    output.labelValue('Memory', memory.join(' · '));
+  }
+
+  if (normalizedContext.preview) {
+    let previewUrl =
+      normalizedContext.preview.preview_url || normalizedContext.preview.url;
     output.labelValue(
       'Preview',
-      `${context.preview.status || 'unknown'}${previewUrl ? ' · available' : ''}`
+      `${normalizedContext.preview.status || 'unknown'}${previewUrl ? ' · available' : ''}`
     );
   }
 
-  if (context.links?.build_url) {
-    output.labelValue('Build URL', context.links.build_url);
+  if (normalizedContext.links?.build_url) {
+    output.labelValue('Build URL', normalizedContext.links.build_url);
   }
 
-  if (comparisons.length > 0) {
+  if (groups.length > 0) {
     output.blank();
-    output.print('  Comparisons');
-    printComparisonList(output, comparisons);
+    printScreenshotGroups(output, groups);
+  }
+
+  if (failedCaptures.length > 0) {
+    output.blank();
+    printFailedCaptures(output, failedCaptures);
   }
 }
 

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -1,3 +1,9 @@
+/**
+ * Read the API's canonical visual-review state with legacy approval fallbacks.
+ *
+ * @param {Object} record - Comparison or review record from the API.
+ * @returns {string|null} The review state when the API supplied one.
+ */
 export function getVisualReviewState(record = {}) {
   return (
     record.visual_review?.state ||
@@ -7,10 +13,22 @@ export function getVisualReviewState(record = {}) {
   );
 }
 
+/**
+ * Keep visual outcome separate from processing status when both are available.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {string|null} The visual result, or the legacy status fallback.
+ */
 export function getComparisonResult(comparison = {}) {
   return comparison.result || comparison.status || null;
 }
 
+/**
+ * Resolve a screenshot name across current and legacy response shapes.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {string|null} The first API-provided name or identity fallback.
+ */
 export function getComparisonName(comparison = {}) {
   return (
     comparison.name ||
@@ -23,6 +41,12 @@ export function getComparisonName(comparison = {}) {
   );
 }
 
+/**
+ * Resolve CSS viewport dimensions without confusing them with bitmap size.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {{width: number|null, height: number|null}|null} Viewport dimensions.
+ */
 export function getComparisonViewport(comparison = {}) {
   let current = comparison.current_screenshot || comparison.screenshot || {};
   let viewport = comparison.viewport || current.viewport || {};
@@ -42,6 +66,12 @@ export function getComparisonViewport(comparison = {}) {
   return width != null || height != null ? { width, height } : null;
 }
 
+/**
+ * Resolve the browser from nested current screenshot or legacy metadata fields.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {string|null} The browser name when present.
+ */
 export function getComparisonBrowser(comparison = {}) {
   return (
     comparison.browser ||
@@ -54,6 +84,13 @@ export function getComparisonBrowser(comparison = {}) {
   );
 }
 
+/**
+ * Resolve bitmap dimensions from nested or flat screenshot fields.
+ *
+ * @param {Object} record - Preferred screenshot record.
+ * @param {Object} fallback - Legacy fields to use when the record is incomplete.
+ * @returns {{width: number|null, height: number|null}|null} Bitmap dimensions.
+ */
 function getBitmap(record = {}, fallback = {}) {
   let bitmap = record.bitmap || fallback.bitmap || {};
   let width =
@@ -64,6 +101,13 @@ function getBitmap(record = {}, fallback = {}) {
   return width != null || height != null ? { width, height } : null;
 }
 
+/**
+ * Resolve viewport dimensions from one screenshot-shaped record.
+ *
+ * @param {Object} record - Preferred screenshot record.
+ * @param {Object} fallback - Legacy fields to use when the record is incomplete.
+ * @returns {{width: number|null, height: number|null}|null} Viewport dimensions.
+ */
 function getRecordViewport(record = {}, fallback = {}) {
   let viewport = record.viewport || fallback.viewport || {};
   let width =
@@ -77,6 +121,12 @@ function getRecordViewport(record = {}, fallback = {}) {
   return width != null || height != null ? { width, height } : null;
 }
 
+/**
+ * Normalize current screenshot identity, render facts, metadata, and asset URL.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {Object} A stable current screenshot projection.
+ */
 function getCurrentScreenshot(comparison = {}) {
   let screenshot = comparison.current_screenshot || comparison.screenshot || {};
 
@@ -120,6 +170,12 @@ function getCurrentScreenshot(comparison = {}) {
   };
 }
 
+/**
+ * Normalize the baseline screenshot without inventing missing render facts.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {Object} A stable baseline screenshot projection.
+ */
 function getBaselineScreenshot(comparison = {}) {
   let current = comparison.current_screenshot || comparison.screenshot || {};
   let baseline =
@@ -147,6 +203,12 @@ function getBaselineScreenshot(comparison = {}) {
   };
 }
 
+/**
+ * Project compact Honeydiff facts while leaving raw region geometry untouched.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @returns {Object} Compact diff evidence suitable for context summaries.
+ */
 function getComparisonDiff(comparison = {}) {
   let diff =
     comparison.diff || comparison.diff_image || comparison.analysis || {};
@@ -180,6 +242,13 @@ function getComparisonDiff(comparison = {}) {
   };
 }
 
+/**
+ * Prefer explicit review need and return null when the API supplied no review fact.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @param {string|null} reviewState - Canonical review state for the record.
+ * @returns {boolean|null} Whether the comparison needs review, when known.
+ */
 function comparisonNeedsReview(comparison = {}, reviewState = null) {
   if (comparison.needs_review != null) {
     return comparison.needs_review === true;
@@ -192,6 +261,14 @@ function comparisonNeedsReview(comparison = {}, reviewState = null) {
   return reviewState === 'pending';
 }
 
+/**
+ * Normalize one comparison across grouped and legacy flat API response shapes.
+ *
+ * @param {Object} comparison - Comparison record from the API.
+ * @param {Object} options - Normalization options.
+ * @param {string|null} [options.fallbackName] - Group name for unnamed variants.
+ * @returns {Object} A stable comparison evidence record.
+ */
 export function normalizeComparisonRecord(comparison = {}, options = {}) {
   let reviewState = getVisualReviewState(comparison);
   let name =
@@ -223,12 +300,26 @@ export function normalizeComparisonRecord(comparison = {}, options = {}) {
   };
 }
 
+/**
+ * Read the server's total variant count across supported response shapes.
+ *
+ * @param {Object} group - Screenshot group from the API.
+ * @returns {number|null} The explicit total when present.
+ */
 function getExplicitVariantCount(group = {}) {
   return (
     group.variant_count ?? group.total_variants ?? group.totalVariants ?? null
   );
 }
 
+/**
+ * Prove whether every variant is available before deriving aggregate facts.
+ *
+ * @param {Object} group - Screenshot group from the API.
+ * @param {Object[]} variants - Returned normalized variants.
+ * @param {boolean} forcedComplete - Whether the caller owns the complete set.
+ * @returns {boolean} Whether aggregate derivation is safe.
+ */
 function hasCompleteVariants(
   group = {},
   variants = [],
@@ -242,6 +333,16 @@ function hasCompleteVariants(
   return explicitCount != null && explicitCount === variants.length;
 }
 
+/**
+ * Derive only facts backed by a complete variant set and complete source fields.
+ *
+ * Unknown review, flaky, result, or diff values stay null instead of becoming
+ * client-authored false or zero values.
+ *
+ * @param {Object[]} variants - Complete normalized variants for one screenshot.
+ * @param {boolean} complete - Whether every variant is present.
+ * @returns {Object} Exact derived aggregate facts, or an empty object.
+ */
 function deriveAggregateFacts(variants = [], complete = false) {
   if (!complete) {
     return {};
@@ -292,6 +393,14 @@ function deriveAggregateFacts(variants = [], complete = false) {
   };
 }
 
+/**
+ * Normalize a screenshot group while keeping explicit server aggregates authoritative.
+ *
+ * @param {Object} group - Grouped visual-review record from the API.
+ * @param {Object} options - Normalization options.
+ * @param {boolean} [options.variantsComplete] - Marks a caller-owned complete set.
+ * @returns {Object} A normalized screenshot group and its variants.
+ */
 export function normalizeComparisonGroup(group = {}, options = {}) {
   let rawVariants = group.variants || group.comparisons || [];
   let groupName = group.name || group.test_name || group.testName || null;
@@ -333,6 +442,12 @@ export function normalizeComparisonGroup(group = {}, options = {}) {
   };
 }
 
+/**
+ * Group a complete legacy flat comparison list by screenshot name.
+ *
+ * @param {Object[]} comparisons - Complete flat comparisons from build context.
+ * @returns {Object[]} Normalized screenshot groups in API order.
+ */
 function groupFlatComparisons(comparisons = []) {
   let grouped = new Map();
 
@@ -348,6 +463,12 @@ function groupFlatComparisons(comparisons = []) {
   );
 }
 
+/**
+ * Keep failed capture identity, render evidence, and the API error together.
+ *
+ * @param {Object} screenshot - Failed screenshot record from the API.
+ * @returns {Object} A normalized failed-capture record.
+ */
 function normalizeFailedCapture(screenshot = {}) {
   let normalized = normalizeComparisonRecord({
     ...screenshot,
@@ -362,6 +483,12 @@ function normalizeFailedCapture(screenshot = {}) {
   };
 }
 
+/**
+ * Collect failed captures from explicit and screenshot-list response shapes.
+ *
+ * @param {Object} context - Raw build context response.
+ * @returns {Object[]} Deduplicated failed captures in API order.
+ */
 function getFailedCaptures(context = {}) {
   let explicit = Array.isArray(context.failed_captures)
     ? context.failed_captures
@@ -384,6 +511,14 @@ function getFailedCaptures(context = {}) {
   });
 }
 
+/**
+ * Adapt raw build context for human presentation across current and legacy APIs.
+ *
+ * Raw JSON output intentionally bypasses this lossy presentation boundary.
+ *
+ * @param {Object} context - Raw build context response from the provider.
+ * @returns {Object} Normalized comparisons, groups, and failed captures.
+ */
 export function normalizeBuildContext(context = {}) {
   let rawComparisons = context.comparisons || [];
   let comparisons = rawComparisons.map(comparison =>

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -16,6 +16,7 @@ export function getComparisonName(comparison = {}) {
     comparison.name ||
     comparison.screenshot_name ||
     comparison.current_screenshot?.name ||
+    comparison.screenshot?.name ||
     comparison.current_name ||
     comparison.id ||
     null
@@ -51,4 +52,352 @@ export function getComparisonBrowser(comparison = {}) {
     comparison.current_metadata?.properties?.browser ||
     null
   );
+}
+
+function getBitmap(record = {}, fallback = {}) {
+  let bitmap = record.bitmap || fallback.bitmap || {};
+  let width =
+    bitmap.width ?? record.bitmap_width ?? fallback.bitmap_width ?? null;
+  let height =
+    bitmap.height ?? record.bitmap_height ?? fallback.bitmap_height ?? null;
+
+  return width != null || height != null ? { width, height } : null;
+}
+
+function getRecordViewport(record = {}, fallback = {}) {
+  let viewport = record.viewport || fallback.viewport || {};
+  let width =
+    viewport.width ?? record.viewport_width ?? fallback.viewport_width ?? null;
+  let height =
+    viewport.height ??
+    record.viewport_height ??
+    fallback.viewport_height ??
+    null;
+
+  return width != null || height != null ? { width, height } : null;
+}
+
+function getCurrentScreenshot(comparison = {}) {
+  let screenshot = comparison.current_screenshot || comparison.screenshot || {};
+
+  return {
+    id: screenshot.id || comparison.current_screenshot_id || null,
+    name: screenshot.name || getComparisonName(comparison),
+    status: screenshot.status || comparison.screenshot_status || null,
+    browser: screenshot.browser || getComparisonBrowser(comparison),
+    device: screenshot.device || comparison.device || null,
+    viewport:
+      getRecordViewport(screenshot, {
+        viewport: comparison.viewport,
+        viewport_width:
+          comparison.current_viewport_width ?? comparison.viewport_width,
+        viewport_height:
+          comparison.current_viewport_height ?? comparison.viewport_height,
+      }) || getComparisonViewport(comparison),
+    bitmap: getBitmap(screenshot, {
+      bitmap: comparison.bitmap,
+      bitmap_width: comparison.current_width ?? comparison.bitmap_width,
+      bitmap_height: comparison.current_height ?? comparison.bitmap_height,
+    }),
+    metadata:
+      screenshot.metadata ||
+      comparison.current_metadata ||
+      comparison.metadata ||
+      null,
+    signature:
+      screenshot.signature ||
+      comparison.current_signature ||
+      comparison.signature ||
+      null,
+    url:
+      screenshot.url ||
+      screenshot.original_url ||
+      comparison.current_url ||
+      comparison.current_original_url ||
+      comparison.current_screenshot_url ||
+      null,
+    error_message: screenshot.error_message || comparison.error_message || null,
+  };
+}
+
+function getBaselineScreenshot(comparison = {}) {
+  let current = comparison.current_screenshot || comparison.screenshot || {};
+  let baseline =
+    comparison.baseline_screenshot ||
+    comparison.baseline ||
+    current.baseline ||
+    {};
+
+  return {
+    id: baseline.id || comparison.baseline_screenshot_id || null,
+    build_id: baseline.build_id || comparison.baseline_build_id || null,
+    name: baseline.name || comparison.baseline_name || null,
+    browser: baseline.browser || null,
+    viewport: getRecordViewport(baseline),
+    bitmap: getBitmap(baseline),
+    metadata: baseline.metadata || comparison.baseline_metadata || null,
+    signature: baseline.signature || comparison.baseline_signature || null,
+    url:
+      baseline.url ||
+      baseline.original_url ||
+      comparison.baseline_url ||
+      comparison.baseline_original_url ||
+      comparison.baseline_screenshot_url ||
+      null,
+  };
+}
+
+function getComparisonDiff(comparison = {}) {
+  let diff =
+    comparison.diff || comparison.diff_image || comparison.analysis || {};
+  let regions = diff.regions || diff.diff_regions || comparison.diff_regions;
+  let projection =
+    diff.projection ||
+    diff.analysis_projection ||
+    comparison.analysis_projection ||
+    comparison.projection ||
+    null;
+
+  return {
+    percentage: diff.percentage ?? comparison.diff_percentage ?? null,
+    changed_pixels: diff.changed_pixels ?? comparison.changed_pixels ?? null,
+    total_pixels: diff.total_pixels ?? comparison.total_pixels ?? null,
+    threshold: diff.threshold ?? comparison.threshold ?? null,
+    fingerprint_hash:
+      diff.fingerprint_hash || comparison.fingerprint_hash || null,
+    region_count:
+      diff.region_count ??
+      comparison.region_count ??
+      projection?.clusters?.count ??
+      (Array.isArray(regions) ? regions.length : null),
+    projection,
+    image_url:
+      diff.image_url ||
+      diff.url ||
+      comparison.diff_url ||
+      comparison.diff_image_url ||
+      null,
+  };
+}
+
+function comparisonNeedsReview(comparison = {}, reviewState = null) {
+  if (comparison.needs_review != null) {
+    return comparison.needs_review === true;
+  }
+
+  if (reviewState == null) {
+    return null;
+  }
+
+  return reviewState === 'pending';
+}
+
+export function normalizeComparisonRecord(comparison = {}, options = {}) {
+  let reviewState = getVisualReviewState(comparison);
+  let name =
+    comparison.name ||
+    comparison.screenshot_name ||
+    comparison.current_screenshot?.name ||
+    comparison.screenshot?.name ||
+    comparison.current_name ||
+    options.fallbackName ||
+    comparison.id ||
+    null;
+
+  return {
+    id: comparison.id || null,
+    name,
+    result: getComparisonResult(comparison),
+    status: comparison.status || null,
+    review_state: reviewState,
+    visual_review: comparison.visual_review || null,
+    approval_status: comparison.approval_status || null,
+    build_branch: comparison.build_branch || null,
+    needs_review: comparisonNeedsReview(comparison, reviewState),
+    is_flaky: comparison.is_flaky == null ? null : comparison.is_flaky === true,
+    browser: getComparisonBrowser(comparison),
+    viewport: getComparisonViewport(comparison),
+    screenshot: getCurrentScreenshot(comparison),
+    baseline: getBaselineScreenshot(comparison),
+    diff: getComparisonDiff(comparison),
+  };
+}
+
+function getExplicitVariantCount(group = {}) {
+  return (
+    group.variant_count ?? group.total_variants ?? group.totalVariants ?? null
+  );
+}
+
+function hasCompleteVariants(
+  group = {},
+  variants = [],
+  forcedComplete = false
+) {
+  if (forcedComplete || group.variants_complete === true) {
+    return true;
+  }
+
+  let explicitCount = getExplicitVariantCount(group);
+  return explicitCount != null && explicitCount === variants.length;
+}
+
+function deriveAggregateFacts(variants = [], complete = false) {
+  if (!complete) {
+    return {};
+  }
+
+  let results = variants.map(variant => variant.result);
+  let reviewStates = variants.map(variant => variant.review_state);
+  let needsReview = variants.map(variant => variant.needs_review);
+  let flaky = variants.map(variant => variant.is_flaky);
+  let percentages = variants
+    .map(variant => variant.diff.percentage)
+    .filter(value => value != null);
+  let allResultsKnown = results.every(value => value != null);
+  let allReviewStatesKnown = reviewStates.every(value => value != null);
+  let allNeedsReviewKnown = needsReview.every(value => value != null);
+  let allFlakyKnown = flaky.every(value => value != null);
+
+  return {
+    has_changes: results.includes('changed')
+      ? true
+      : allResultsKnown
+        ? false
+        : null,
+    has_new: results.includes('new') ? true : allResultsKnown ? false : null,
+    all_approved:
+      variants.length > 0 && allReviewStatesKnown
+        ? reviewStates.every(state => state === 'approved')
+        : null,
+    needs_review: allNeedsReviewKnown
+      ? needsReview.some(value => value === true)
+      : null,
+    needs_review_count: allNeedsReviewKnown
+      ? needsReview.filter(value => value === true).length
+      : null,
+    failed_count: allResultsKnown
+      ? results.filter(result => ['failed', 'error'].includes(result)).length
+      : null,
+    has_rejected: reviewStates.includes('rejected')
+      ? true
+      : allReviewStatesKnown
+        ? false
+        : null,
+    has_flaky: flaky.includes(true) ? true : allFlakyKnown ? false : null,
+    max_diff_percentage:
+      percentages.length === variants.length && percentages.length > 0
+        ? Math.max(...percentages)
+        : null,
+  };
+}
+
+export function normalizeComparisonGroup(group = {}, options = {}) {
+  let rawVariants = group.variants || group.comparisons || [];
+  let groupName = group.name || group.test_name || group.testName || null;
+  let variants = rawVariants.map(variant =>
+    normalizeComparisonRecord(variant, { fallbackName: groupName })
+  );
+  let complete = hasCompleteVariants(
+    group,
+    variants,
+    options.variantsComplete === true
+  );
+  let derived = deriveAggregateFacts(variants, complete);
+  let aggregate = group.aggregate_status || {};
+  let needsReviewCount =
+    aggregate.needs_review_count ?? derived.needs_review_count ?? null;
+
+  return {
+    name: groupName || variants[0]?.name || 'unknown screenshot',
+    variant_count:
+      getExplicitVariantCount(group) ?? (complete ? variants.length : null),
+    variants_complete: complete,
+    variants,
+    aggregate_status: {
+      has_changes: aggregate.has_changes ?? derived.has_changes ?? null,
+      has_new: aggregate.has_new ?? derived.has_new ?? null,
+      all_approved: aggregate.all_approved ?? derived.all_approved ?? null,
+      needs_review:
+        aggregate.needs_review ??
+        (aggregate.needs_review_count != null
+          ? aggregate.needs_review_count > 0
+          : (derived.needs_review ?? null)),
+      needs_review_count: needsReviewCount,
+      failed_count: aggregate.failed_count ?? derived.failed_count ?? null,
+      has_rejected: aggregate.has_rejected ?? derived.has_rejected ?? null,
+      has_flaky: aggregate.has_flaky ?? derived.has_flaky ?? null,
+      max_diff_percentage:
+        aggregate.max_diff_percentage ?? derived.max_diff_percentage ?? null,
+    },
+  };
+}
+
+function groupFlatComparisons(comparisons = []) {
+  let grouped = new Map();
+
+  for (let comparison of comparisons) {
+    let name = getComparisonName(comparison) || 'unknown screenshot';
+    let group = grouped.get(name) || { name, variants: [] };
+    group.variants.push(comparison);
+    grouped.set(name, group);
+  }
+
+  return [...grouped.values()].map(group =>
+    normalizeComparisonGroup(group, { variantsComplete: true })
+  );
+}
+
+function normalizeFailedCapture(screenshot = {}) {
+  let normalized = normalizeComparisonRecord({
+    ...screenshot,
+    screenshot,
+    result: screenshot.result || screenshot.status || 'failed',
+  });
+
+  return {
+    ...normalized,
+    error_message:
+      screenshot.error_message || normalized.screenshot.error_message || null,
+  };
+}
+
+function getFailedCaptures(context = {}) {
+  let explicit = Array.isArray(context.failed_captures)
+    ? context.failed_captures
+    : Array.isArray(context.failed_screenshots)
+      ? context.failed_screenshots
+      : [];
+  let screenshots = (context.screenshots || []).filter(screenshot =>
+    ['failed', 'error'].includes(screenshot.status)
+  );
+  let captures = [...explicit, ...screenshots];
+  let seen = new Set();
+
+  return captures.map(normalizeFailedCapture).filter(capture => {
+    let key = capture.id || capture.screenshot.signature || capture.name;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function normalizeBuildContext(context = {}) {
+  let rawComparisons = context.comparisons || [];
+  let comparisons = rawComparisons.map(comparison =>
+    normalizeComparisonRecord(comparison)
+  );
+  let groups =
+    Array.isArray(context.groups) && context.groups.length > 0
+      ? context.groups.map(group => normalizeComparisonGroup(group))
+      : groupFlatComparisons(rawComparisons);
+
+  return {
+    ...context,
+    comparisons,
+    groups,
+    failed_captures: getFailedCaptures(context),
+  };
 }

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -563,6 +563,113 @@ describe('commands/context', () => {
       assert.ok(printLines.some(line => line.includes('needs review')));
     });
 
+    it('renders grouped review facts and failed captures without replacing server aggregates', async () => {
+      let output = createMockOutput();
+
+      await contextBuildCommand(
+        'build-1',
+        {},
+        {},
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => ({
+            resource: 'build_context',
+            scope: {
+              organization: { slug: 'acme' },
+              project: { slug: 'checkout' },
+            },
+            build: {
+              id: 'build-1',
+              name: 'Grouped Review Build',
+              status: 'completed',
+            },
+            groups: [
+              {
+                name: 'Checkout',
+                variant_count: 8,
+                aggregate_status: {
+                  has_changes: false,
+                  has_new: false,
+                  all_approved: true,
+                  needs_review: false,
+                  needs_review_count: 0,
+                  failed_count: 0,
+                  max_diff_percentage: 0,
+                },
+                variants: [
+                  {
+                    id: 'partial-variant',
+                    result: 'changed',
+                    visual_review: { state: 'pending' },
+                    browser: 'chromium',
+                    viewport: { width: 375, height: 667 },
+                  },
+                ],
+              },
+              {
+                name: 'Payment',
+                variant_count: 6,
+                aggregate_status: {
+                  needs_review: true,
+                  needs_review_count: 3,
+                  failed_count: 2,
+                },
+                variants: [],
+              },
+            ],
+            screenshots: [
+              {
+                id: 'failed-capture',
+                name: 'Settings',
+                status: 'failed',
+                error_message: 'Browser render failed',
+                browser: 'webkit',
+                viewport: { width: 1280, height: 720 },
+                url: 'https://cdn.test/failed-current.png',
+              },
+            ],
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let lines = output.calls
+        .filter(call => call.method === 'print')
+        .map(call => call.args[0]);
+      let checkoutIndex = lines.findIndex(line =>
+        line.includes('Checkout APPROVED')
+      );
+      let paymentIndex = lines.findIndex(line =>
+        line.includes('Payment FAILED')
+      );
+
+      assert.ok(lines.some(line => line.includes('Screenshot groups')));
+      assert.ok(checkoutIndex >= 0);
+      assert.ok(paymentIndex > checkoutIndex);
+      assert.ok(
+        lines.some(line => line.includes('8 variants · 0 needs review'))
+      );
+      assert.ok(
+        lines.some(line =>
+          line.includes('6 variants · 3 needs review · 2 failed')
+        )
+      );
+      assert.ok(lines.some(line => line.includes('Failed captures')));
+      assert.ok(lines.some(line => line.includes('Settings FAILED')));
+      assert.ok(
+        lines.some(
+          line =>
+            line.includes('Browser render failed') &&
+            line.includes('https://cdn.test/failed-current.png')
+        )
+      );
+    });
+
     it('prints compact agent context for local and cloud build handoff', async () => {
       let output = createMockOutput();
 

--- a/tests/utils/visual-context-normalizers.test.js
+++ b/tests/utils/visual-context-normalizers.test.js
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  normalizeBuildContext,
+  normalizeComparisonGroup,
+} from '../../src/utils/visual-context-normalizers.js';
+
+describe('visual context normalizers', () => {
+  it('groups complete legacy comparisons without losing visual evidence', () => {
+    let context = normalizeBuildContext({
+      comparisons: [
+        {
+          id: 'comparison-mobile',
+          screenshot_name: 'Checkout',
+          result: 'changed',
+          approval_status: 'pending',
+          current_screenshot_id: 'current-mobile',
+          current_browser: 'chromium',
+          current_viewport_width: 375,
+          current_viewport_height: 667,
+          current_width: 398,
+          current_height: 2942,
+          current_metadata: { properties: { scenario: 'long-cart' } },
+          current_signature: 'Checkout|375|chromium|long-cart',
+          current_original_url: 'https://cdn.test/current.png',
+          baseline_screenshot_id: 'baseline-mobile',
+          baseline_build_id: 'baseline-build',
+          baseline_original_url: 'https://cdn.test/baseline.png',
+          diff_image_url: 'https://cdn.test/diff.png',
+          diff_percentage: 2.5,
+          fingerprint_hash: 'fp-checkout',
+          analysis_projection: { clusters: { count: 2 } },
+        },
+        {
+          id: 'comparison-desktop',
+          screenshot_name: 'Checkout',
+          result: 'identical',
+          visual_review: { state: 'approved' },
+        },
+      ],
+    });
+
+    assert.strictEqual(context.groups.length, 1);
+    let group = context.groups[0];
+    let comparison = group.variants[0];
+
+    assert.strictEqual(group.name, 'Checkout');
+    assert.strictEqual(group.variant_count, 2);
+    assert.strictEqual(group.variants_complete, true);
+    assert.strictEqual(group.aggregate_status.needs_review_count, 1);
+    assert.strictEqual(group.aggregate_status.has_changes, true);
+    assert.strictEqual(comparison.review_state, 'pending');
+    assert.deepStrictEqual(comparison.screenshot.viewport, {
+      width: 375,
+      height: 667,
+    });
+    assert.deepStrictEqual(comparison.screenshot.bitmap, {
+      width: 398,
+      height: 2942,
+    });
+    assert.deepStrictEqual(comparison.screenshot.metadata, {
+      properties: { scenario: 'long-cart' },
+    });
+    assert.strictEqual(
+      comparison.screenshot.signature,
+      'Checkout|375|chromium|long-cart'
+    );
+    assert.strictEqual(
+      comparison.screenshot.url,
+      'https://cdn.test/current.png'
+    );
+    assert.strictEqual(
+      comparison.baseline.url,
+      'https://cdn.test/baseline.png'
+    );
+    assert.strictEqual(comparison.diff.image_url, 'https://cdn.test/diff.png');
+    assert.strictEqual(comparison.diff.fingerprint_hash, 'fp-checkout');
+    assert.strictEqual(comparison.diff.region_count, 2);
+    assert.deepStrictEqual(comparison.diff.projection, {
+      clusters: { count: 2 },
+    });
+  });
+
+  it('keeps explicit grouped aggregate false and zero values authoritative', () => {
+    let group = normalizeComparisonGroup({
+      name: 'Checkout',
+      variant_count: 8,
+      aggregate_status: {
+        has_changes: false,
+        has_new: false,
+        all_approved: true,
+        needs_review: false,
+        needs_review_count: 0,
+        failed_count: 0,
+        has_rejected: false,
+        has_flaky: false,
+        max_diff_percentage: 0,
+      },
+      variants: [
+        {
+          id: 'partial-variant',
+          result: 'changed',
+          visual_review: { state: 'pending' },
+        },
+      ],
+    });
+
+    assert.strictEqual(group.variants_complete, false);
+    assert.deepStrictEqual(group.aggregate_status, {
+      has_changes: false,
+      has_new: false,
+      all_approved: true,
+      needs_review: false,
+      needs_review_count: 0,
+      failed_count: 0,
+      has_rejected: false,
+      has_flaky: false,
+      max_diff_percentage: 0,
+    });
+
+    let partialWithoutAggregates = normalizeComparisonGroup({
+      name: 'Partial checkout',
+      variant_count: 8,
+      variants: [
+        {
+          id: 'partial-variant',
+          result: 'changed',
+          visual_review: { state: 'pending' },
+        },
+      ],
+    });
+
+    assert.strictEqual(
+      partialWithoutAggregates.aggregate_status.needs_review_count,
+      null
+    );
+    assert.strictEqual(
+      partialWithoutAggregates.aggregate_status.failed_count,
+      null
+    );
+    assert.strictEqual(
+      partialWithoutAggregates.aggregate_status.max_diff_percentage,
+      null
+    );
+  });
+
+  it('preserves aggregate-only review facts and failed capture evidence', () => {
+    let context = normalizeBuildContext({
+      groups: [
+        {
+          name: 'Payment',
+          variant_count: 8,
+          aggregate_status: {
+            needs_review: true,
+            needs_review_count: 3,
+            failed_count: 2,
+          },
+          variants: [],
+        },
+      ],
+      screenshots: [
+        {
+          id: 'failed-capture',
+          name: 'Settings',
+          status: 'failed',
+          error_message: 'Browser render failed',
+          browser: 'webkit',
+          viewport: { width: 1280, height: 720 },
+          bitmap: { width: 1280, height: 900 },
+          metadata: { route: '/settings' },
+          signature: 'Settings|1280|webkit',
+          url: 'https://cdn.test/failed-current.png',
+        },
+      ],
+    });
+
+    assert.strictEqual(
+      context.groups[0].aggregate_status.needs_review_count,
+      3
+    );
+    assert.strictEqual(context.groups[0].aggregate_status.failed_count, 2);
+    assert.strictEqual(context.failed_captures.length, 1);
+    assert.strictEqual(
+      context.failed_captures[0].error_message,
+      'Browser render failed'
+    );
+    assert.deepStrictEqual(context.failed_captures[0].screenshot.bitmap, {
+      width: 1280,
+      height: 900,
+    });
+    assert.strictEqual(
+      context.failed_captures[0].screenshot.url,
+      'https://cdn.test/failed-current.png'
+    );
+  });
+});


### PR DESCRIPTION
## Why

Build context can arrive as either legacy flat comparisons or the API's grouped visual-review response. The human CLI currently understands only the flat shape, so grouped builds can hide review aggregates, variants, and failed captures even though the API returned those facts.

## Approach

Use one normalization boundary for human build output. Explicit API aggregates remain authoritative—including `false` and `0`—and missing values stay unknown unless the response contains the complete underlying data needed for an exact derivation.

The normalized records retain current, baseline, and diff asset identity; render dimensions and metadata; canonical review state; failed-capture errors; and compact Honeydiff evidence. Human output now presents screenshot groups in API order and reports failed captures with the evidence that is actually available.

Ordinary JSON and full agent JSON still return the raw API response. Compact agent JSON, auth, pagination, ordering policy, and dynamic-content behavior are intentionally unchanged.

## Evidence

Coverage exercises complete legacy comparisons, partial grouped responses, aggregate-only groups, explicit false/zero values, missing aggregate facts, and failed captures. It verifies both the pure response contract and the terminal output users see. The full test suite and release-facing build, lint, type, and package checks pass.
