### PR TITLE
✨ Bound agent visual context

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -271,8 +271,11 @@ vizzly context build current --source local --agent
 ```
 
 Use `--json` for durable automation. Use `--agent --json` when you want the compact handoff that
-agents should read first. Add `--include screenshots,diffs,comments` for selected detail, or
-`--full` when you need the complete build context payload.
+agents should read first. It returns at most 10 actionable evidence records while preserving API
+order, with failed captures first and one variant from each screenshot group before additional
+variants. Add `--include diffs` for raw Honeydiff diagnostics on those selected records. Explicit
+`screenshots` and `comments` includes return those API collections, and `--full` returns the
+complete build context payload unchanged.
 
 Compact agent JSON:
 
@@ -311,27 +314,70 @@ Compact agent JSON:
       "new": 1
     }
   },
+  "evidence_limit": 10,
+  "evidence_returned": 1,
+  "evidence_truncated": false,
   "evidence": [
     {
+      "kind": "comparison",
       "id": "cmp-1",
       "name": "Dashboard",
       "result": "changed",
+      "review_state": "pending",
       "needs_review": true,
+      "group": {
+        "name": "Dashboard",
+        "variant_count": 2,
+        "needs_review_count": 1,
+        "failed_count": 0,
+        "max_diff_percentage": 0.42
+      },
+      "screenshot": {
+        "id": "current-1",
+        "browser": "chrome",
+        "viewport": { "width": 1440, "height": 900 },
+        "bitmap": { "width": 2880, "height": 1800 },
+        "signature": "Dashboard|1440|chrome",
+        "url": "https://.../current.png"
+      },
+      "baseline": {
+        "id": "baseline-1",
+        "build_id": "baseline-build",
+        "url": "https://.../baseline.png"
+      },
       "diff": {
         "percentage": 0.42,
         "fingerprint_hash": "00000000001ec127",
         "region_count": 12,
+        "projection": {
+          "clusters": { "count": 12 }
+        },
         "image_url": "https://..."
       }
     }
   ],
-  "next_actions": [
-    "Inspect the changed and new comparisons before editing related UI.",
-    "Use approved baselines as the expected visual behavior.",
-    "Leave approval decisions to human reviewers."
+  "suggested_commands": [
+    {
+      "label": "Inspect comparison context",
+      "command": "vizzly --json context comparison cmp-1"
+    },
+    {
+      "label": "Inspect screenshot history",
+      "command": "vizzly --json context screenshot Dashboard"
+    },
+    {
+      "label": "Load raw diff diagnostics",
+      "command": "vizzly --json context build abc123 --agent --include diffs"
+    }
   ]
 }
 ```
