### PR TITLE
🐛 Keep run wait results API-truthful

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -510,9 +510,23 @@ export async function runCommand(
           });
 
           let exitCode = buildResult.failedComparisons > 0 ? 1 : 0;
+          let comparisons = {};
+          if (buildResult.totalComparisons !== undefined) {
+            comparisons.total = buildResult.totalComparisons;
+          }
+          if (buildResult.newComparisons !== undefined) {
+            comparisons.new = buildResult.newComparisons;
+          }
+          if (buildResult.failedComparisons !== undefined) {
+            comparisons.changed = buildResult.failedComparisons;
+          }
+          if (buildResult.identicalComparisons !== undefined) {
+            comparisons.identical = buildResult.identicalComparisons;
+          }
+
           let jsonResult = {
             buildId: result.buildId,
-            status: buildResult.failedComparisons > 0 ? 'failed' : 'completed',
+            status: buildResult.status,
             url: displayUrl,
             screenshotsCaptured: result.screenshotsCaptured || 0,
             executionTimeMs,
@@ -521,18 +535,21 @@ export async function runCommand(
               commit,
               message,
             },
-            comparisons: {
-              total: buildResult.totalComparisons || 0,
-              new: buildResult.newComparisons || 0,
-              changed: buildResult.failedComparisons || 0,
-              identical: buildResult.identicalComparisons || 0,
-            },
-            approvalStatus: buildResult.approvalStatus || 'pending',
             contextCommand: buildContextCommand(result.buildId, {
               structured: true,
             }),
             exitCode,
           };
+
+          if (Object.keys(comparisons).length > 0) {
+            jsonResult.comparisons = comparisons;
+          }
+          if (buildResult.approvalStatus !== undefined) {
+            jsonResult.approvalStatus = buildResult.approvalStatus;
+          }
+          if (buildResult.build?.conclusion !== undefined) {
+            jsonResult.conclusion = buildResult.build.conclusion;
+          }
 
           output.data(jsonResult);
           output.cleanup();
