### PR TITLE
🐛 Preserve visual context source provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ evidence in one place.
 
 ```bash
 # Cloud context for a build or comparison
-vizzly context build abc123
-vizzly context comparison def456 --json
+vizzly context build abc123 --source cloud
+vizzly context comparison def456 --source cloud --json
 
 # Local workspace context from .vizzly/
 vizzly context build current --source local

--- a/docs/json-output.md
+++ b/docs/json-output.md
@@ -71,7 +71,7 @@ vizzly run "pnpm test" --json
   "data": {
     "buildId": "abc123-def456",
     "status": "completed",
-    "contextCommand": "vizzly context build abc123-def456 --agent --json",
+    "contextCommand": "vizzly context build abc123-def456 --agent --json --source cloud",
     "screenshotsCaptured": 15,
     "executionTimeMs": 4821,
     "git": {
@@ -106,7 +106,7 @@ With `--wait`, includes comparison results:
       "identical": 12
     },
     "approvalStatus": "pending",
-    "contextCommand": "vizzly context build abc123-def456 --agent --json",
+    "contextCommand": "vizzly context build abc123-def456 --agent --json --source cloud",
     "exitCode": 1
   }
 }
@@ -262,10 +262,10 @@ cloud data or your local `.vizzly` workspace.
 #### `vizzly context build`
 
 ```bash
-vizzly context build abc123 --json
-vizzly context build abc123 --agent --json
-vizzly context build abc123 --agent --json --include diffs,comments
-vizzly context build abc123 --agent --json --full
+vizzly context build abc123 --source cloud --json
+vizzly context build abc123 --source cloud --agent --json
+vizzly context build abc123 --source cloud --agent --json --include diffs,comments
+vizzly context build abc123 --source cloud --agent --json --full
 vizzly context build current --source local --json
 vizzly context build current --source local --agent
 ```
@@ -359,15 +359,15 @@ Compact agent JSON:
   "suggested_commands": [
     {
       "label": "Inspect comparison context",
-      "command": "vizzly --json context comparison cmp-1"
+      "command": "vizzly --json context comparison cmp-1 --source cloud"
     },
     {
       "label": "Inspect screenshot history",
-      "command": "vizzly --json context screenshot Dashboard"
+      "command": "vizzly --json context screenshot Dashboard --source cloud"
     },
     {
       "label": "Load raw diff diagnostics",
-      "command": "vizzly --json context build abc123 --agent --include diffs"
+      "command": "vizzly --json context build abc123 --agent --include diffs --source cloud"
     }
   ]
 }
@@ -451,7 +451,7 @@ Full build context JSON:
 #### `vizzly context comparison`
 
 ```bash
-vizzly context comparison cmp-1 --json
+vizzly context comparison cmp-1 --source cloud --json
 vizzly context comparison build-detail-screenshots --source local --json
 ```
 
@@ -482,7 +482,7 @@ vizzly context comparison build-detail-screenshots --source local --json
 #### `vizzly context screenshot`
 
 ```bash
-vizzly context screenshot Dashboard --json
+vizzly context screenshot Dashboard --source cloud --json
 vizzly context screenshot Dashboard --source local --json
 ```
 
@@ -507,7 +507,7 @@ vizzly context screenshot Dashboard --source local --json
 #### `vizzly context similar`
 
 ```bash
-vizzly context similar fp-dashboard --project storybook --org acme --json
+vizzly context similar fp-dashboard --source cloud --project storybook --org acme --json
 ```
 
 ```json
@@ -533,7 +533,7 @@ the CLI returns a clear error instead of pretending the data exists.
 #### `vizzly context review-queue`
 
 ```bash
-vizzly context review-queue --project storybook --org acme --json
+vizzly context review-queue --source cloud --project storybook --org acme --json
 vizzly context review-queue --source local --json
 ```
 
