### PR TITLE
✨ Use API-backed build status

### DIFF
--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -952,8 +952,11 @@ vizzly status <build-id> --json
 {
   "status": "data",
   "data": {
+    "resource": "build_status",
+    "schemaVersion": 1,
     "buildId": "abc123-def456",
     "status": "completed",
+    "conclusion": "review_required",
     "name": "Build #123",
     "createdAt": "2025-01-15T10:30:00Z",
     "completedAt": "2025-01-15T10:32:00Z",
@@ -962,12 +965,50 @@ vizzly status <build-id> --json
     "commit": "abc1234",
     "commitMessage": "Add feature",
     "screenshotsTotal": 15,
+    "processing": {
+      "total": 15,
+      "completed": 15,
+      "failed": 0,
+      "active": 0,
+      "pending": 0
+    },
     "comparisonsTotal": 15,
+    "comparisons": {
+      "total": 15,
+      "new": 2,
+      "changed": 1,
+      "identical": 12
+    },
     "newComparisons": 2,
     "changedComparisons": 1,
     "identicalComparisons": 12,
-    "approvalStatus": "pending",
+    "reviewState": "pending",
+    "review": {
+      "pending": 3,
+      "approved": 12,
+      "rejected": 0,
+      "auto_approved": 0
+    },
+    "reviewFlow": "cricket",
+    "visualReview": { "state": "pending" },
     "executionTime": 4500,
+    "scope": {
+      "organization": { "id": "org-1", "slug": "acme" },
+      "project": { "id": "project-1", "slug": "storybook" }
+    },
+    "links": {
+      "web": "https://app.vizzly.dev/acme/storybook/builds/abc123-def456"
+    },
+    "suggestedCommands": [
+      {
+        "label": "Inspect build context",
+        "command": "vizzly --json context build abc123-def456 --agent"
+      },
+      {
+        "label": "List comparisons",
+        "command": "vizzly --json comparisons --build abc123-def456"
+      }
+    ],
     "preview": {
       "url": "https://preview.vizzly.dev/...",
       "status": "ready",
@@ -977,6 +1018,13 @@ vizzly status <build-id> --json
   }
 }
 ```
+
+The status command reads the API status bundle directly. Processing counts,
+comparison counts, conclusion, and review state stay separate; a pending review
+is never treated as unfinished screenshot processing. Fields the API does not
+provide are omitted instead of becoming client-authored zeroes. Legacy review
+responses continue to expose `approvalStatus`, and legacy build links continue
+to use the project-ID route when slug scope is unavailable.
 
 ### `vizzly init`
 

--- a/src/api/endpoints.js
+++ b/src/api/endpoints.js
@@ -37,6 +37,20 @@ export async function getBuild(client, buildId, include = null) {
 }
 
 /**
+ * Get the server-owned build processing and review status.
+ *
+ * This endpoint keeps processing, comparison, and review counts separate so
+ * callers do not have to reconstruct lifecycle state from legacy build fields.
+ *
+ * @param {Object} client - API client
+ * @param {string} buildId - Build ID
+ * @returns {Promise<Object>} Canonical build status bundle
+ */
+export async function getBuildStatus(client, buildId) {
+  return client.request(`/api/sdk/builds/${buildId}/status`);
+}
+
+/**
  * Get builds for a project
  * @param {Object} client - API client
  * @param {Object} filters - Filter options

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -45,6 +45,7 @@ export {
   getBatchHotspots,
   getBuild,
   getBuildContext,
+  getBuildStatus,
   getBuilds,
   getComparison,
   getComparisonContext,

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -5,21 +5,20 @@
 
 import {
   createApiClient as defaultCreateApiClient,
-  getBuild as defaultGetBuild,
+  getBuildStatus as defaultGetBuildStatus,
   getPreviewInfo as defaultGetPreviewInfo,
 } from '../api/index.js';
 import { getAppBaseUrl } from '../utils/api-url.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
-import { getApiUrl as defaultGetApiUrl } from '../utils/environment-config.js';
 import * as defaultOutput from '../utils/output.js';
+import { getVisualReviewState } from '../utils/visual-context-normalizers.js';
 
 function createStatusDeps(deps = {}) {
   return {
     loadConfig: deps.loadConfig || defaultLoadConfig,
     createApiClient: deps.createApiClient || defaultCreateApiClient,
-    getBuild: deps.getBuild || defaultGetBuild,
+    getBuildStatus: deps.getBuildStatus || defaultGetBuildStatus,
     getPreviewInfo: deps.getPreviewInfo || defaultGetPreviewInfo,
-    getApiUrl: deps.getApiUrl || defaultGetApiUrl,
     output: deps.output || defaultOutput,
     exit: deps.exit || (code => process.exit(code)),
   };
@@ -36,7 +35,7 @@ function configureOutput(output, globalOptions) {
 function createStatusClient({ createApiClient, config }) {
   return createApiClient({
     baseUrl: config.apiUrl,
-    token: config.apiKey,
+    token: config.apiKey || config.userToken,
     command: 'status',
   });
 }
@@ -60,10 +59,133 @@ export function normalizeBuildStatus(buildStatus) {
   return buildStatus.build || buildStatus;
 }
 
-export function createStatusData(build, previewInfo = null) {
+/**
+ * Read exact processing counts from canonical or legacy status responses.
+ *
+ * Legacy `pending_screenshots` is review state, not queue state, so it is
+ * deliberately excluded. Missing processing fields remain missing instead of
+ * becoming client-authored zeroes.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @returns {Object|undefined} API-provided processing facts when available.
+ */
+export function getProcessingStatus(status = {}) {
+  if (status.processing) {
+    return status.processing;
+  }
+
+  let build = normalizeBuildStatus(status);
+  let processing = {};
+  let fields = [
+    ['total', build.screenshot_count],
+    ['completed', build.completed_jobs],
+    ['failed', build.failed_jobs],
+    ['active', build.processing_screenshots],
+  ];
+
+  for (let [name, value] of fields) {
+    if (value != null) {
+      processing[name] = value;
+    }
+  }
+
+  return Object.keys(processing).length > 0 ? processing : undefined;
+}
+
+/**
+ * Read comparison totals without deriving them from screenshot counts.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @returns {Object|undefined} API-provided comparison facts when available.
+ */
+export function getComparisonStatus(status = {}) {
+  if (status.comparisons) {
+    return status.comparisons;
+  }
+
+  let build = normalizeBuildStatus(status);
+  let comparisons = {};
+  let fields = [
+    ['total', build.total_comparisons],
+    ['new', build.new_comparisons],
+    ['changed', build.changed_comparisons],
+    ['identical', build.identical_comparisons],
+  ];
+
+  for (let [name, value] of fields) {
+    if (value != null) {
+      comparisons[name] = value;
+    }
+  }
+
+  return Object.keys(comparisons).length > 0 ? comparisons : undefined;
+}
+
+/**
+ * Prefer canonical Cricket review state while retaining the legacy fallback.
+ *
+ * Processing status stays separate: a pending review never means a screenshot
+ * is still being processed.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @returns {string|null} API-provided review state when available.
+ */
+export function getBuildReviewState(status = {}) {
+  let build = normalizeBuildStatus(status);
+  return (
+    getVisualReviewState(build) ||
+    getVisualReviewState(status.visualReview?.build || status.visual_review) ||
+    null
+  );
+}
+
+/**
+ * Give agents concrete paths from lifecycle status into visual evidence.
+ *
+ * @param {Object} build - Build record from the status response.
+ * @returns {{label: string, command: string}[]} Executable CLI commands.
+ */
+export function createStatusSuggestedCommands(build = {}) {
+  if (!build.id) {
+    return [];
+  }
+
+  return [
+    {
+      label: 'Inspect build context',
+      command: `vizzly --json context build ${build.id} --agent`,
+    },
+    {
+      label: 'List comparisons',
+      command: `vizzly --json comparisons --build ${build.id}`,
+    },
+  ];
+}
+
+/**
+ * Preserve the established JSON fields while exposing canonical status facts.
+ *
+ * Every lifecycle, processing, comparison, and review value comes directly
+ * from the API. Undefined values intentionally disappear during JSON encoding
+ * rather than being presented as false certainty.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @param {Object|null} previewInfo - Optional preview response.
+ * @returns {Object} Machine-readable status payload.
+ */
+export function createStatusData(status, previewInfo = null) {
+  let build = normalizeBuildStatus(status);
+  let processing = getProcessingStatus(status);
+  let comparisons = getComparisonStatus(status);
+  let visualReview =
+    build.visual_review || status.visualReview?.build || status.visual_review;
+
   return {
+    resource: status.resource,
+    schemaVersion: status.schema_version,
     buildId: build.id,
     status: build.status,
+    conclusion: status.conclusion,
     name: build.name,
     createdAt: build.created_at,
     updatedAt: build.updated_at,
@@ -72,15 +194,24 @@ export function createStatusData(build, previewInfo = null) {
     branch: build.branch,
     commit: build.commit_sha,
     commitMessage: build.commit_message,
-    screenshotsTotal: build.screenshot_count || 0,
-    comparisonsTotal: build.total_comparisons || 0,
-    newComparisons: build.new_comparisons || 0,
-    changedComparisons: build.changed_comparisons || 0,
-    identicalComparisons: build.identical_comparisons || 0,
+    screenshotsTotal: processing?.total ?? build.screenshot_count,
+    processing,
+    comparisonsTotal: comparisons?.total ?? build.total_comparisons,
+    comparisons,
+    newComparisons: comparisons?.new ?? build.new_comparisons,
+    changedComparisons: comparisons?.changed ?? build.changed_comparisons,
+    identicalComparisons: comparisons?.identical ?? build.identical_comparisons,
+    reviewState: getBuildReviewState(status),
+    review: status.review,
+    reviewFlow: status.reviewFlow,
+    visualReview,
     approvalStatus: build.approval_status,
     executionTime: build.execution_time_ms,
     isBaseline: build.is_baseline,
     userAgent: build.user_agent,
+    scope: status.scope,
+    links: status.links,
+    suggestedCommands: createStatusSuggestedCommands(build),
     preview: previewInfo
       ? {
           url: previewInfo.preview_url,
@@ -110,11 +241,20 @@ export function createBuildInfo(build) {
   return buildInfo;
 }
 
-export function createComparisonStats(build, colors) {
+/**
+ * Format API comparison outcomes without filling missing buckets with zeroes.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @param {Object} colors - Output color helpers.
+ * @returns {string} Human-readable comparison summary.
+ */
+export function createComparisonStats(status, colors) {
+  let build = normalizeBuildStatus(status);
+  let comparisons = getComparisonStatus(status) || {};
   let stats = [];
-  let newCount = build.new_comparisons || 0;
-  let changedCount = build.changed_comparisons || 0;
-  let identicalCount = build.identical_comparisons || 0;
+  let newCount = comparisons.new ?? build.new_comparisons;
+  let changedCount = comparisons.changed ?? build.changed_comparisons;
+  let identicalCount = comparisons.identical ?? build.identical_comparisons;
 
   if (newCount > 0) {
     stats.push(`${colors.brand.info(newCount)} new`);
@@ -129,33 +269,55 @@ export function createComparisonStats(build, colors) {
   return stats.join(colors.brand.textMuted(' · '));
 }
 
-export function createBuildUrl(baseUrl, build) {
-  if (!baseUrl || !build.project_id) {
+/**
+ * Build the best available legacy link when the API did not return one.
+ *
+ * Slug routes match the current app, while the project-ID route remains as a
+ * compatibility fallback for older build responses.
+ *
+ * @param {string} baseUrl - API or app base URL.
+ * @param {Object} build - Build record.
+ * @param {Object|null} scope - Canonical organization and project scope.
+ * @returns {string|null} Build URL when the response has enough identity.
+ */
+export function createBuildUrl(baseUrl, build, scope = null) {
+  if (!baseUrl) {
     return null;
   }
 
-  return `${getAppBaseUrl(baseUrl)}/projects/${build.project_id}/builds/${build.id}`;
+  let organizationSlug =
+    scope?.organization?.slug || build.organization_slug || build.org_slug;
+  let projectSlug = scope?.project?.slug || build.project_slug;
+  let appBaseUrl = getAppBaseUrl(baseUrl);
+
+  if (organizationSlug && projectSlug) {
+    return `${appBaseUrl}/${organizationSlug}/${projectSlug}/builds/${build.id}`;
+  }
+
+  if (build.project_id) {
+    return `${appBaseUrl}/projects/${build.project_id}/builds/${build.id}`;
+  }
+
+  return null;
 }
 
-export function shouldFailStatus(build) {
-  return build.status === 'failed' || build.failed_jobs > 0;
-}
-
-export function getProcessingProgress(build) {
-  if (build.status !== 'processing' && build.status !== 'pending') {
-    return null;
-  }
-
-  let completedJobs = build.completed_jobs || 0;
-  let failedJobs = build.failed_jobs || 0;
-  let processingScreenshots = build.processing_screenshots || 0;
-  let totalJobs = completedJobs + failedJobs + processingScreenshots;
-
-  if (totalJobs <= 0) {
-    return null;
-  }
-
-  return ((completedJobs + failedJobs) / totalJobs) * 100;
+/**
+ * Preserve status failure behavior while accepting the canonical conclusion.
+ *
+ * Review-required and rejected builds keep their existing successful command
+ * exit behavior. Only build or processing failures produce a failing status.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @returns {boolean} Whether human status should exit non-zero.
+ */
+export function shouldFailStatus(status) {
+  let build = normalizeBuildStatus(status);
+  let processing = getProcessingStatus(status);
+  return (
+    build.status === 'failed' ||
+    ['build_failed', 'processing_failed'].includes(status.conclusion) ||
+    (processing?.failed ?? 0) > 0
+  );
 }
 
 function writeStatusTiming({ build, output }) {
@@ -176,15 +338,51 @@ function writeStatusTiming({ build, output }) {
   }
 }
 
-function createVerboseInfo(build) {
+/**
+ * Render follow-up commands after the factual status summary.
+ *
+ * Status answers lifecycle questions; these commands are the explicit bridge
+ * to screenshot evidence without bloating the status response itself.
+ *
+ * @param {Object} build - Build record from the status response.
+ * @param {Object} output - Configured output boundary.
+ */
+function writeSuggestedCommands({ build, output }) {
+  let commands = createStatusSuggestedCommands(build);
+  if (commands.length === 0) {
+    return;
+  }
+
+  let colors = output.getColors();
+  output.blank();
+  output.print('  Suggested commands');
+
+  for (let item of commands) {
+    output.print(`    ${colors.brand.textMuted(item.command)}`);
+  }
+}
+
+/**
+ * Add optional API facts without inventing placeholders for missing metadata.
+ *
+ * @param {Object} status - Canonical status bundle or legacy build record.
+ * @returns {Object} Available verbose fields.
+ */
+function createVerboseInfo(status) {
+  let build = normalizeBuildStatus(status);
   let verboseInfo = {};
 
-  if (
-    build.approved_screenshots > 0 ||
-    build.rejected_screenshots > 0 ||
-    build.pending_screenshots > 0
-  ) {
-    verboseInfo.Approvals = `${build.approved_screenshots || 0} approved, ${build.rejected_screenshots || 0} rejected, ${build.pending_screenshots || 0} pending`;
+  if (status.review) {
+    let reviewParts = [
+      ['approved', status.review.approved],
+      ['rejected', status.review.rejected],
+      ['pending', status.review.pending],
+    ]
+      .filter(([, value]) => value != null)
+      .map(([label, value]) => `${value} ${label}`);
+    if (reviewParts.length > 0) {
+      verboseInfo.Review = reviewParts.join(', ');
+    }
   }
 
   if (build.avg_diff_percentage != null) {
@@ -200,35 +398,83 @@ function createVerboseInfo(build) {
     verboseInfo.Baseline = 'Yes';
   }
 
-  verboseInfo['User Agent'] = build.user_agent || 'Unknown';
+  if (build.user_agent) {
+    verboseInfo['User Agent'] = build.user_agent;
+  }
   verboseInfo['Build ID'] = build.id;
-  verboseInfo['Project ID'] = build.project_id;
+  if (status.scope?.project?.id || build.project_id) {
+    verboseInfo['Project ID'] = status.scope?.project?.id || build.project_id;
+  }
 
   return verboseInfo;
 }
 
+/**
+ * Format only the processing facts supplied by the API.
+ *
+ * @param {Object|undefined} processing - Canonical processing counts.
+ * @returns {string} Human-readable processing summary.
+ */
+function formatProcessingStatus(processing) {
+  if (!processing) {
+    return '';
+  }
+
+  let labels = {
+    total: 'total',
+    completed: 'completed',
+    failed: 'failed',
+    active: 'active',
+    pending: 'pending',
+  };
+
+  return Object.entries(labels)
+    .filter(([field]) => processing[field] != null)
+    .map(([field, label]) => `${processing[field]} ${label}`)
+    .join(' · ');
+}
+
+/**
+ * Present lifecycle, processing, comparisons, and review as separate facts.
+ *
+ * Keeping these lanes separate prevents review-pending counts from looking
+ * like unfinished processing and keeps the human view aligned with JSON.
+ *
+ * @param {Object} options - Human status presentation inputs.
+ */
 function writeHumanStatus({
   build,
   buildUrl,
   globalOptions,
   output,
   previewInfo,
+  status,
 }) {
   output.header('status', build.status);
   output.keyValue(createBuildInfo(build));
   output.blank();
 
   let colors = output.getColors();
-  let comparisonStats = createComparisonStats(build, colors);
+  let comparisonStats = createComparisonStats(status, colors);
+  let processing = getProcessingStatus(status);
+  let screenshotsTotal = processing?.total ?? build.screenshot_count;
+  let processingSummary = formatProcessingStatus(processing);
 
-  output.labelValue('Screenshots', String(build.screenshot_count || 0));
+  if (screenshotsTotal != null) {
+    output.labelValue('Screenshots', String(screenshotsTotal));
+  }
+
+  if (processingSummary) {
+    output.labelValue('Processing', processingSummary);
+  }
 
   if (comparisonStats) {
     output.labelValue('Comparisons', comparisonStats);
   }
 
-  if (build.approval_status) {
-    output.labelValue('Approval', build.approval_status);
+  let reviewState = getBuildReviewState(status);
+  if (reviewState) {
+    output.labelValue('Review', reviewState);
   }
 
   output.blank();
@@ -254,20 +500,18 @@ function writeHumanStatus({
     output.blank();
     output.divider();
     output.blank();
-    output.keyValue(createVerboseInfo(build));
+    output.keyValue(createVerboseInfo(status));
   }
 
-  let progress = getProcessingProgress(build);
-  if (progress !== null) {
-    output.blank();
-    output.print(
-      `  ${output.progressBar(progress, 100)} ${Math.round(progress)}%`
-    );
-  }
+  writeSuggestedCommands({ build, output });
 }
 
 /**
- * Status command implementation
+ * Fetch and present the server-owned build status contract.
+ *
+ * Preview remains an optional adjacent resource, and established 5xx and
+ * build-failure exit semantics remain unchanged.
+ *
  * @param {string} buildId - Build ID to check status for
  * @param {Object} options - Command options
  * @param {Object} globalOptions - Global CLI options
@@ -282,9 +526,8 @@ export async function statusCommand(
   let {
     loadConfig,
     createApiClient,
-    getBuild,
+    getBuildStatus,
     getPreviewInfo,
-    getApiUrl,
     output,
     exit,
   } = createStatusDeps(deps);
@@ -297,9 +540,9 @@ export async function statusCommand(
     let config = await loadConfig(globalOptions.config, allOptions);
 
     // Validate API token
-    if (!config.apiKey) {
+    if (!config.apiKey && !config.userToken) {
       output.error(
-        'API token required. Use --token or set VIZZLY_TOKEN environment variable'
+        'Authentication required. Use --token, set VIZZLY_TOKEN, or run "vizzly login"'
       );
       output.cleanup();
       exit(1);
@@ -309,7 +552,7 @@ export async function statusCommand(
     // Get build details via functional API
     output.startSpinner('Fetching build status...');
     let client = createStatusClient({ createApiClient, config });
-    let buildStatus = await getBuild(client, buildId);
+    let buildStatus = await getBuildStatus(client, buildId);
 
     // Also fetch preview info (if exists)
     let previewInfo = await fetchOptionalPreviewInfo(
@@ -324,21 +567,29 @@ export async function statusCommand(
 
     // Output in JSON mode
     if (globalOptions.json) {
-      output.data(createStatusData(build, previewInfo));
+      output.data(createStatusData(buildStatus, previewInfo));
       output.cleanup();
       return;
     }
 
     // Human-readable output
     // Show build URL if we can construct it
-    let baseUrl = config.baseUrl || getApiUrl();
-    let buildUrl = createBuildUrl(baseUrl, build);
-    writeHumanStatus({ build, buildUrl, globalOptions, output, previewInfo });
+    let buildUrl =
+      buildStatus.links?.web ||
+      createBuildUrl(config.apiUrl, build, buildStatus.scope);
+    writeHumanStatus({
+      build,
+      buildUrl,
+      globalOptions,
+      output,
+      previewInfo,
+      status: buildStatus,
+    });
 
     output.cleanup();
 
     // Exit with appropriate code based on build status
-    if (shouldFailStatus(build)) {
+    if (shouldFailStatus(buildStatus)) {
       exit(1);
     }
   } catch (error) {

--- a/tests/api/endpoints.test.js
+++ b/tests/api/endpoints.test.js
@@ -16,6 +16,7 @@ import {
   getBatchHotspots,
   getBuild,
   getBuildContext,
+  getBuildStatus,
   getBuilds,
   getComparison,
   getComparisonContext,
@@ -99,6 +100,19 @@ describe('api/endpoints', () => {
       assert.strictEqual(
         client.getLastCall().endpoint,
         '/api/sdk/builds/123?include=screenshots'
+      );
+    });
+  });
+
+  describe('getBuildStatus', () => {
+    it('requests the canonical build status endpoint', async () => {
+      let client = createMockClient({ resource: 'build_status' });
+
+      await getBuildStatus(client, 'build-123');
+
+      assert.strictEqual(
+        client.getLastCall().endpoint,
+        '/api/sdk/builds/build-123/status'
       );
     });
   });

--- a/tests/commands/status-cli.test.js
+++ b/tests/commands/status-cli.test.js
@@ -16,9 +16,14 @@ async function withApiServer(callback) {
     requests.push({ method: req.method, url: req.url });
     res.setHeader('content-type', 'application/json');
 
-    if (req.method === 'GET' && req.url === '/api/sdk/builds/build-123') {
+    if (
+      req.method === 'GET' &&
+      req.url === '/api/sdk/builds/build-123/status'
+    ) {
       res.end(
         JSON.stringify({
+          resource: 'build_status',
+          schema_version: 1,
           build: {
             id: 'build-123',
             status: 'completed',
@@ -30,15 +35,29 @@ async function withApiServer(callback) {
             branch: 'main',
             commit_sha: 'abcdef1234567890',
             commit_message: 'Dogfood status',
-            screenshot_count: 1,
-            total_comparisons: 1,
-            new_comparisons: 1,
-            changed_comparisons: 0,
-            identical_comparisons: 0,
-            approval_status: 'pending',
+            visual_review: { state: 'pending' },
             execution_time_ms: 100,
             is_baseline: false,
             user_agent: 'vizzly-test',
+          },
+          conclusion: 'review_required',
+          processing: {
+            total: 1,
+            completed: 1,
+            failed: 0,
+            active: 0,
+            pending: 0,
+          },
+          comparisons: { total: 1, new: 1, changed: 0, identical: 0 },
+          review: { pending: 1, approved: 0, rejected: 0 },
+          reviewFlow: 'cricket',
+          visualReview: { build: { state: 'pending' } },
+          scope: {
+            organization: { id: 'org-1', slug: 'acme' },
+            project: { id: 'project-1', slug: 'web' },
+          },
+          links: {
+            web: 'https://app.test/acme/web/builds/build-123',
           },
         })
       );
@@ -92,13 +111,29 @@ describe('commands/status CLI', () => {
 
       let payload = JSON.parse(result.stdout);
       assert.strictEqual(payload.status, 'data');
+      assert.strictEqual(payload.data.resource, 'build_status');
+      assert.strictEqual(payload.data.schemaVersion, 1);
       assert.strictEqual(payload.data.buildId, 'build-123');
       assert.strictEqual(payload.data.status, 'completed');
+      assert.strictEqual(payload.data.conclusion, 'review_required');
+      assert.deepStrictEqual(payload.data.processing, {
+        total: 1,
+        completed: 1,
+        failed: 0,
+        active: 0,
+        pending: 0,
+      });
+      assert.strictEqual(payload.data.reviewState, 'pending');
+      assert.ok(!Object.hasOwn(payload.data, 'approvalStatus'));
+      assert.strictEqual(
+        payload.data.links.web,
+        'https://app.test/acme/web/builds/build-123'
+      );
       assert.strictEqual(payload.data.preview, null);
       assert.deepStrictEqual(
         requests.map(request => `${request.method} ${request.url}`),
         [
-          'GET /api/sdk/builds/build-123',
+          'GET /api/sdk/builds/build-123/status',
           'GET /api/sdk/builds/build-123/preview',
         ]
       );

--- a/tests/commands/status.test.js
+++ b/tests/commands/status.test.js
@@ -5,7 +5,10 @@ import {
   createBuildUrl,
   createComparisonStats,
   createStatusData,
-  getProcessingProgress,
+  createStatusSuggestedCommands,
+  getBuildReviewState,
+  getComparisonStatus,
+  getProcessingStatus,
   normalizeBuildStatus,
   shouldFailStatus,
   statusCommand,
@@ -79,7 +82,54 @@ function createBuild(overrides = {}) {
   };
 }
 
-function createStatusHarness(build = createBuild(), previewInfo = null) {
+function createStatusBundle(overrides = {}) {
+  let build = {
+    id: 'build-123',
+    status: 'completed',
+    name: 'Homepage',
+    created_at: '2026-05-18T12:00:00.000Z',
+    updated_at: '2026-05-18T12:01:00.000Z',
+    completed_at: '2026-05-18T12:02:00.000Z',
+    environment: 'ci',
+    branch: 'main',
+    commit_sha: 'abcdef1234567890',
+    commit_message: 'Update homepage',
+    visual_review: { state: 'pending' },
+    execution_time_ms: 4250,
+    is_baseline: false,
+    user_agent: 'vizzly-test',
+    ...overrides.build,
+  };
+
+  return {
+    resource: 'build_status',
+    schema_version: 1,
+    conclusion: 'review_required',
+    processing: {
+      total: 3,
+      completed: 3,
+      failed: 0,
+      active: 0,
+      pending: 0,
+    },
+    comparisons: { total: 3, new: 1, changed: 1, identical: 1 },
+    review: { pending: 2, approved: 1, rejected: 0, auto_approved: 0 },
+    reviewFlow: 'cricket',
+    visualReview: { build: { state: 'pending' } },
+    scope: {
+      organization: { id: 'org-1', slug: 'acme' },
+      project: { id: 'project-123', slug: 'web' },
+    },
+    links: { web: 'https://app.test/acme/web/builds/build-123' },
+    ...overrides,
+    build,
+  };
+}
+
+function createStatusHarness(
+  status = createStatusBundle(),
+  previewInfo = null
+) {
   let output = createMockOutput();
   let clientConfig = null;
   let exitCode = null;
@@ -101,7 +151,8 @@ function createStatusHarness(build = createBuild(), previewInfo = null) {
         clientConfig = config;
         return { kind: 'client' };
       },
-      getBuild: async () => ({ build }),
+      getBuildStatus: async () =>
+        status.resource === 'build_status' ? status : { build: status },
       getPreviewInfo: async () => previewInfo,
       getApiUrl: () => 'https://app.test/api',
       output,
@@ -139,7 +190,7 @@ describe('commands/status', () => {
     });
 
     it('creates JSON status data with preview details', () => {
-      let data = createStatusData(createBuild(), {
+      let data = createStatusData(createStatusBundle(), {
         preview_url: 'https://preview.test',
         status: 'ready',
         file_count: 12,
@@ -147,8 +198,11 @@ describe('commands/status', () => {
       });
 
       assert.deepStrictEqual(data, {
+        resource: 'build_status',
+        schemaVersion: 1,
         buildId: 'build-123',
         status: 'completed',
+        conclusion: 'review_required',
         name: 'Homepage',
         createdAt: '2026-05-18T12:00:00.000Z',
         updatedAt: '2026-05-18T12:01:00.000Z',
@@ -158,20 +212,93 @@ describe('commands/status', () => {
         commit: 'abcdef1234567890',
         commitMessage: 'Update homepage',
         screenshotsTotal: 3,
+        processing: {
+          total: 3,
+          completed: 3,
+          failed: 0,
+          active: 0,
+          pending: 0,
+        },
         comparisonsTotal: 3,
+        comparisons: { total: 3, new: 1, changed: 1, identical: 1 },
         newComparisons: 1,
         changedComparisons: 1,
         identicalComparisons: 1,
-        approvalStatus: 'pending',
+        reviewState: 'pending',
+        review: {
+          pending: 2,
+          approved: 1,
+          rejected: 0,
+          auto_approved: 0,
+        },
+        reviewFlow: 'cricket',
+        visualReview: { state: 'pending' },
+        approvalStatus: undefined,
         executionTime: 4250,
         isBaseline: false,
         userAgent: 'vizzly-test',
+        scope: {
+          organization: { id: 'org-1', slug: 'acme' },
+          project: { id: 'project-123', slug: 'web' },
+        },
+        links: { web: 'https://app.test/acme/web/builds/build-123' },
+        suggestedCommands: [
+          {
+            label: 'Inspect build context',
+            command: 'vizzly --json context build build-123 --agent',
+          },
+          {
+            label: 'List comparisons',
+            command: 'vizzly --json comparisons --build build-123',
+          },
+        ],
         preview: {
           url: 'https://preview.test',
           status: 'ready',
           fileCount: 12,
           expiresAt: '2026-05-19T12:00:00.000Z',
         },
+      });
+    });
+
+    it('keeps missing legacy status facts unknown instead of inventing zeroes', () => {
+      let data = createStatusData({
+        build: {
+          id: 'legacy-build',
+          status: 'processing',
+          approval_status: 'pending',
+          pending_screenshots: 12,
+        },
+      });
+
+      assert.strictEqual(data.reviewState, 'pending');
+      assert.strictEqual(data.processing, undefined);
+      assert.strictEqual(data.screenshotsTotal, undefined);
+      assert.strictEqual(data.comparisons, undefined);
+      assert.strictEqual(data.comparisonsTotal, undefined);
+      assert.strictEqual(data.newComparisons, undefined);
+    });
+
+    it('reads canonical and legacy review facts without mixing them into processing', () => {
+      let canonical = createStatusBundle();
+      let legacy = createBuild({
+        completed_jobs: 2,
+        processing_screenshots: 1,
+        pending_screenshots: 9,
+      });
+
+      assert.strictEqual(getBuildReviewState(canonical), 'pending');
+      assert.deepStrictEqual(getProcessingStatus(legacy), {
+        total: 3,
+        completed: 2,
+        failed: 0,
+        active: 1,
+      });
+      assert.deepStrictEqual(getComparisonStatus(canonical), {
+        total: 3,
+        new: 1,
+        changed: 1,
+        identical: 1,
       });
     });
 
@@ -192,7 +319,14 @@ describe('commands/status', () => {
       );
     });
 
-    it('creates build URLs, progress, and failure status', () => {
+    it('prefers slug build URLs and retains the legacy project route', () => {
+      assert.strictEqual(
+        createBuildUrl('https://app.test/api', createBuild(), {
+          organization: { slug: 'acme' },
+          project: { slug: 'web' },
+        }),
+        'https://app.test/acme/web/builds/build-123'
+      );
       assert.strictEqual(
         createBuildUrl('https://app.test/api', createBuild()),
         'https://app.test/projects/project-123/builds/build-123'
@@ -202,18 +336,9 @@ describe('commands/status', () => {
         'https://api.test/projects/project-123/builds/build-123'
       );
       assert.strictEqual(createBuildUrl(null, createBuild()), null);
-      assert.strictEqual(
-        getProcessingProgress(
-          createBuild({
-            status: 'processing',
-            completed_jobs: 2,
-            failed_jobs: 1,
-            processing_screenshots: 1,
-          })
-        ),
-        75
-      );
-      assert.strictEqual(getProcessingProgress(createBuild()), null);
+    });
+
+    it('uses API processing conclusions without changing review failures', () => {
       assert.strictEqual(
         shouldFailStatus(createBuild({ status: 'failed' })),
         true
@@ -223,6 +348,29 @@ describe('commands/status', () => {
         true
       );
       assert.strictEqual(shouldFailStatus(createBuild()), false);
+      assert.strictEqual(
+        shouldFailStatus(
+          createStatusBundle({ conclusion: 'processing_failed' })
+        ),
+        true
+      );
+      assert.strictEqual(
+        shouldFailStatus(createStatusBundle({ conclusion: 'rejected' })),
+        false
+      );
+    });
+
+    it('creates executable visual-context follow-up commands', () => {
+      assert.deepStrictEqual(createStatusSuggestedCommands(createBuild()), [
+        {
+          label: 'Inspect build context',
+          command: 'vizzly --json context build build-123 --agent',
+        },
+        {
+          label: 'List comparisons',
+          command: 'vizzly --json comparisons --build build-123',
+        },
+      ]);
     });
   });
 
@@ -275,13 +423,18 @@ describe('commands/status', () => {
       );
     });
 
-    it('prints processing progress when jobs are active', async () => {
+    it('prints API processing counts without inventing a progress percentage', async () => {
       let harness = createStatusHarness(
-        createBuild({
-          status: 'processing',
-          completed_jobs: 2,
-          failed_jobs: 0,
-          processing_screenshots: 2,
+        createStatusBundle({
+          build: { status: 'processing', completed_at: null },
+          conclusion: 'processing',
+          processing: {
+            total: 4,
+            completed: 2,
+            failed: 0,
+            active: 2,
+            pending: 0,
+          },
         })
       );
 
@@ -289,7 +442,41 @@ describe('commands/status', () => {
 
       assert.ok(
         harness.output.calls.some(
-          call => call.method === 'print' && call.args[0].includes('50%')
+          call =>
+            call.method === 'labelValue' &&
+            call.args[0] === 'Processing' &&
+            call.args[1] ===
+              '4 total · 2 completed · 0 failed · 2 active · 0 pending'
+        )
+      );
+      assert.ok(
+        harness.output.calls.every(
+          call => call.method !== 'print' || !call.args[0].includes('%')
+        )
+      );
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'labelValue' &&
+            call.args[0] === 'Review' &&
+            call.args[1] === 'pending'
+        )
+      );
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'labelValue' &&
+            call.args[0] === 'View' &&
+            call.args[1] === 'https://app.test/acme/web/builds/build-123'
+        )
+      );
+      assert.ok(
+        harness.output.calls.some(
+          call =>
+            call.method === 'print' &&
+            call.args[0].includes(
+              'vizzly --json context build build-123 --agent'
+            )
         )
       );
     });
@@ -333,6 +520,19 @@ describe('commands/status', () => {
       assert.ok(output.calls.some(call => call.method === 'cleanup'));
     });
 
+    it('uses logged-in user auth when no project token is configured', async () => {
+      let harness = createStatusHarness();
+      harness.deps.loadConfig = async () => ({
+        userToken: 'user-token',
+        apiUrl: 'https://api.test',
+      });
+
+      await statusCommand('build-123', {}, { json: true }, harness.deps);
+
+      assert.strictEqual(harness.clientConfig.token, 'user-token');
+      assert.strictEqual(harness.exitCode, null);
+    });
+
     it('does not fail CI when API returns 5xx error', async () => {
       let output = createMockOutput();
       let exitCode = null;
@@ -352,7 +552,7 @@ describe('commands/status', () => {
             apiUrl: 'https://api.test',
           }),
           createApiClient: () => ({}),
-          getBuild: async () => {
+          getBuildStatus: async () => {
             throw apiError;
           },
           getPreviewInfo: async () => null,
@@ -391,7 +591,7 @@ describe('commands/status', () => {
             apiUrl: 'https://api.test',
           }),
           createApiClient: () => ({}),
-          getBuild: async () => {
+          getBuildStatus: async () => {
             throw apiError;
           },
           getPreviewInfo: async () => null,


### PR DESCRIPTION
## Why

The CLI status command was reading the general build endpoint and reconstructing lifecycle state from a handful of legacy fields. That made review-pending counts look like unfinished processing, produced zeroes when the API had not supplied a fact, and calculated a progress percentage from an incomplete denominator.

## Approach

Status now reads the dedicated `/api/sdk/builds/:id/status` contract. Processing, comparison outcomes, review counts, review flow, canonical conclusion, scope, and links remain separate API-owned facts. The established camelCase JSON fields stay available as compatibility projections, but missing source values are omitted instead of filled in client-side.

Cricket review state is preferred with the existing legacy approval fallback. Human output shows exact processing counts and concrete commands for build context and comparisons; it no longer invents progress or an uncompared screenshot count. API-provided slug links win, while the legacy `project_id` route remains available when slug scope is missing.

Failure behavior stays narrow: build and processing failures still fail human status, while review-required and rejected conclusions retain the previous successful exit behavior. Logged-in user tokens now work alongside project tokens because the current status endpoint supports both.

## Evidence

A real CLI process talks to a loopback server and verifies the canonical status endpoint, response fields, missing legacy approval field, and optional-preview behavior. Focused coverage also exercises legacy responses with absent facts, Cricket and legacy review state, slug and project-ID links, exact zero counts, user authentication, and unchanged failure semantics. The full 2,318-test suite passes with six existing skips; lint, formatting, type definitions, production build, and package contents are clean.

## Risk

Scripts that depended on fabricated zeroes for absent legacy fields will now see those fields omitted. That is deliberate: unknown API state should not look like a measured zero.