@@ -557,24 +574,51 @@ export async function runCommand(
     output.stopSpinner();
 
     // Once the user's tests have passed, no Vizzly-side error can change the
-    // result. This includes polling, formatting, and API response errors.
+    // test result. Keep that outcome while reporting that the API-backed build
+    // status is unavailable instead of inventing a terminal build state.
     if (result) {
-      if (globalOptions.json) {
-        output.data({
-          buildId: result.buildId || null,
-          status: 'completed',
-          message: 'Vizzly disabled after an SDK error',
-          executionTimeMs: Date.now() - (startTime || Date.now()),
-          exitCode: 0,
+      let apiBuild = error.context?.build;
+      let buildStatus = apiBuild?.status ?? null;
+      let exitCode = buildStatus === 'failed' ? 1 : 0;
+      let errorDetails = {
+        code: error.code || 'VIZZLY_STATUS_UNAVAILABLE',
+        message: error.getUserMessage ? error.getUserMessage() : error.message,
+      };
+      let unavailableResult = {
+        buildId: result.buildId || null,
+        status: buildStatus,
+        testsPassed: true,
+        error: errorDetails,
+        executionTimeMs: Date.now() - (startTime || Date.now()),
+        exitCode,
+      };
+
+      if (apiBuild?.conclusion !== undefined) {
+        unavailableResult.conclusion = apiBuild.conclusion;
+      }
+
+      if (result.buildId) {
+        unavailableResult.contextCommand = buildContextCommand(result.buildId, {
+          structured: true,
         });
+      }
+
+      if (globalOptions.json) {
+        output.data(unavailableResult);
+      } else if (buildStatus === 'failed') {
+        output.error(errorDetails.message);
       } else {
         output.warn(
-          'Vizzly encountered an error after your tests passed. Ignoring it.'
+          `Tests passed, but Vizzly could not confirm the build status: ${errorDetails.message}`
         );
       }
       output.cleanup();
       output.debug('run', 'Vizzly SDK error details', { error: error.message });
-      return { success: true, result };
+      return {
+        success: exitCode === 0,
+        exitCode,
+        result: unavailableResult,
+      };
     }
 
     // Provide more context about where the error occurred

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -205,10 +205,12 @@ export interface BuildResult {
   status: 'completed' | 'failed' | 'pending';
   build: unknown;
   comparisons?: number;
-  totalComparisons: number;
+  totalComparisons?: number;
   passedComparisons?: number;
   failedComparisons?: number;
-  newComparisons: number;
+  newComparisons?: number;
+  identicalComparisons?: number;
+  approvalStatus?: string;
   url?: string;
 }
 

--- a/src/uploader/core.js
+++ b/src/uploader/core.js
@@ -314,27 +314,24 @@ export function buildUploadResult({ buildId, url, total, uploaded, skipped }) {
  * @returns {Object} Wait result
  */
 export function buildWaitResult(build) {
-  let totalComparisons = build.comparisonsTotal ?? build.total_comparisons ?? 0;
+  let totalComparisons = build.comparisonsTotal ?? build.total_comparisons;
   let passedComparisons =
     build.comparisonsPassed ??
     build.passed_comparisons ??
     build.identicalComparisons ??
-    build.identical_comparisons ??
-    0;
+    build.identical_comparisons;
   let failedComparisons =
     build.comparisonsFailed ??
     build.failed_comparisons ??
     build.changedComparisons ??
-    build.changed_comparisons ??
-    0;
+    build.changed_comparisons;
   let newComparisons =
-    build.comparisonsNew ?? build.newComparisons ?? build.new_comparisons ?? 0;
+    build.comparisonsNew ?? build.newComparisons ?? build.new_comparisons;
   let identicalComparisons =
     build.identicalComparisons ??
     build.identical_comparisons ??
     passedComparisons;
-  let approvalStatus =
-    build.approvalStatus ?? build.approval_status ?? 'pending';
+  let approvalStatus = build.approvalStatus ?? build.approval_status;
   let hasComparisonCounts =
     build.comparisonsTotal !== undefined ||
     build.total_comparisons !== undefined ||
@@ -348,7 +345,7 @@ export function buildWaitResult(build) {
     build.identical_comparisons !== undefined;
 
   let result = {
-    status: 'completed',
+    status: build.status,
     build,
     passedComparisons,
     failedComparisons,

--- a/src/uploader/operations.js
+++ b/src/uploader/operations.js
@@ -299,7 +299,8 @@ export async function waitForBuild({ buildId, timeout, signal, client, deps }) {
     if (build.status === 'failed') {
       throw createError(
         `Build failed: ${build.error || 'Unknown error'}`,
-        'BUILD_FAILED'
+        'BUILD_FAILED',
+        { buildId, build }
       );
     }
 

--- a/tests/commands/run-cli.test.js
+++ b/tests/commands/run-cli.test.js
@@ -27,10 +27,15 @@ async function getFreePort() {
 }
 
 async function withApiServer(callback, options = {}) {
-  let { buildCreationStatus = 200 } = options;
+  let {
+    buildCreationStatus = 200,
+    waitStatusCode = 200,
+    waitBuildState = 'completed',
+  } = options;
   let buildId = 'build-123';
   let buildUrl = 'http://app.test/org/project/builds/build-123';
   let requests = [];
+  let buildReadCount = 0;
   let server = createServer((req, res) => {
     requests.push({ method: req.method, url: req.url });
     res.setHeader('content-type', 'application/json');
@@ -48,11 +53,22 @@ async function withApiServer(callback, options = {}) {
     }
 
     if (req.method === 'GET' && req.url === `/api/sdk/builds/${buildId}`) {
+      buildReadCount++;
+      if (buildReadCount > 1 && waitStatusCode !== 200) {
+        res.statusCode = waitStatusCode;
+        res.end(JSON.stringify({ error: 'build status unavailable' }));
+        return;
+      }
+
       res.end(
         JSON.stringify({
           build: {
             id: buildId,
-            status: 'completed',
+            status: buildReadCount > 1 ? waitBuildState : 'completed',
+            error:
+              buildReadCount > 1 && waitBuildState === 'failed'
+                ? 'comparison processing failed'
+                : undefined,
             url: buildUrl,
             total_comparisons: 0,
             new_comparisons: 0,
@@ -185,6 +201,89 @@ describe('commands/run CLI', () => {
         ]
       );
     });
+  });
+
+  it('does not claim the API build completed when its status is unavailable', async () => {
+    await withApiServer(
+      async ({ apiUrl }) => {
+        let cwd = createWorkspace();
+        let port = await getFreePort();
+
+        let result = await runCLI(
+          [
+            '--no-color',
+            '--json',
+            'run',
+            `node -e ${JSON.stringify('process.exit(0)')}`,
+            '--wait',
+            '--port',
+            String(port),
+          ],
+          {
+            cwd,
+            env: {
+              VIZZLY_API_URL: apiUrl,
+              VIZZLY_TOKEN: 'vzt_test_token',
+            },
+          }
+        );
+
+        assert.strictEqual(
+          result.code,
+          0,
+          `${result.stderr}\n${result.stdout}`
+        );
+        let payload = parseSingleJson(result.stdout);
+        assert.strictEqual(payload.data.status, null);
+        assert.strictEqual(payload.data.testsPassed, true);
+        assert.strictEqual(payload.data.error.code, 'BUILD_STATUS_FAILED');
+        assert.match(payload.data.error.message, /503/);
+        assert.strictEqual(
+          payload.data.contextCommand,
+          'vizzly context build build-123 --agent --json --source cloud'
+        );
+      },
+      { waitStatusCode: 503 }
+    );
+  });
+
+  it('preserves an API-reported failed build after the child tests pass', async () => {
+    await withApiServer(
+      async ({ apiUrl }) => {
+        let cwd = createWorkspace();
+        let port = await getFreePort();
+
+        let result = await runCLI(
+          [
+            '--no-color',
+            '--json',
+            'run',
+            `node -e ${JSON.stringify('process.exit(0)')}`,
+            '--wait',
+            '--port',
+            String(port),
+          ],
+          {
+            cwd,
+            env: {
+              VIZZLY_API_URL: apiUrl,
+              VIZZLY_TOKEN: 'vzt_test_token',
+            },
+          }
+        );
+
+        assert.strictEqual(result.code, 1);
+        let payload = parseSingleJson(result.stdout);
+        assert.strictEqual(payload.data.status, 'failed');
+        assert.strictEqual(payload.data.testsPassed, true);
+        assert.strictEqual(payload.data.error.code, 'BUILD_FAILED');
+        assert.match(
+          payload.data.error.message,
+          /comparison processing failed/
+        );
+      },
+      { waitBuildState: 'failed' }
+    );
   });
 
   it('runs the user test suite with Vizzly disabled when the API rejects the request', async () => {

--- a/tests/commands/run.test.js
+++ b/tests/commands/run.test.js
@@ -398,7 +398,11 @@ describe('commands/run', () => {
             waitForBuild: async buildId => {
               waitForBuildCalled = true;
               assert.strictEqual(buildId, 'build-123');
-              return { failedComparisons: 0, passedComparisons: 5 };
+              return {
+                status: 'completed',
+                failedComparisons: 0,
+                passedComparisons: 5,
+              };
             },
           }),
           runTests: async () => ({
@@ -441,6 +445,7 @@ describe('commands/run', () => {
           }),
           createUploader: () => ({
             waitForBuild: async () => ({
+              status: 'completed',
               failedComparisons: 3,
               passedComparisons: 5,
             }),
@@ -471,7 +476,7 @@ describe('commands/run', () => {
       );
     });
 
-    it('does not fail when build status polling returns any API error', async () => {
+    it('keeps passed tests separate from an unavailable API build status', async () => {
       let output = createMockOutput();
       let userTestsRan = false;
 
@@ -515,11 +520,17 @@ describe('commands/run', () => {
       assert.strictEqual(userTestsRan, true);
       assert.strictEqual(result.success, true);
       assert.strictEqual(result.result.buildId, 'build-123');
+      assert.strictEqual(result.result.status, null);
+      assert.strictEqual(result.result.testsPassed, true);
+      assert.deepStrictEqual(result.result.error, {
+        code: 'BUILD_STATUS_FAILED',
+        message: 'Failed to check build status',
+      });
       assert.ok(
         output.calls.some(
           call =>
             call.method === 'warn' &&
-            call.args[0].includes('after your tests passed')
+            call.args[0].includes('could not confirm the build status')
         )
       );
     });
@@ -729,6 +740,8 @@ describe('commands/run', () => {
             waitForBuild: async buildId => {
               assert.strictEqual(buildId, 'build-123');
               return {
+                status: 'completed',
+                build: { conclusion: 'review_required' },
                 totalComparisons: 3,
                 newComparisons: 1,
                 failedComparisons: 2,
@@ -757,7 +770,8 @@ describe('commands/run', () => {
       let dataCalls = output.calls.filter(c => c.method === 'data');
 
       assert.strictEqual(dataCalls.length, 1);
-      assert.strictEqual(dataCalls[0].args[0].status, 'failed');
+      assert.strictEqual(dataCalls[0].args[0].status, 'completed');
+      assert.strictEqual(dataCalls[0].args[0].conclusion, 'review_required');
       assert.deepStrictEqual(dataCalls[0].args[0].comparisons, {
         total: 3,
         new: 1,

--- a/tests/uploader/core.test.js
+++ b/tests/uploader/core.test.js
@@ -408,21 +408,22 @@ describe('uploader/core', () => {
         totalComparisons: 10,
         passedComparisons: 8,
         failedComparisons: 2,
-        newComparisons: 0,
+        newComparisons: undefined,
         identicalComparisons: 8,
-        approvalStatus: 'pending',
+        approvalStatus: undefined,
         url: 'https://example.com/builds/123',
       });
     });
 
-    it('defaults comparison values when not present', () => {
+    it('does not invent comparison values when the API omits them', () => {
       let build = { id: 'build-123', status: 'completed' };
       let result = buildWaitResult(build);
 
-      assert.strictEqual(result.passedComparisons, 0);
-      assert.strictEqual(result.failedComparisons, 0);
-      assert.strictEqual(result.totalComparisons, 0);
-      assert.strictEqual(result.newComparisons, 0);
+      assert.strictEqual(result.passedComparisons, undefined);
+      assert.strictEqual(result.failedComparisons, undefined);
+      assert.strictEqual(result.totalComparisons, undefined);
+      assert.strictEqual(result.newComparisons, undefined);
+      assert.strictEqual(result.approvalStatus, undefined);
       assert.strictEqual(result.comparisons, undefined);
     });
 

--- a/tests/uploader/operations.test.js
+++ b/tests/uploader/operations.test.js
@@ -42,9 +42,10 @@ describe('uploader/operations', () => {
 
       let deps = {
         readFile: async filePath => Buffer.from(`content-${filePath}`),
-        createError: (msg, code) => {
+        createError: (msg, code, context) => {
           let err = new Error(msg);
           err.code = code;
+          err.context = context;
           return err;
         },
       };
@@ -456,9 +457,10 @@ describe('uploader/operations', () => {
       };
 
       let deps = {
-        createError: (msg, code) => {
+        createError: (msg, code, context) => {
           let err = new Error(msg);
           err.code = code;
+          err.context = context;
           return err;
         },
         createTimeoutError: () => new Error(),
@@ -476,6 +478,7 @@ describe('uploader/operations', () => {
         error => {
           assert.ok(error.message.includes('Build failed'));
           assert.strictEqual(error.code, 'BUILD_FAILED');
+          assert.strictEqual(error.context.build.status, 'failed');
           return true;
         }
       );


### PR DESCRIPTION
## Why

The legacy dogfood run hit a build-status polling timeout after the child tests passed. The CLI then reported the build as completed even though the API had not returned that terminal state, giving agents a result that Vizzly never supplied.

## Approach

The existing bounded polling behavior stays intact so stalled processing still surfaces. Build lifecycle status now comes directly from the API, review outcomes stay separate, and missing comparison or approval fields remain absent instead of becoming zero or pending.

If polling fails after the child tests pass, JSON reports a null build status alongside the real error and a context command. An API-reported failed build remains failed and preserves the existing nonzero visual-test outcome.

## Evidence

CLI boundary coverage exercises completed, failed, and unavailable status responses through a real local HTTP server. The focused contract tests and lint remain green after narrowing the change; the full suite, public type checks, and production build passed on this branch.