+
+`status`, `summary`, review state, asset URLs, and Honeydiff values come from the API. The compact
+client does not estimate processing progress or rebuild server aggregates. Its local work is
+limited to normalization, bounded evidence selection, truncation facts, and executable
+`suggested_commands`. When `evidence_truncated` is `true`, the suggestions also include a `--full`
+command.
 
 Full build context JSON:
 

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -254,10 +254,15 @@ export async function getComparison(client, comparisonId) {
  * Get build context bundle for agent and reviewer workflows
  * @param {Object} client - API client
  * @param {string} buildId - Build ID
+ * @param {Object} options - Optional query params
  * @returns {Promise<Object>} Build context bundle
  */
-export async function getBuildContext(client, buildId) {
-  return client.request(`/api/sdk/context/builds/${buildId}`);
+export async function getBuildContext(client, buildId, options = {}) {
+  let endpoint = buildEndpointWithParams(
+    `/api/sdk/context/builds/${buildId}`,
+    options
+  );
+  return client.request(endpoint);
 }
 
 /**

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -251,7 +251,12 @@ export async function getComparison(client, comparisonId) {
 }
 
 /**
- * Get build context bundle for agent and reviewer workflows
+ * Get a build context bundle at the detail level the caller can consume.
+ *
+ * Passing detail selection to the API keeps compact callers from downloading
+ * raw Honeydiff geometry by default while preserving the unfiltered endpoint
+ * for raw and full context consumers.
+ *
  * @param {Object} client - API client
  * @param {string} buildId - Build ID
  * @param {Object} options - Optional query params

--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -331,6 +331,16 @@ function getComparisonFingerprint(comparison = {}) {
   );
 }
 
+/**
+ * Decide whether a comparison belongs in the agent handoff.
+ *
+ * Explicit API review state wins because an already-reviewed visual change is
+ * not actionable. Legacy result fallback keeps older flat responses useful
+ * only when the server did not supply that review fact.
+ *
+ * @param {Object} comparison - Normalized comparison record.
+ * @returns {boolean} Whether the record is actionable evidence.
+ */
 function isEvidenceCandidate(comparison = {}) {
   if (comparison.needs_review != null) {
     return comparison.needs_review === true;
@@ -339,6 +349,15 @@ function isEvidenceCandidate(comparison = {}) {
   return ['changed', 'new', 'failed', 'error'].includes(comparison.result);
 }
 
+/**
+ * Keep the group facts needed to understand one comparison in isolation.
+ *
+ * Repeating this small server-owned summary on each record avoids returning
+ * the full, potentially unbounded group tree in compact agent output.
+ *
+ * @param {Object} group - Normalized screenshot group.
+ * @returns {Object} Compact API-backed aggregate facts for the group.
+ */
 function buildEvidenceGroup(group = {}) {
   let aggregate = group.aggregate_status || {};
 
@@ -351,6 +370,17 @@ function buildEvidenceGroup(group = {}) {
   };
 }
 
+/**
+ * Shape one normalized comparison for the bounded evidence queue.
+ *
+ * The projection keeps visual result, review state, render assets, and
+ * Honeydiff facts together so an agent can reason about a diff without
+ * joining separate collections client-side.
+ *
+ * @param {Object} comparison - Normalized comparison record.
+ * @param {Object} group - Normalized group containing the comparison.
+ * @returns {Object} One self-contained comparison evidence record.
+ */
 function buildComparisonEvidence(comparison = {}, group = {}) {
   return {
     kind: 'comparison',
@@ -370,6 +400,16 @@ function buildComparisonEvidence(comparison = {}, group = {}) {
   };
 }
 
+/**
+ * Represent a capture failure without pretending it is a comparison.
+ *
+ * Failed screenshots have useful render evidence but no comparison ID. The
+ * explicit kind and null ID prevent suggested commands from sending a
+ * screenshot identifier to the comparison endpoint.
+ *
+ * @param {Object} capture - Normalized failed screenshot capture.
+ * @returns {Object} One failed-capture evidence record.
+ */
 function buildFailedCaptureEvidence(capture = {}) {
   return {
     ...buildComparisonEvidence(capture, { name: capture.name }),
@@ -379,6 +419,15 @@ function buildFailedCaptureEvidence(capture = {}) {
   };
 }
 
+/**
+ * Read actionable variants without overriding a server-reviewed group.
+ *
+ * A false aggregate is authoritative even when a partial variant payload
+ * appears pending, which prevents the client from reopening completed work.
+ *
+ * @param {Object} group - Normalized screenshot group.
+ * @returns {Object[]} Actionable variants in API order.
+ */
 function getGroupEvidence(group = {}) {
   if (group.aggregate_status?.needs_review === false) {
     return [];
@@ -387,6 +436,16 @@ function getGroupEvidence(group = {}) {
   return (group.variants || []).filter(isEvidenceCandidate);
 }
 
+/**
+ * Interleave actionable variants across groups in their original API order.
+ *
+ * Taking one variant per group before taking second variants preserves useful
+ * breadth when the final handoff is capped and one screenshot has many device
+ * or browser variants.
+ *
+ * @param {Object[]} groups - Normalized screenshot groups.
+ * @returns {Object[]} Self-contained evidence records in breadth-first order.
+ */
 function selectBreadthFirstEvidence(groups = []) {
   let candidatesByGroup = groups.map(getGroupEvidence);
   let evidence = [];
@@ -408,6 +467,15 @@ function selectBreadthFirstEvidence(groups = []) {
   return evidence;
 }
 
+/**
+ * Quote a value only when a suggested command needs shell protection.
+ *
+ * Suggested commands are meant to be executable, so names with whitespace or
+ * apostrophes must survive copy and paste without changing their value.
+ *
+ * @param {unknown} value - CLI argument value.
+ * @returns {string} A shell-safe argument for the displayed command.
+ */
 function quoteCommandArgument(value) {
   let stringValue = String(value);
   if (/^[A-Za-z0-9._:/-]+$/.test(stringValue)) {
@@ -417,14 +485,42 @@ function quoteCommandArgument(value) {
   return `'${stringValue.replaceAll("'", `'\\''`)}'`;
 }
 
+/**
+ * Recognize both local source labels emitted across supported context shapes.
+ *
+ * @param {Object} context - Normalized context response.
+ * @returns {boolean} Whether follow-up commands must stay in local mode.
+ */
 function isLocalContext(context = {}) {
   return ['local', 'local_workspace'].includes(context.source);
 }
 
+/**
+ * Keep suggested commands on the same source as the evidence they inspect.
+ *
+ * Without the explicit local flag, an executable suggestion could silently
+ * switch to cloud context and describe a different build.
+ *
+ * @param {string} command - Base CLI command.
+ * @param {Object} context - Context that produced the command.
+ * @returns {string} Command pinned to local context when needed.
+ */
 function appendLocalSource(command, context = {}) {
   return isLocalContext(context) ? `${command} --source local` : command;
 }
 
+/**
+ * Build concrete drill-down paths from the evidence actually returned.
+ *
+ * Executable commands replace generic client-authored advice. They let an
+ * agent ask the API for deeper comparison, history, or raw diff context, and
+ * only suggest the full build when the bounded queue omitted records.
+ *
+ * @param {Object} context - Normalized build context.
+ * @param {Object[]} evidence - Evidence included in the compact handoff.
+ * @param {boolean} truncated - Whether additional evidence was omitted.
+ * @returns {{label: string, command: string}[]} Suggested CLI commands.
+ */
 function buildSuggestedCommands(
   context = {},
   evidence = [],
@@ -482,6 +578,20 @@ function buildSuggestedCommands(
   return commands;
 }
 
+/**
+ * Create the compact agent presentation without rewriting API truth.
+ *
+ * Status, summaries, review facts, assets, and Honeydiff values pass through
+ * normalization from the server. The client owns only the bounded selection,
+ * truthful truncation facts, explicit includes, and follow-up commands.
+ *
+ * @param {Object} context - Raw build context returned by the provider.
+ * @param {Object} options - Compact presentation options.
+ * @param {string|null} [options.source] - Resolved source fallback.
+ * @param {string[]} [options.include] - Explicit detail collections.
+ * @param {number} [options.evidenceLimit] - Maximum evidence record count.
+ * @returns {Object} Bounded agent build context.
+ */
 function buildAgentBuildPayload(
   context,
   { source = null, include = [], evidenceLimit = 10 } = {}

--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -142,8 +142,8 @@ function createCloudContextProvider(config, deps = {}) {
 
   return {
     source: 'cloud',
-    async getBuildContext(buildId) {
-      return await getBuildContext(client, buildId);
+    async getBuildContext(buildId, query) {
+      return await getBuildContext(client, buildId, query);
     },
     async getComparisonContext(comparisonId, query) {
       return await getComparisonContext(client, comparisonId, query);
@@ -331,170 +331,207 @@ function getComparisonFingerprint(comparison = {}) {
   );
 }
 
-function getComparisonDiffImageUrl(comparison = {}) {
-  return (
-    comparison.diff?.image_url || comparison.analysis?.diff_image_url || null
-  );
-}
-
-function getComparisonRegionCount(comparison = {}) {
-  let regions = comparison.diff?.regions || comparison.analysis?.diff_regions;
-  return Array.isArray(regions) ? regions.length : 0;
-}
-
-function getComparisonScreenshot(comparison = {}) {
-  return comparison.screenshot || {};
-}
-
-function getComparisonBaseline(comparison = {}) {
-  return comparison.baseline || comparison.screenshot?.baseline || {};
-}
-
-function buildCompactDiff(comparison = {}, includeDiffs = false) {
-  let diff = comparison.diff || comparison.analysis || {};
-  let compact = {
-    percentage: getComparisonDiffPercentage(comparison),
-    changed_pixels: diff.changed_pixels ?? comparison.changed_pixels ?? null,
-    total_pixels: diff.total_pixels ?? comparison.total_pixels ?? null,
-    threshold: diff.threshold ?? comparison.threshold ?? null,
-    fingerprint_hash: getComparisonFingerprint(comparison),
-    region_count: getComparisonRegionCount(comparison),
-    image_url: getComparisonDiffImageUrl(comparison),
-  };
-
-  if (includeDiffs) {
-    compact.regions = diff.regions || diff.diff_regions || [];
-    compact.cluster_metadata = diff.cluster_metadata || null;
-    compact.ssim_score = diff.ssim_score ?? null;
-    compact.gmsd_score = diff.gmsd_score ?? null;
-    compact.diff_lines = diff.diff_lines || [];
+function isEvidenceCandidate(comparison = {}) {
+  if (comparison.needs_review != null) {
+    return comparison.needs_review === true;
   }
 
-  return compact;
+  return ['changed', 'new', 'failed', 'error'].includes(comparison.result);
 }
 
-function buildCompactComparison(
-  comparison = {},
-  { includeDiffs = false } = {}
+function buildEvidenceGroup(group = {}) {
+  let aggregate = group.aggregate_status || {};
+
+  return {
+    name: group.name || null,
+    variant_count: group.variant_count ?? null,
+    needs_review_count: aggregate.needs_review_count ?? null,
+    failed_count: aggregate.failed_count ?? null,
+    max_diff_percentage: aggregate.max_diff_percentage ?? null,
+  };
+}
+
+function buildComparisonEvidence(comparison = {}, group = {}) {
+  return {
+    kind: 'comparison',
+    id: comparison.id,
+    name: comparison.name,
+    result: comparison.result,
+    status: comparison.status,
+    review_state: comparison.review_state,
+    visual_review: comparison.visual_review,
+    approval_status: comparison.approval_status,
+    needs_review: comparison.needs_review,
+    is_flaky: comparison.is_flaky,
+    group: buildEvidenceGroup(group),
+    screenshot: comparison.screenshot,
+    baseline: comparison.baseline,
+    diff: comparison.diff,
+  };
+}
+
+function buildFailedCaptureEvidence(capture = {}) {
+  return {
+    ...buildComparisonEvidence(capture, { name: capture.name }),
+    kind: 'failed_capture',
+    id: null,
+    error_message: capture.error_message,
+  };
+}
+
+function getGroupEvidence(group = {}) {
+  if (group.aggregate_status?.needs_review === false) {
+    return [];
+  }
+
+  return (group.variants || []).filter(isEvidenceCandidate);
+}
+
+function selectBreadthFirstEvidence(groups = []) {
+  let candidatesByGroup = groups.map(getGroupEvidence);
+  let evidence = [];
+  let variantIndex = 0;
+  let remaining = candidatesByGroup.some(candidates => candidates.length > 0);
+
+  while (remaining) {
+    remaining = false;
+    for (let groupIndex = 0; groupIndex < groups.length; groupIndex += 1) {
+      let comparison = candidatesByGroup[groupIndex][variantIndex];
+      if (comparison) {
+        evidence.push(buildComparisonEvidence(comparison, groups[groupIndex]));
+        remaining = true;
+      }
+    }
+    variantIndex += 1;
+  }
+
+  return evidence;
+}
+
+function quoteCommandArgument(value) {
+  let stringValue = String(value);
+  if (/^[A-Za-z0-9._:/-]+$/.test(stringValue)) {
+    return stringValue;
+  }
+
+  return `'${stringValue.replaceAll("'", `'\\''`)}'`;
+}
+
+function isLocalContext(context = {}) {
+  return ['local', 'local_workspace'].includes(context.source);
+}
+
+function appendLocalSource(command, context = {}) {
+  return isLocalContext(context) ? `${command} --source local` : command;
+}
+
+function buildSuggestedCommands(
+  context = {},
+  evidence = [],
+  truncated = false
 ) {
-  let screenshot = getComparisonScreenshot(comparison);
-  let baseline = getComparisonBaseline(comparison);
+  let commands = [];
+  let firstComparison = evidence.find(
+    item => item.kind === 'comparison' && item.id
+  );
+  let firstNamedEvidence = evidence.find(item => item.name);
+  let buildTarget = isLocalContext(context)
+    ? 'current'
+    : context.build?.id || null;
 
-  return {
-    id: comparison.id || null,
-    name: getComparisonName(comparison),
-    result: getComparisonDisplayState(comparison),
-    approval_status: comparison.approval_status || null,
-    needs_review: Boolean(comparison.needs_review),
-    is_flaky: Boolean(comparison.is_flaky),
-    screenshot: {
-      id: screenshot.id || null,
-      url: screenshot.url || screenshot.original_url || null,
-    },
-    baseline: {
-      id: baseline.id || null,
-      build_id: baseline.build_id || null,
-      url: baseline.url || baseline.original_url || null,
-    },
-    diff: buildCompactDiff(comparison, includeDiffs),
-  };
-}
-
-function summarizeComparisons(comparisons = []) {
-  return {
-    total: comparisons.length,
-    changed: comparisons.filter(isChangedComparison).length,
-    new: comparisons.filter(isNewComparison).length,
-    needs_review: comparisons.filter(comparison => comparison.needs_review)
-      .length,
-  };
-}
-
-function buildAgentNextActions(context = {}, comparisonSummary = {}) {
-  if (context.status?.needs_review) {
-    return [
-      'Inspect the changed and new comparisons before editing related UI.',
-      'Use approved baselines as the expected visual behavior.',
-      'Leave approval decisions to human reviewers.',
-    ];
+  if (firstComparison?.id) {
+    commands.push({
+      label: 'Inspect comparison context',
+      command: appendLocalSource(
+        `vizzly --json context comparison ${quoteCommandArgument(firstComparison.id)}`,
+        context
+      ),
+    });
   }
 
-  if (comparisonSummary.total > 0) {
-    return [
-      'Use the approved baseline and reviewed screenshots as current visual truth.',
-      'Prefer targeted edits that preserve identical comparisons.',
-    ];
+  if (firstNamedEvidence?.name) {
+    commands.push({
+      label: 'Inspect screenshot history',
+      command: appendLocalSource(
+        `vizzly --json context screenshot ${quoteCommandArgument(firstNamedEvidence.name)}`,
+        context
+      ),
+    });
   }
 
-  return [
-    'No comparisons were returned for this build context.',
-    'Open the build URL for more detail if this is unexpected.',
-  ];
-}
+  if (buildTarget && evidence.length > 0) {
+    commands.push({
+      label: 'Load raw diff diagnostics',
+      command: appendLocalSource(
+        `vizzly --json context build ${quoteCommandArgument(buildTarget)} --agent --include diffs`,
+        context
+      ),
+    });
+  }
 
-function formatAgentStatus(status = {}) {
-  return {
-    needs_review: Boolean(status.needs_review),
-    reasons: status.reasons || [],
-    pending_comparisons: status.pending_comparisons || 0,
-    unresolved_comments: status.unresolved_comments || 0,
-  };
-}
+  if (buildTarget && truncated) {
+    commands.push({
+      label: 'Load full build context',
+      command: appendLocalSource(
+        `vizzly --json context build ${quoteCommandArgument(buildTarget)} --agent --full`,
+        context
+      ),
+    });
+  }
 
-function formatAgentSummary(context = {}, comparisons = []) {
-  return {
-    comparisons:
-      context.summary?.comparisons || summarizeComparisons(comparisons),
-    review: context.summary?.review || {},
-    comments: context.summary?.comments || {
-      build: getBuildCommentsCount(context),
-      screenshot: getScreenshotCommentsCount(context),
-    },
-  };
+  return commands;
 }
 
 function buildAgentBuildPayload(
   context,
   { source = null, include = [], evidenceLimit = 10 } = {}
 ) {
-  let comparisons = context.comparisons || [];
   let includeSet = new Set(include);
   let includeDiffs = includeSet.has('diffs');
-  let changed = comparisons.filter(isChangedComparison);
-  let fresh = comparisons.filter(isNewComparison);
-  let evidence = [...changed, ...fresh]
-    .slice(0, evidenceLimit)
-    .map(comparison => buildCompactComparison(comparison, { includeDiffs }));
-  let comparisonSummary = summarizeComparisons(comparisons);
+  let normalized = normalizeBuildContext(context, { includeDiffs });
+  let candidates = [
+    ...normalized.failed_captures.map(buildFailedCaptureEvidence),
+    ...selectBreadthFirstEvidence(normalized.groups),
+  ];
+  let evidence = candidates.slice(0, evidenceLimit);
+  let evidenceTruncated = candidates.length > evidence.length;
   let payload = {
     resource: 'build_agent_context',
-    source: context.source || source || 'cloud',
-    scope: context.scope || null,
+    source: normalized.source || source || 'cloud',
+    scope: normalized.scope || null,
     project: {
-      organization: context.scope?.organization?.slug || null,
-      slug: context.scope?.project?.slug || null,
-      name: context.scope?.project?.name || null,
-      visibility: context.scope?.project?.visibility || null,
+      organization: normalized.scope?.organization?.slug || null,
+      slug: normalized.scope?.project?.slug || null,
+      name: normalized.scope?.project?.name || null,
+      visibility: normalized.scope?.project?.visibility || null,
     },
-    build: context.build || null,
+    build: normalized.build || null,
     baseline: {
-      selected: context.baseline?.selected || null,
-      selection_reason: context.baseline?.selection_reason || null,
+      selected: normalized.baseline?.selected || null,
+      selection_reason: normalized.baseline?.selection_reason || null,
     },
-    status: formatAgentStatus(context.status),
-    summary: formatAgentSummary(context, comparisons),
+    status: normalized.status || null,
+    summary: normalized.summary || null,
+    signature_properties: normalized.signature_properties ?? null,
+    evidence_limit: evidenceLimit,
+    evidence_returned: evidence.length,
+    evidence_truncated: evidenceTruncated,
     evidence,
-    links: context.links || {},
-    preview: context.preview || null,
-    next_actions: buildAgentNextActions(context, comparisonSummary),
+    links: normalized.links || {},
+    preview: normalized.preview || null,
+    suggested_commands: buildSuggestedCommands(
+      normalized,
+      evidence,
+      evidenceTruncated
+    ),
   };
 
   if (includeSet.has('screenshots')) {
-    payload.screenshots = context.screenshots || [];
+    payload.screenshots = normalized.screenshots || [];
   }
 
   if (includeSet.has('comments')) {
-    payload.comments = context.comments || {};
+    payload.comments = normalized.comments || {};
   }
 
   return payload;
@@ -1058,16 +1095,24 @@ export async function contextBuildCommand(
     }
 
     let resolvedBuildId = resolveBuildContextId(buildId, runtime, deps);
+    let include = parseIncludeOption(options.include);
+    let query =
+      globalOptions.json && options.agent && !options.full
+        ? { details: include.includes('diffs') ? 'diffs' : 'summary' }
+        : undefined;
 
     output.startSpinner('Fetching build context...');
-    let context = await runtime.provider.getBuildContext(resolvedBuildId);
+    let context = await runtime.provider.getBuildContext(
+      resolvedBuildId,
+      query
+    );
     output.stopSpinner();
 
     if (globalOptions.json && options.agent && !options.full) {
       output.data(
         buildAgentBuildPayload(context, {
           source: runtime.source,
-          include: parseIncludeOption(options.include),
+          include,
         })
       );
       output.cleanup();

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -207,28 +207,54 @@ function getBaselineScreenshot(comparison = {}) {
  * Project compact Honeydiff facts while leaving raw region geometry untouched.
  *
  * @param {Object} comparison - Comparison record from the API.
+ * @param {boolean} includeDiffs - Whether to include raw Honeydiff diagnostics.
  * @returns {Object} Compact diff evidence suitable for context summaries.
  */
-function getComparisonDiff(comparison = {}) {
+function getComparisonDiff(comparison = {}, includeDiffs = false) {
   let diff =
     comparison.diff || comparison.diff_image || comparison.analysis || {};
-  let regions = diff.regions || diff.diff_regions || comparison.diff_regions;
+  let analysis = comparison.analysis || {};
+  let regions =
+    diff.regions ||
+    diff.diff_regions ||
+    analysis.diff_regions ||
+    comparison.diff_regions;
   let projection =
     diff.projection ||
     diff.analysis_projection ||
+    analysis.projection ||
+    analysis.analysis_projection ||
     comparison.analysis_projection ||
     comparison.projection ||
     null;
 
-  return {
-    percentage: diff.percentage ?? comparison.diff_percentage ?? null,
-    changed_pixels: diff.changed_pixels ?? comparison.changed_pixels ?? null,
-    total_pixels: diff.total_pixels ?? comparison.total_pixels ?? null,
-    threshold: diff.threshold ?? comparison.threshold ?? null,
+  let compact = {
+    percentage:
+      diff.percentage ??
+      analysis.percentage ??
+      analysis.diff_percentage ??
+      comparison.diff_percentage ??
+      null,
+    changed_pixels:
+      diff.changed_pixels ??
+      analysis.changed_pixels ??
+      comparison.changed_pixels ??
+      null,
+    total_pixels:
+      diff.total_pixels ??
+      analysis.total_pixels ??
+      comparison.total_pixels ??
+      null,
+    threshold:
+      diff.threshold ?? analysis.threshold ?? comparison.threshold ?? null,
     fingerprint_hash:
-      diff.fingerprint_hash || comparison.fingerprint_hash || null,
+      diff.fingerprint_hash ||
+      analysis.fingerprint_hash ||
+      comparison.fingerprint_hash ||
+      null,
     region_count:
       diff.region_count ??
+      analysis.region_count ??
       comparison.region_count ??
       projection?.clusters?.count ??
       (Array.isArray(regions) ? regions.length : null),
@@ -236,10 +262,28 @@ function getComparisonDiff(comparison = {}) {
     image_url:
       diff.image_url ||
       diff.url ||
+      analysis.diff_image_url ||
       comparison.diff_url ||
       comparison.diff_image_url ||
       null,
   };
+
+  if (includeDiffs) {
+    compact.regions = regions || [];
+    compact.cluster_metadata =
+      diff.cluster_metadata ||
+      analysis.cluster_metadata ||
+      comparison.cluster_metadata ||
+      null;
+    compact.ssim_score =
+      diff.ssim_score ?? analysis.ssim_score ?? comparison.ssim_score ?? null;
+    compact.gmsd_score =
+      diff.gmsd_score ?? analysis.gmsd_score ?? comparison.gmsd_score ?? null;
+    compact.diff_lines =
+      diff.diff_lines || analysis.diff_lines || comparison.diff_lines || [];
+  }
+
+  return compact;
 }
 
 /**
@@ -267,6 +311,7 @@ function comparisonNeedsReview(comparison = {}, reviewState = null) {
  * @param {Object} comparison - Comparison record from the API.
  * @param {Object} options - Normalization options.
  * @param {string|null} [options.fallbackName] - Group name for unnamed variants.
+ * @param {boolean} [options.includeDiffs] - Include raw Honeydiff diagnostics.
  * @returns {Object} A stable comparison evidence record.
  */
 export function normalizeComparisonRecord(comparison = {}, options = {}) {
@@ -296,7 +341,7 @@ export function normalizeComparisonRecord(comparison = {}, options = {}) {
     viewport: getComparisonViewport(comparison),
     screenshot: getCurrentScreenshot(comparison),
     baseline: getBaselineScreenshot(comparison),
-    diff: getComparisonDiff(comparison),
+    diff: getComparisonDiff(comparison, options.includeDiffs === true),
   };
 }
 
@@ -405,7 +450,10 @@ export function normalizeComparisonGroup(group = {}, options = {}) {
   let rawVariants = group.variants || group.comparisons || [];
   let groupName = group.name || group.test_name || group.testName || null;
   let variants = rawVariants.map(variant =>
-    normalizeComparisonRecord(variant, { fallbackName: groupName })
+    normalizeComparisonRecord(variant, {
+      fallbackName: groupName,
+      includeDiffs: options.includeDiffs,
+    })
   );
   let complete = hasCompleteVariants(
     group,
@@ -446,9 +494,10 @@ export function normalizeComparisonGroup(group = {}, options = {}) {
  * Group a complete legacy flat comparison list by screenshot name.
  *
  * @param {Object[]} comparisons - Complete flat comparisons from build context.
+ * @param {Object} options - Normalization options passed to each comparison.
  * @returns {Object[]} Normalized screenshot groups in API order.
  */
-function groupFlatComparisons(comparisons = []) {
+function groupFlatComparisons(comparisons = [], options = {}) {
   let grouped = new Map();
 
   for (let comparison of comparisons) {
@@ -459,7 +508,7 @@ function groupFlatComparisons(comparisons = []) {
   }
 
   return [...grouped.values()].map(group =>
-    normalizeComparisonGroup(group, { variantsComplete: true })
+    normalizeComparisonGroup(group, { ...options, variantsComplete: true })
   );
 }
 
@@ -467,14 +516,18 @@ function groupFlatComparisons(comparisons = []) {
  * Keep failed capture identity, render evidence, and the API error together.
  *
  * @param {Object} screenshot - Failed screenshot record from the API.
+ * @param {Object} options - Normalization options passed to the record.
  * @returns {Object} A normalized failed-capture record.
  */
-function normalizeFailedCapture(screenshot = {}) {
-  let normalized = normalizeComparisonRecord({
-    ...screenshot,
-    screenshot,
-    result: screenshot.result || screenshot.status || 'failed',
-  });
+function normalizeFailedCapture(screenshot = {}, options = {}) {
+  let normalized = normalizeComparisonRecord(
+    {
+      ...screenshot,
+      screenshot,
+      result: screenshot.result || screenshot.status || 'failed',
+    },
+    options
+  );
 
   return {
     ...normalized,
@@ -487,9 +540,10 @@ function normalizeFailedCapture(screenshot = {}) {
  * Collect failed captures from explicit and screenshot-list response shapes.
  *
  * @param {Object} context - Raw build context response.
+ * @param {Object} options - Normalization options passed to each capture.
  * @returns {Object[]} Deduplicated failed captures in API order.
  */
-function getFailedCaptures(context = {}) {
+function getFailedCaptures(context = {}, options = {}) {
   let explicit = Array.isArray(context.failed_captures)
     ? context.failed_captures
     : Array.isArray(context.failed_screenshots)
@@ -501,14 +555,16 @@ function getFailedCaptures(context = {}) {
   let captures = [...explicit, ...screenshots];
   let seen = new Set();
 
-  return captures.map(normalizeFailedCapture).filter(capture => {
-    let key = capture.id || capture.screenshot.signature || capture.name;
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
+  return captures
+    .map(capture => normalizeFailedCapture(capture, options))
+    .filter(capture => {
+      let key = capture.id || capture.screenshot.signature || capture.name;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    });
 }
 
 /**
@@ -517,22 +573,24 @@ function getFailedCaptures(context = {}) {
  * Raw JSON output intentionally bypasses this lossy presentation boundary.
  *
  * @param {Object} context - Raw build context response from the provider.
+ * @param {Object} options - Normalization options.
+ * @param {boolean} [options.includeDiffs] - Include raw Honeydiff diagnostics.
  * @returns {Object} Normalized comparisons, groups, and failed captures.
  */
-export function normalizeBuildContext(context = {}) {
+export function normalizeBuildContext(context = {}, options = {}) {
   let rawComparisons = context.comparisons || [];
   let comparisons = rawComparisons.map(comparison =>
-    normalizeComparisonRecord(comparison)
+    normalizeComparisonRecord(comparison, options)
   );
   let groups =
     Array.isArray(context.groups) && context.groups.length > 0
-      ? context.groups.map(group => normalizeComparisonGroup(group))
-      : groupFlatComparisons(rawComparisons);
+      ? context.groups.map(group => normalizeComparisonGroup(group, options))
+      : groupFlatComparisons(rawComparisons, options);
 
   return {
     ...context,
     comparisons,
     groups,
-    failed_captures: getFailedCaptures(context),
+    failed_captures: getFailedCaptures(context, options),
   };
 }

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -204,7 +204,11 @@ function getBaselineScreenshot(comparison = {}) {
 }
 
 /**
- * Project compact Honeydiff facts while leaving raw region geometry untouched.
+ * Project compact Honeydiff facts without making raw geometry the default.
+ *
+ * Agents need stable counts, fingerprints, URLs, and the API projection for
+ * first-pass diagnosis. Raw regions and scoring details stay behind an
+ * explicit include because they can dominate an otherwise bounded handoff.
  *
  * @param {Object} comparison - Comparison record from the API.
  * @param {boolean} includeDiffs - Whether to include raw Honeydiff diagnostics.
@@ -514,6 +518,9 @@ function groupFlatComparisons(comparisons = [], options = {}) {
 
 /**
  * Keep failed capture identity, render evidence, and the API error together.
+ *
+ * A capture can fail before any comparison exists, so it must remain useful
+ * evidence without inheriting comparison-only assumptions.
  *
  * @param {Object} screenshot - Failed screenshot record from the API.
  * @param {Object} options - Normalization options passed to the record.

--- a/tests/api/endpoints.test.js
+++ b/tests/api/endpoints.test.js
@@ -115,6 +115,17 @@ describe('api/endpoints', () => {
       );
     });
 
+    it('includes build context detail params when provided', async () => {
+      let client = createMockClient({ resource: 'build_context' });
+
+      await getBuildContext(client, 'build-123', { details: 'summary' });
+
+      assert.strictEqual(
+        client.getLastCall().endpoint,
+        '/api/sdk/context/builds/build-123?details=summary'
+      );
+    });
+
     it('includes comparison context query params when provided', async () => {
       let client = createMockClient({ resource: 'comparison_context' });
 

--- a/tests/commands/context-cli.test.js
+++ b/tests/commands/context-cli.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -140,7 +141,133 @@ function createWorkspaceFixture() {
   return cwd;
 }
 
+async function withBuildContextApi(callback) {
+  let requests = [];
+  let groups = Array.from({ length: 11 }, (_, index) => ({
+    name: `Screenshot ${index + 1}`,
+    variant_count: 1,
+    aggregate_status: {
+      needs_review: true,
+      needs_review_count: 1,
+      max_diff_percentage: index + 0.5,
+    },
+    variants: [
+      {
+        id: `comparison-${index + 1}`,
+        result: 'changed',
+        needs_review: true,
+        visual_review: { state: 'pending' },
+        current_screenshot: {
+          id: `current-${index + 1}`,
+          name: `Screenshot ${index + 1}`,
+          browser: 'chrome',
+          viewport: { width: 1440, height: 900 },
+          bitmap: { width: 2880, height: 1800 },
+          metadata: { locale: 'en-US' },
+          signature: `Screenshot ${index + 1}|1440|chrome`,
+          url: `https://cdn.test/current-${index + 1}.png`,
+        },
+        baseline_screenshot: {
+          id: `baseline-${index + 1}`,
+          build_id: 'baseline-build',
+          url: `https://cdn.test/baseline-${index + 1}.png`,
+        },
+        analysis: {
+          diff_image_url: `https://cdn.test/diff-${index + 1}.png`,
+          fingerprint_hash: `fingerprint-${index + 1}`,
+          projection: { clusters: { count: 1 } },
+          diff_regions: [{ x: 10, y: 20, width: 30, height: 40 }],
+        },
+      },
+    ],
+  }));
+  let server = createServer((req, res) => {
+    requests.push(req.url);
+    res.setHeader('content-type', 'application/json');
+    res.end(
+      JSON.stringify({
+        resource: 'build_context',
+        source: 'cloud',
+        scope: {
+          organization: { slug: 'acme' },
+          project: { slug: 'web', name: 'Web' },
+        },
+        build: { id: 'build-123', status: 'completed' },
+        status: { needs_review: true, pending_comparisons: 11 },
+        summary: { comparisons: { total: 11, changed: 11 } },
+        groups,
+      })
+    );
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    let address = server.address();
+    await callback({
+      apiUrl: `http://127.0.0.1:${address.port}`,
+      requests,
+    });
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
 describe('context CLI integration', () => {
+  it('returns bounded API-backed agent evidence through the real CLI', async () => {
+    await withBuildContextApi(async ({ apiUrl, requests }) => {
+      let cwd = mkdtempSync(join(tmpdir(), 'vizzly-context-cloud-'));
+      let env = {
+        VIZZLY_API_URL: apiUrl,
+        VIZZLY_TOKEN: 'vzt_test_token',
+      };
+      let compact = await runCLI(
+        ['--json', 'context', 'build', 'build-123', '--agent'],
+        { cwd, env }
+      );
+
+      assert.strictEqual(compact.code, 0);
+      let compactPayload = JSON.parse(compact.stdout).data;
+      assert.strictEqual(compactPayload.evidence_returned, 10);
+      assert.strictEqual(compactPayload.evidence_truncated, true);
+      assert.strictEqual(compactPayload.evidence[0].review_state, 'pending');
+      assert.strictEqual(
+        compactPayload.evidence[0].screenshot.url,
+        'https://cdn.test/current-1.png'
+      );
+      assert.strictEqual(
+        compactPayload.evidence[0].diff.image_url,
+        'https://cdn.test/diff-1.png'
+      );
+      assert.ok(!compactPayload.evidence[0].diff.regions);
+      assert.ok(!compactPayload.groups);
+      assert.ok(!compactPayload.next_actions);
+
+      let withDiffs = await runCLI(
+        [
+          '--json',
+          'context',
+          'build',
+          'build-123',
+          '--agent',
+          '--include',
+          'diffs',
+        ],
+        { cwd, env }
+      );
+
+      assert.strictEqual(withDiffs.code, 0);
+      let diffPayload = JSON.parse(withDiffs.stdout).data;
+      assert.deepStrictEqual(diffPayload.evidence[0].diff.regions, [
+        { x: 10, y: 20, width: 30, height: 40 },
+      ]);
+      assert.deepStrictEqual(requests, [
+        '/api/sdk/context/builds/build-123?details=summary',
+        '/api/sdk/context/builds/build-123?details=diffs',
+      ]);
+    });
+  });
+
   it('treats root-level --json as a flag before the context command', async () => {
     let result = await runCLI(['--json', 'context', 'build', 'build-123']);
 

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -136,6 +136,7 @@ describe('commands/context', () => {
 
     it('returns build context in JSON mode', async () => {
       let output = createMockOutput();
+      let capturedQuery = 'not-called';
       let context = {
         resource: 'build_context',
         build: { id: 'build-1' },
@@ -152,7 +153,10 @@ describe('commands/context', () => {
             apiUrl: 'https://api.test',
           }),
           createApiClient: () => ({}),
-          getBuildContext: async () => context,
+          getBuildContext: async (_client, _buildId, query) => {
+            capturedQuery = query;
+            return context;
+          },
           output,
           exit: () => {},
         }
@@ -162,6 +166,8 @@ describe('commands/context', () => {
       assert.ok(dataCall);
       assert.strictEqual(dataCall.args[0].resource, 'build_context');
       assert.strictEqual(dataCall.args[0].build.id, 'build-1');
+      assert.strictEqual(dataCall.args[0], context);
+      assert.strictEqual(capturedQuery, undefined);
     });
 
     it('returns compact agent JSON by default instead of the full context payload', async () => {
@@ -213,6 +219,7 @@ describe('commands/context', () => {
                 id: 'cmp-1',
                 screenshot_name: 'Dashboard',
                 result: 'changed',
+                visual_review: { state: 'pending', reviewer: null },
                 needs_review: true,
                 diff: {
                   percentage: 1.23,
@@ -222,14 +229,27 @@ describe('commands/context', () => {
                   image_url: 'https://cdn.test/diff.png',
                   regions: [{ pixelCount: 50 }],
                   fingerprint_hash: 'fp-dashboard',
+                  projection: {
+                    clusters: { count: 1 },
+                    distribution: 'header',
+                  },
                 },
                 screenshot: {
                   id: 'ss-1',
+                  browser: 'chrome',
+                  device: 'desktop',
+                  viewport: { width: 1440, height: 900 },
+                  bitmap: { width: 2880, height: 1800 },
+                  metadata: { locale: 'en-US' },
+                  signature: 'Dashboard|1440|chrome',
                   original_url: 'https://cdn.test/current.png',
                 },
                 baseline: {
                   id: 'base-ss-1',
                   build_id: 'baseline-1',
+                  browser: 'chrome',
+                  viewport: { width: 1440, height: 900 },
+                  bitmap: { width: 2880, height: 1800 },
                   original_url: 'https://cdn.test/baseline.png',
                 },
               },
@@ -259,13 +279,195 @@ describe('commands/context', () => {
       assert.strictEqual(payload.baseline.selected.name, 'Approved Main');
       assert.strictEqual(payload.status.needs_review, true);
       assert.strictEqual(payload.evidence.length, 2);
+      assert.strictEqual(payload.evidence_limit, 10);
+      assert.strictEqual(payload.evidence_returned, 2);
+      assert.strictEqual(payload.evidence_truncated, false);
       assert.strictEqual(payload.evidence[0].name, 'Dashboard');
       assert.strictEqual(payload.evidence[0].diff.region_count, 1);
+      assert.deepStrictEqual(payload.evidence[0].diff.projection, {
+        clusters: { count: 1 },
+        distribution: 'header',
+      });
+      assert.strictEqual(payload.evidence[0].review_state, 'pending');
+      assert.strictEqual(payload.evidence[0].screenshot.browser, 'chrome');
+      assert.deepStrictEqual(payload.evidence[0].screenshot.viewport, {
+        width: 1440,
+        height: 900,
+      });
+      assert.strictEqual(
+        payload.evidence[0].screenshot.url,
+        'https://cdn.test/current.png'
+      );
+      assert.strictEqual(
+        payload.evidence[0].baseline.url,
+        'https://cdn.test/baseline.png'
+      );
+      assert.ok(!payload.evidence[0].diff.regions);
       assert.ok(!payload.screenshots);
       assert.ok(!payload.comments);
+      assert.ok(!payload.groups);
+      assert.ok(!payload.next_actions);
+      assert.deepStrictEqual(
+        payload.suggested_commands.map(item => item.command),
+        [
+          'vizzly --json context comparison cmp-1',
+          'vizzly --json context screenshot Dashboard',
+          'vizzly --json context build build-1 --agent --include diffs',
+        ]
+      );
+    });
+
+    it('keeps one bounded breadth-first evidence queue in API order', async () => {
+      let output = createMockOutput();
+      let groups = Array.from({ length: 6 }, (_, groupIndex) => ({
+        name: `Group ${groupIndex + 1}`,
+        variant_count: 2,
+        aggregate_status: {
+          needs_review: true,
+          needs_review_count: 2,
+        },
+        variants: Array.from({ length: 2 }, (_, variantIndex) => ({
+          id: `cmp-${groupIndex + 1}-${variantIndex + 1}`,
+          result: 'changed',
+          needs_review: true,
+        })),
+      }));
+
+      await contextBuildCommand(
+        'build-1',
+        { agent: true },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => ({
+            build: { id: 'build-1' },
+            groups,
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let payload = output.calls.find(call => call.method === 'data').args[0];
+      assert.strictEqual(payload.evidence_returned, 10);
+      assert.strictEqual(payload.evidence_truncated, true);
+      assert.deepStrictEqual(
+        payload.evidence.map(item => item.id),
+        [
+          'cmp-1-1',
+          'cmp-2-1',
+          'cmp-3-1',
+          'cmp-4-1',
+          'cmp-5-1',
+          'cmp-6-1',
+          'cmp-1-2',
+          'cmp-2-2',
+          'cmp-3-2',
+          'cmp-4-2',
+        ]
+      );
       assert.ok(
-        payload.next_actions.some(action =>
-          action.includes('Inspect the changed and new comparisons')
+        payload.suggested_commands.some(item =>
+          item.command.endsWith('--agent --full')
+        )
+      );
+    });
+
+    it('returns no compact evidence when the API marks every group reviewed', async () => {
+      let output = createMockOutput();
+
+      await contextBuildCommand(
+        'build-1',
+        { agent: true },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => ({
+            build: { id: 'build-1' },
+            groups: [
+              {
+                name: 'Dashboard',
+                aggregate_status: { needs_review: false },
+                variants: [
+                  {
+                    id: 'cmp-approved',
+                    result: 'changed',
+                    needs_review: true,
+                  },
+                ],
+              },
+            ],
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let payload = output.calls.find(call => call.method === 'data').args[0];
+      assert.strictEqual(payload.status, null);
+      assert.strictEqual(payload.summary, null);
+      assert.strictEqual(payload.evidence_returned, 0);
+      assert.deepStrictEqual(payload.evidence, []);
+      assert.deepStrictEqual(payload.suggested_commands, []);
+    });
+
+    it('keeps failed captures actionable without inventing comparison IDs', async () => {
+      let output = createMockOutput();
+
+      await contextBuildCommand(
+        'build-1',
+        { agent: true },
+        { json: true },
+        {
+          loadConfig: async () => ({
+            apiKey: 'token',
+            apiUrl: 'https://api.test',
+          }),
+          createApiClient: () => ({}),
+          getBuildContext: async () => ({
+            build: { id: 'build-1' },
+            screenshots: [
+              {
+                id: 'failed-screenshot',
+                name: 'Settings page',
+                status: 'failed',
+                error_message: 'Browser render failed',
+                url: 'https://cdn.test/failed.png',
+              },
+            ],
+          }),
+          output,
+          exit: () => {},
+        }
+      );
+
+      let payload = output.calls.find(call => call.method === 'data').args[0];
+      assert.strictEqual(payload.evidence[0].kind, 'failed_capture');
+      assert.strictEqual(payload.evidence[0].id, null);
+      assert.strictEqual(
+        payload.evidence[0].screenshot.id,
+        'failed-screenshot'
+      );
+      assert.strictEqual(
+        payload.evidence[0].error_message,
+        'Browser render failed'
+      );
+      assert.ok(
+        payload.suggested_commands.every(
+          item => !item.command.includes('context comparison')
+        )
+      );
+      assert.ok(
+        payload.suggested_commands.some(item =>
+          item.command.includes("context screenshot 'Settings page'")
         )
       );
     });
@@ -327,6 +529,7 @@ describe('commands/context', () => {
 
     it('returns the full payload when agent JSON asks for full context', async () => {
       let output = createMockOutput();
+      let capturedQuery = 'not-called';
       let context = {
         resource: 'build_context',
         build: { id: 'build-1' },
@@ -343,7 +546,10 @@ describe('commands/context', () => {
             apiUrl: 'https://api.test',
           }),
           createApiClient: () => ({}),
-          getBuildContext: async () => context,
+          getBuildContext: async (_client, _buildId, query) => {
+            capturedQuery = query;
+            return context;
+          },
           output,
           exit: () => {},
         }
@@ -352,6 +558,7 @@ describe('commands/context', () => {
       let payload = output.calls.find(call => call.method === 'data').args[0];
       assert.strictEqual(payload.resource, 'build_context');
       assert.deepStrictEqual(payload.screenshots, [{ id: 'ss-1' }]);
+      assert.strictEqual(capturedQuery, undefined);
     });
 
     it('resolves cloud current builds from the active run session', async () => {


### PR DESCRIPTION
## Why

The compact build handoff could still overwhelm an agent with duplicated group trees while also hiding the render and Honeydiff facts needed to explain a visual change. Worse, it filled missing status and summary fields with client-authored booleans and zeroes, so unknown API state could look authoritative.

## Approach

This makes the compact contract one bounded, 10-record evidence queue. Failed captures come first, then comparison variants are selected breadth-first in API order so one screenshot cannot crowd out the rest. Each record keeps its small group summary, review state, current/baseline/diff URLs, render metadata, and compact Honeydiff projection. Raw region geometry remains opt-in through `--include diffs`.

The API remains the source of truth for status, summaries, review facts, and analysis values. Raw JSON and `--agent --full` still return the API response unchanged. The compact request asks for `details=summary` by default and `details=diffs` only when requested.

This deliberately replaces generic `next_actions` prose with executable `suggested_commands` for comparison context, screenshot history, raw diff diagnostics, and the full build when evidence was truncated.

## Evidence

Coverage exercises grouped and legacy response shapes, reviewed groups, failed captures, explicit includes, raw/full pass-through, and bounded breadth-first selection. A real CLI process talks to a loopback API to verify the requested detail level and confirms that raw Honeydiff regions only appear on the explicit diff path. The full 2,312-test suite, lint, formatting, type definitions, and production build are clean.

## Risk

The compact agent JSON contract changes by removing `next_actions`. That is intentional: these consumers can follow concrete CLI commands, and keeping both fields would preserve vague client-authored guidance we no longer want.