@@ -1002,7 +1002,7 @@ vizzly status <build-id> --json
     "suggestedCommands": [
       {
         "label": "Inspect build context",
-        "command": "vizzly --json context build abc123-def456 --agent"
+        "command": "vizzly --json context build abc123-def456 --agent --source cloud"
       },
       {
         "label": "List comparisons",

--- a/skills/vizzly/SKILL.md
+++ b/skills/vizzly/SKILL.md
@@ -29,7 +29,7 @@ existing test workflow in charge of how the UI is exercised.
 
    ```bash
    vizzly context build current --source local --agent --json
-   vizzly context build <build-id> --agent --json
+   vizzly context build <build-id> --source cloud --agent --json
    ```
 
 3. Check the build identity, source, branch, timestamps, baseline selection,

--- a/skills/vizzly/references/cli-context.md
+++ b/skills/vizzly/references/cli-context.md
@@ -54,7 +54,7 @@ When the task already has a build ID:
 
 ```bash
 vizzly status <build-id> --json
-vizzly context build <build-id> --agent --json
+vizzly context build <build-id> --source cloud --agent --json
 ```
 
 Use status for server-owned lifecycle, processing, comparison, and review
@@ -65,7 +65,7 @@ command:
 
 ```bash
 vizzly run "<existing visual test command>" --wait --json
-vizzly context build <build-id> --agent --json
+vizzly context build <build-id> --source cloud --agent --json
 ```
 
 ## Read And Drill Into Evidence
@@ -84,11 +84,13 @@ For each evidence record:
 Useful manual drill-downs are:
 
 ```bash
-vizzly context comparison <comparison-id> --json
-vizzly context screenshot "<screenshot-name>" --json
-vizzly context similar <fingerprint-hash> --json
-vizzly context review-queue --json
+vizzly context comparison <comparison-id> --source <local-or-cloud> --json
+vizzly context screenshot "<screenshot-name>" --source <local-or-cloud> --json
+vizzly context similar <fingerprint-hash> --source cloud --json
+vizzly context review-queue --source <local-or-cloud> --json
 ```
 
-`context similar` is cloud-only. Keep missing values unknown, and do not turn
-metadata into a visual conclusion when the underlying images are unavailable.
+Use the source from the evidence you are inspecting in place of
+`<local-or-cloud>`. `context similar` is cloud-only. Keep missing values
+unknown, and do not turn metadata into a visual conclusion when the underlying
+images are unavailable.

--- a/skills/vizzly/references/dynamic-content.md
+++ b/skills/vizzly/references/dynamic-content.md
@@ -8,10 +8,11 @@ responsive text as possible causes of change, not automatic explanations.
 1. Inspect screenshot history and the actual image evidence:
 
    ```bash
-   vizzly context screenshot "<screenshot-name>" --json
+   vizzly context screenshot "<screenshot-name>" --source <local-or-cloud> --json
    ```
 
-2. Record the observed region, recurrence, render metadata, and whether the
+2. Replace `<local-or-cloud>` with the source of the evidence being diagnosed.
+   Record the observed region, recurrence, render metadata, and whether the
    same change appears across builds or variants.
 3. Check whether deterministic fixtures can remove irrelevant variation.
 4. Treat hotspots and confirmed regions as server- or user-owned evidence.

--- a/skills/vizzly/references/setup-ci.md
+++ b/skills/vizzly/references/setup-ci.md
@@ -60,7 +60,8 @@ having every shard race to finalize the build.
 - Run `vizzly doctor` for local configuration checks.
 - Run `vizzly tdd status --json` for a local daemon started by the task.
 - Run `vizzly status <build-id> --json` for cloud lifecycle facts.
-- Run `vizzly context build <build-id> --agent --json` for visual evidence.
+- Run `vizzly context build <build-id> --source cloud --agent --json` for visual
+  evidence.
 - If screenshots are absent, verify the existing SDK or integration, the test
   path that should capture them, and the active local or cloud session.
 - If authentication is absent, report it rather than initiating login unless

--- a/src/cli.js
+++ b/src/cli.js
@@ -990,12 +990,12 @@ contextCmd
     'after',
     `
 Examples:
-  $ vizzly context build abc123
+  $ vizzly context build abc123 --source cloud
   $ vizzly context build current --source local
   $ vizzly context build current --source local --agent
-  $ vizzly context build abc123 --agent --json
-  $ vizzly context build abc123 --agent --json --include diffs,comments
-  $ vizzly context build abc123 --agent --json --full
+  $ vizzly context build abc123 --source cloud --agent --json
+  $ vizzly context build abc123 --source cloud --agent --json --include diffs,comments
+  $ vizzly context build abc123 --source cloud --agent --json --full
 `
   )
   .action(async (buildId, options) => {
@@ -1032,10 +1032,10 @@ contextCmd
     'after',
     `
 Examples:
-  $ vizzly context comparison def456
+  $ vizzly context comparison def456 --source cloud
   $ vizzly context comparison def456 --source local
-  $ vizzly context comparison def456 --similar-limit 5 --recent-limit 5
-  $ vizzly context comparison def456 --json
+  $ vizzly context comparison def456 --source cloud --similar-limit 5 --recent-limit 5
+  $ vizzly context comparison def456 --source cloud --json
 `
   )
   .action(async (comparisonId, options) => {
@@ -1069,10 +1069,10 @@ contextCmd
     'after',
     `
 Examples:
-  $ vizzly context screenshot Dashboard
+  $ vizzly context screenshot Dashboard --source cloud
   $ vizzly context screenshot Dashboard --source local
-  $ vizzly context screenshot Dashboard --project storybook --org acme
-  $ vizzly context screenshot Dashboard --json
+  $ vizzly context screenshot Dashboard --source cloud --project storybook --org acme
+  $ vizzly context screenshot Dashboard --source cloud --json
 `
   )
   .action(async (name, options) => {
@@ -1097,9 +1097,9 @@ contextCmd
     'after',
     `
 Examples:
-  $ vizzly context similar fp-dashboard
-  $ vizzly context similar fp-dashboard --project storybook --org acme
-  $ vizzly context similar fp-dashboard --json
+  $ vizzly context similar fp-dashboard --source cloud
+  $ vizzly context similar fp-dashboard --source cloud --project storybook --org acme
+  $ vizzly context similar fp-dashboard --source cloud --json
 `
   )
   .action(async (fingerprintHash, options) => {
@@ -1124,10 +1124,10 @@ contextCmd
     'after',
     `
 Examples:
-  $ vizzly context review-queue --project storybook --org acme
+  $ vizzly context review-queue --source cloud --project storybook --org acme
   $ vizzly context review-queue --source local
-  $ vizzly context review-queue --limit 10
-  $ vizzly context review-queue --json
+  $ vizzly context review-queue --source cloud --limit 10
+  $ vizzly context review-queue --source cloud --json
 `
   )
   .action(async options => {

--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -496,17 +496,19 @@ function isLocalContext(context = {}) {
 }
 
 /**
- * Keep suggested commands on the same source as the evidence they inspect.
+ * Keep executable suggestions on the source that produced their evidence.
  *
- * Without the explicit local flag, an executable suggestion could silently
- * switch to cloud context and describe a different build.
+ * Mixed workspaces can contain both a cloud run session and persisted local
+ * TDD results. Pinning either source prevents a follow-up command from
+ * silently crossing that boundary and describing a different build.
  *
  * @param {string} command - Base CLI command.
  * @param {Object} context - Context that produced the command.
- * @returns {string} Command pinned to local context when needed.
+ * @returns {string} Command pinned to its originating source.
  */
-function appendLocalSource(command, context = {}) {
-  return isLocalContext(context) ? `${command} --source local` : command;
+function appendContextSource(command, context = {}) {
+  let source = isLocalContext(context) ? 'local' : 'cloud';
+  return `${command} --source ${source}`;
 }
 
 /**
@@ -538,7 +540,7 @@ function buildSuggestedCommands(
   if (firstComparison?.id) {
     commands.push({
       label: 'Inspect comparison context',
-      command: appendLocalSource(
+      command: appendContextSource(
         `vizzly --json context comparison ${quoteCommandArgument(firstComparison.id)}`,
         context
       ),
@@ -548,7 +550,7 @@ function buildSuggestedCommands(
   if (firstNamedEvidence?.name) {
     commands.push({
       label: 'Inspect screenshot history',
-      command: appendLocalSource(
+      command: appendContextSource(
         `vizzly --json context screenshot ${quoteCommandArgument(firstNamedEvidence.name)}`,
         context
       ),
@@ -558,7 +560,7 @@ function buildSuggestedCommands(
   if (buildTarget && evidence.length > 0) {
     commands.push({
       label: 'Load raw diff diagnostics',
-      command: appendLocalSource(
+      command: appendContextSource(
         `vizzly --json context build ${quoteCommandArgument(buildTarget)} --agent --include diffs`,
         context
       ),
@@ -568,7 +570,7 @@ function buildSuggestedCommands(
   if (buildTarget && truncated) {
     commands.push({
       label: 'Load full build context',
-      command: appendLocalSource(
+      command: appendContextSource(
         `vizzly --json context build ${quoteCommandArgument(buildTarget)} --agent --full`,
         context
       ),

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -78,7 +78,7 @@ export async function resolveBuildDisplayUrl({
  */
 function buildContextCommand(buildId, { structured = false } = {}) {
   let jsonFlag = structured ? ' --json' : '';
-  return `vizzly context build ${buildId} --agent${jsonFlag}`;
+  return `vizzly context build ${buildId} --agent${jsonFlag} --source cloud`;
 }
 
 /**

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -153,7 +153,7 @@ export function createStatusSuggestedCommands(build = {}) {
   return [
     {
       label: 'Inspect build context',
-      command: `vizzly --json context build ${build.id} --agent`,
+      command: `vizzly --json context build ${build.id} --agent --source cloud`,
     },
     {
       label: 'List comparisons',

--- a/src/context/local-workspace-provider.js
+++ b/src/context/local-workspace-provider.js
@@ -181,21 +181,28 @@ function buildComparisonLinks(snapshot, comparisonId) {
   };
 }
 
+/**
+ * Describe the local evidence set without borrowing cloud run identity.
+ *
+ * A cloud `session.json` can coexist with older file-backed TDD evidence. Using
+ * that session here makes stale local comparisons look like the current cloud
+ * build, so local identity comes only from the active local server.
+ *
+ * @param {Object} snapshot - Persisted local workspace evidence.
+ * @returns {Object} Build-shaped identity for the local context payload.
+ */
 function buildBuildSnapshot(snapshot) {
-  let buildId =
-    snapshot.session?.buildId ||
-    snapshot.serverInfo?.buildId ||
-    'local-workspace';
+  let buildId = snapshot.serverInfo?.buildId || 'local-workspace';
 
   return {
     id: buildId,
     name: buildId,
-    branch: snapshot.session?.branch || 'local',
-    commit_sha: snapshot.session?.commit || null,
+    branch: 'local',
+    commit_sha: null,
     commit_message: null,
     approval_status: snapshot.serverInfo ? 'pending' : 'approved',
     status: snapshot.serverInfo ? 'running' : 'completed',
-    created_at: snapshot.session?.createdAt || null,
+    created_at: null,
   };
 }
 
@@ -417,7 +424,6 @@ export function createLocalWorkspaceContextProvider(options = {}, deps = {}) {
       vizzlyDir,
       existsSync,
       serverInfo: readJson(join(vizzlyDir, 'server.json')),
-      session: readJson(join(vizzlyDir, 'session.json')),
       reportData: normalizeReportData(
         readJson(join(vizzlyDir, 'report-data.json')) || createEmptyReportData()
       ),
@@ -436,7 +442,6 @@ export function createLocalWorkspaceContextProvider(options = {}, deps = {}) {
   function isAvailable(snapshot = loadSnapshot()) {
     return Boolean(
       snapshot.serverInfo ||
-        snapshot.session ||
         snapshot.reportData.comparisons.length > 0 ||
         snapshot.baselineMetadata
     );
@@ -529,7 +534,7 @@ export function createLocalWorkspaceContextProvider(options = {}, deps = {}) {
       )
     ) {
       throw createLocalWorkspaceError(
-        `Local workspace context is only available for the active session build (${resolvedBuild.id})`
+        `Local workspace context is only available for the active local build (${resolvedBuild.id})`
       );
     }
 

--- a/tests/commands/context-cli.test.js
+++ b/tests/commands/context-cli.test.js
@@ -268,6 +268,56 @@ describe('context CLI integration', () => {
     });
   });
 
+  it('does not let a cloud session relabel stale local evidence', async () => {
+    await withBuildContextApi(async ({ apiUrl, requests }) => {
+      let cwd = mkdtempSync(join(tmpdir(), 'vizzly-context-mixed-source-'));
+      let vizzlyDir = join(cwd, '.vizzly');
+      mkdirSync(vizzlyDir, { recursive: true });
+      writeFileSync(
+        join(vizzlyDir, 'session.json'),
+        JSON.stringify({
+          buildId: 'build-123',
+          branch: 'main',
+          commit: 'abc123',
+          createdAt: '2026-07-22T00:00:00.000Z',
+        })
+      );
+      writeFileSync(
+        join(vizzlyDir, 'report-data.json'),
+        JSON.stringify({
+          comparisons: [
+            {
+              id: 'stale-local-comparison',
+              name: 'Old local screenshot',
+              status: 'failed',
+              current: '/images/current/old.png',
+            },
+          ],
+        })
+      );
+
+      let result = await runCLI(
+        ['--json', 'context', 'build', 'build-123', '--agent'],
+        {
+          cwd,
+          env: {
+            VIZZLY_API_URL: apiUrl,
+            VIZZLY_TOKEN: 'vzt_test_token',
+          },
+        }
+      );
+
+      assert.strictEqual(result.code, 0, result.stderr);
+      let payload = JSON.parse(result.stdout).data;
+      assert.strictEqual(payload.source, 'cloud');
+      assert.strictEqual(payload.build.id, 'build-123');
+      assert.strictEqual(payload.evidence[0].id, 'comparison-1');
+      assert.deepStrictEqual(requests, [
+        '/api/sdk/context/builds/build-123?details=summary',
+      ]);
+    });
+  });
+
   it('treats root-level --json as a flag before the context command', async () => {
     let result = await runCLI(['--json', 'context', 'build', 'build-123']);
 
@@ -282,7 +332,7 @@ describe('context CLI integration', () => {
     mkdirSync(vizzlyHome, { recursive: true });
 
     let result = await runCLI(
-      ['--json', 'context', 'build', 'current', '--source', 'local'],
+      ['--json', 'context', 'build', 'current', '--source', 'local', '--agent'],
       {
         cwd,
         env: {
@@ -296,9 +346,14 @@ describe('context CLI integration', () => {
     assert.strictEqual(parsed.status, 'data');
     assert.strictEqual(parsed.data.source, 'local_workspace');
     assert.strictEqual(parsed.data.build.id, 'local-build-1');
+    assert.ok(
+      parsed.data.suggested_commands.every(item =>
+        item.command.endsWith('--source local')
+      )
+    );
   });
 
-  it('auto-selects local screenshot context when a workspace session is active', async () => {
+  it('auto-selects local screenshot context when local evidence is available', async () => {
     let cwd = createWorkspaceFixture();
     let vizzlyHome = join(cwd, '.vizzly-home');
     mkdirSync(vizzlyHome, { recursive: true });

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -310,9 +310,9 @@ describe('commands/context', () => {
       assert.deepStrictEqual(
         payload.suggested_commands.map(item => item.command),
         [
-          'vizzly --json context comparison cmp-1',
-          'vizzly --json context screenshot Dashboard',
-          'vizzly --json context build build-1 --agent --include diffs',
+          'vizzly --json context comparison cmp-1 --source cloud',
+          'vizzly --json context screenshot Dashboard --source cloud',
+          'vizzly --json context build build-1 --agent --include diffs --source cloud',
         ]
       );
     });
@@ -372,7 +372,7 @@ describe('commands/context', () => {
       );
       assert.ok(
         payload.suggested_commands.some(item =>
-          item.command.endsWith('--agent --full')
+          item.command.endsWith('--agent --full --source cloud')
         )
       );
     });

--- a/tests/commands/run-cli.test.js
+++ b/tests/commands/run-cli.test.js
@@ -172,7 +172,7 @@ describe('commands/run CLI', () => {
       assert.strictEqual(payload.data.comparisons.total, 0);
       assert.strictEqual(
         payload.data.contextCommand,
-        'vizzly context build build-123 --agent --json'
+        'vizzly context build build-123 --agent --json --source cloud'
       );
       assert.deepStrictEqual(
         requests.map(request => `${request.method} ${request.url}`),

--- a/tests/commands/status.test.js
+++ b/tests/commands/status.test.js
@@ -245,7 +245,8 @@ describe('commands/status', () => {
         suggestedCommands: [
           {
             label: 'Inspect build context',
-            command: 'vizzly --json context build build-123 --agent',
+            command:
+              'vizzly --json context build build-123 --agent --source cloud',
           },
           {
             label: 'List comparisons',
@@ -364,7 +365,8 @@ describe('commands/status', () => {
       assert.deepStrictEqual(createStatusSuggestedCommands(createBuild()), [
         {
           label: 'Inspect build context',
-          command: 'vizzly --json context build build-123 --agent',
+          command:
+            'vizzly --json context build build-123 --agent --source cloud',
         },
         {
           label: 'List comparisons',
@@ -475,7 +477,7 @@ describe('commands/status', () => {
           call =>
             call.method === 'print' &&
             call.args[0].includes(
-              'vizzly --json context build build-123 --agent'
+              'vizzly --json context build build-123 --agent --source cloud'
             )
         )
       );

--- a/tests/context/local-workspace-provider.test.js
+++ b/tests/context/local-workspace-provider.test.js
@@ -152,7 +152,79 @@ describe('context/local-workspace-provider', () => {
     assert.strictEqual(provider.canHandle('comparison', 'comp-1'), true);
     provider.getBuildContext('local-build');
 
-    assert.strictEqual(readCount, 7);
+    assert.strictEqual(readCount, 6);
+  });
+
+  it('does not treat a cloud session as local evidence', () => {
+    let projectRoot = '/tmp/vizzly-cloud-session-only';
+    let paths = createWorkspacePaths(projectRoot);
+    let provider = createLocalWorkspaceContextProvider(
+      { projectRoot },
+      {
+        readJsonIfExists: path => {
+          if (path === paths.session) {
+            return {
+              buildId: 'cloud-build',
+              branch: 'main',
+              commit: 'abc123',
+            };
+          }
+
+          return null;
+        },
+      }
+    );
+
+    assert.strictEqual(provider.isAvailable(), false);
+    assert.strictEqual(provider.canHandle('build', 'cloud-build'), false);
+  });
+
+  it('keeps stale local report evidence separate from a cloud session', () => {
+    let projectRoot = '/tmp/vizzly-cloud-session-with-local-report';
+    let paths = createWorkspacePaths(projectRoot);
+    let provider = createLocalWorkspaceContextProvider(
+      { projectRoot },
+      {
+        readJsonIfExists: path => {
+          if (path === paths.session) {
+            return {
+              buildId: 'cloud-build',
+              branch: 'main',
+              commit: 'abc123',
+            };
+          }
+
+          if (path === paths.report) {
+            return {
+              comparisons: [
+                {
+                  id: 'stale-local-comparison',
+                  name: 'Old local screenshot',
+                  status: 'failed',
+                  current: '/images/current/old.png',
+                  properties: {},
+                },
+              ],
+            };
+          }
+
+          if (path === paths.comparisonDetails) {
+            return {};
+          }
+
+          return null;
+        },
+      }
+    );
+
+    assert.strictEqual(provider.isAvailable(), true);
+    assert.strictEqual(provider.canHandle('build', 'cloud-build'), false);
+    assert.strictEqual(provider.canHandle('build', 'current'), true);
+
+    let context = provider.getBuildContext('current');
+    assert.strictEqual(context.build.id, 'local-workspace');
+    assert.strictEqual(context.build.branch, 'local');
+    assert.strictEqual(context.build.commit_sha, null);
   });
 
   it('caps the default local review queue size', () => {


### PR DESCRIPTION
## Why

A cloud run session can coexist with persisted local TDD evidence. The local provider was borrowing that cloud build identity, so automatic resolution could return stale local comparisons while claiming they belonged to the requested cloud build. Generated follow-up commands were also ambiguous and could cross the same boundary on their next invocation.

## Approach

- Treat only local server, report, and baseline artifacts as local evidence, and derive local build identity from the active local server when one exists.
- Pin every generated context follow-up to the cloud or local source that produced it.
- Carry the same explicit provenance through CLI help, JSON contract examples, and the packaged agent skill.

## Evidence

A real CLI regression now exercises a mixed workspace containing a cloud session and stale local report, proving the requested cloud build comes from the API. Local integration coverage proves generated TDD drill-downs remain local. The complete test suite, lint, formatting, and production build are green.