### PR TITLE
🐛 Preserve API context evidence

### DIFF
--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -108,6 +108,21 @@ function createClient(config, createApiClient) {
   });
 }
 
+/**
+ * Attach the provider that produced a context payload.
+ *
+ * Context endpoints return API-owned evidence, while source selection belongs
+ * to the CLI. Keeping both in one payload prevents follow-up agent commands
+ * from silently crossing between cloud and local evidence.
+ *
+ * @param {Object} context - Context payload returned by a provider.
+ * @param {string} source - Provider source selected by the CLI.
+ * @returns {Object} Context payload with explicit source provenance.
+ */
+function attachContextSource(context, source) {
+  return { ...context, source: context?.source || source };
+}
+
 async function loadContextConfig(globalOptions, options, deps) {
   let {
     loadConfig = defaultLoadConfig,
@@ -143,19 +158,34 @@ function createCloudContextProvider(config, deps = {}) {
   return {
     source: 'cloud',
     async getBuildContext(buildId, query) {
-      return await getBuildContext(client, buildId, query);
+      return attachContextSource(
+        await getBuildContext(client, buildId, query),
+        'cloud'
+      );
     },
     async getComparisonContext(comparisonId, query) {
-      return await getComparisonContext(client, comparisonId, query);
+      return attachContextSource(
+        await getComparisonContext(client, comparisonId, query),
+        'cloud'
+      );
     },
     async getScreenshotContext(screenshotName, query) {
-      return await getScreenshotContext(client, screenshotName, query);
+      return attachContextSource(
+        await getScreenshotContext(client, screenshotName, query),
+        'cloud'
+      );
     },
     async getSimilarFingerprintContext(fingerprintHash, query) {
-      return await getSimilarFingerprintContext(client, fingerprintHash, query);
+      return attachContextSource(
+        await getSimilarFingerprintContext(client, fingerprintHash, query),
+        'cloud'
+      );
     },
     async getReviewQueueContext(query) {
-      return await getReviewQueueContext(client, query);
+      return attachContextSource(
+        await getReviewQueueContext(client, query),
+        'cloud'
+      );
     },
   };
 }
@@ -609,7 +639,8 @@ function buildAgentBuildPayload(
   let evidenceTruncated = candidates.length > evidence.length;
   let payload = {
     resource: 'build_agent_context',
-    source: normalized.source || source || 'cloud',
+    source: normalized.source || source,
+    review_flow: normalized.review_flow,
     scope: normalized.scope || null,
     project: {
       organization: normalized.scope?.organization?.slug || null,

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -517,6 +517,40 @@ function groupFlatComparisons(comparisons = [], options = {}) {
 }
 
 /**
+ * Join compact group variants to the exact comparison records in the same API
+ * response.
+ *
+ * The build context API deliberately keeps group variants small while also
+ * returning complete comparison evidence at the top level. Joining by the
+ * server-owned comparison ID keeps the useful group ordering and aggregates
+ * without dropping screenshot identity, baseline facts, or Honeydiff data.
+ *
+ * @param {Object[]} groups - Raw comparison groups from build context.
+ * @param {Object[]} comparisons - Exact top-level comparison records.
+ * @returns {Object[]} Groups whose variants include exact comparison evidence.
+ */
+function joinGroupComparisons(groups = [], comparisons = []) {
+  let comparisonsById = new Map(
+    comparisons
+      .filter(comparison => comparison?.id)
+      .map(comparison => [comparison.id, comparison])
+  );
+
+  return groups.map(group => {
+    let variantKey = Array.isArray(group.variants) ? 'variants' : 'comparisons';
+    let variants = Array.isArray(group[variantKey]) ? group[variantKey] : [];
+
+    return {
+      ...group,
+      [variantKey]: variants.map(variant => ({
+        ...variant,
+        ...(comparisonsById.get(variant.id) || {}),
+      })),
+    };
+  });
+}
+
+/**
  * Keep failed capture identity, render evidence, and the API error together.
  *
  * A capture can fail before any comparison exists, so it must remain useful
@@ -589,9 +623,10 @@ export function normalizeBuildContext(context = {}, options = {}) {
   let comparisons = rawComparisons.map(comparison =>
     normalizeComparisonRecord(comparison, options)
   );
+  let joinedGroups = joinGroupComparisons(context.groups || [], rawComparisons);
   let groups =
-    Array.isArray(context.groups) && context.groups.length > 0
-      ? context.groups.map(group => normalizeComparisonGroup(group, options))
+    joinedGroups.length > 0
+      ? joinedGroups.map(group => normalizeComparisonGroup(group, options))
       : groupFlatComparisons(rawComparisons, options);
 
   return {

--- a/tests/commands/context-cli.test.js
+++ b/tests/commands/context-cli.test.js
@@ -143,6 +143,39 @@ function createWorkspaceFixture() {
 
 async function withBuildContextApi(callback) {
   let requests = [];
+  let comparisons = Array.from({ length: 11 }, (_, index) => ({
+    id: `comparison-${index + 1}`,
+    screenshot_name: `Screenshot ${index + 1}`,
+    result: 'changed',
+    needs_review: true,
+    visual_review: { state: 'pending' },
+    is_flaky: false,
+    screenshot: {
+      id: `current-${index + 1}`,
+      name: `Screenshot ${index + 1}`,
+      browser: 'chrome',
+      viewport: { width: 1440, height: 900 },
+      bitmap: { width: 2880, height: 1800 },
+      metadata: { locale: 'en-US' },
+      signature: `Screenshot ${index + 1}|1440|chrome`,
+      url: `https://cdn.test/current-${index + 1}.png`,
+      baseline: {
+        id: `baseline-${index + 1}`,
+        build_id: 'baseline-build',
+        name: `Screenshot ${index + 1}`,
+        url: `https://cdn.test/baseline-${index + 1}.png`,
+      },
+    },
+    diff: {
+      percentage: index + 0.5,
+      changed_pixels: index + 10,
+      total_pixels: 5184000,
+      image_url: `https://cdn.test/diff-${index + 1}.png`,
+      fingerprint_hash: `fingerprint-${index + 1}`,
+      projection: { clusters: { count: 1 } },
+      regions: [{ x: 10, y: 20, width: 30, height: 40 }],
+    },
+  }));
   let groups = Array.from({ length: 11 }, (_, index) => ({
     name: `Screenshot ${index + 1}`,
     variant_count: 1,
@@ -155,39 +188,66 @@ async function withBuildContextApi(callback) {
       {
         id: `comparison-${index + 1}`,
         result: 'changed',
+        status: 'completed',
         needs_review: true,
         visual_review: { state: 'pending' },
-        current_screenshot: {
-          id: `current-${index + 1}`,
-          name: `Screenshot ${index + 1}`,
-          browser: 'chrome',
-          viewport: { width: 1440, height: 900 },
-          bitmap: { width: 2880, height: 1800 },
-          metadata: { locale: 'en-US' },
-          signature: `Screenshot ${index + 1}|1440|chrome`,
-          url: `https://cdn.test/current-${index + 1}.png`,
-        },
-        baseline_screenshot: {
-          id: `baseline-${index + 1}`,
-          build_id: 'baseline-build',
-          url: `https://cdn.test/baseline-${index + 1}.png`,
-        },
-        analysis: {
-          diff_image_url: `https://cdn.test/diff-${index + 1}.png`,
-          fingerprint_hash: `fingerprint-${index + 1}`,
-          projection: { clusters: { count: 1 } },
-          diff_regions: [{ x: 10, y: 20, width: 30, height: 40 }],
-        },
+        diff_percentage: index + 0.5,
       },
     ],
   }));
   let server = createServer((req, res) => {
     requests.push(req.url);
     res.setHeader('content-type', 'application/json');
+
+    if (req.url.startsWith('/api/sdk/context/comparisons/')) {
+      res.end(
+        JSON.stringify({
+          resource: 'comparison_context',
+          review_flow: 'legacy',
+          comparison: comparisons[0],
+        })
+      );
+      return;
+    }
+
+    if (req.url.startsWith('/api/sdk/context/screenshots/')) {
+      res.end(
+        JSON.stringify({
+          resource: 'screenshot_context',
+          review_flow: 'legacy',
+          screenshot: { name: 'Screenshot 1' },
+        })
+      );
+      return;
+    }
+
+    if (req.url.startsWith('/api/sdk/context/fingerprints/')) {
+      res.end(
+        JSON.stringify({
+          resource: 'fingerprint_context',
+          review_flow: 'legacy',
+          fingerprint: { hash: 'fingerprint-1' },
+          matches: [],
+        })
+      );
+      return;
+    }
+
+    if (req.url.startsWith('/api/sdk/context/review-queue')) {
+      res.end(
+        JSON.stringify({
+          resource: 'review_queue_context',
+          review_flow: 'legacy',
+          comparisons: [],
+        })
+      );
+      return;
+    }
+
     res.end(
       JSON.stringify({
         resource: 'build_context',
-        source: 'cloud',
+        review_flow: 'legacy',
         scope: {
           organization: { slug: 'acme' },
           project: { slug: 'web', name: 'Web' },
@@ -196,6 +256,7 @@ async function withBuildContextApi(callback) {
         status: { needs_review: true, pending_comparisons: 11 },
         summary: { comparisons: { total: 11, changed: 11 } },
         groups,
+        comparisons,
       })
     );
   });
@@ -230,7 +291,15 @@ describe('context CLI integration', () => {
       let compactPayload = JSON.parse(compact.stdout).data;
       assert.strictEqual(compactPayload.evidence_returned, 10);
       assert.strictEqual(compactPayload.evidence_truncated, true);
+      assert.strictEqual(compactPayload.source, 'cloud');
+      assert.strictEqual(compactPayload.review_flow, 'legacy');
       assert.strictEqual(compactPayload.evidence[0].review_state, 'pending');
+      assert.strictEqual(compactPayload.evidence[0].id, 'comparison-1');
+      assert.strictEqual(compactPayload.evidence[0].name, 'Screenshot 1');
+      assert.strictEqual(compactPayload.evidence[0].is_flaky, false);
+      assert.strictEqual(compactPayload.evidence[0].screenshot.id, 'current-1');
+      assert.strictEqual(compactPayload.evidence[0].baseline.id, 'baseline-1');
+      assert.strictEqual(compactPayload.evidence[0].diff.total_pixels, 5184000);
       assert.strictEqual(
         compactPayload.evidence[0].screenshot.url,
         'https://cdn.test/current-1.png'
@@ -265,6 +334,34 @@ describe('context CLI integration', () => {
         '/api/sdk/context/builds/build-123?details=summary',
         '/api/sdk/context/builds/build-123?details=diffs',
       ]);
+    });
+  });
+
+  it('labels every cloud context resource with its selected source', async () => {
+    await withBuildContextApi(async ({ apiUrl }) => {
+      let cwd = mkdtempSync(join(tmpdir(), 'vizzly-context-provenance-'));
+      let env = {
+        VIZZLY_API_URL: apiUrl,
+        VIZZLY_TOKEN: 'vzt_test_token',
+      };
+      let commands = [
+        ['comparison', 'comparison-1'],
+        ['screenshot', 'Screenshot 1'],
+        ['similar', 'fingerprint-1'],
+        ['review-queue'],
+      ];
+
+      for (let command of commands) {
+        let result = await runCLI(
+          ['--json', 'context', ...command, '--source', 'cloud'],
+          { cwd, env }
+        );
+
+        assert.strictEqual(result.code, 0, result.stderr);
+        let payload = JSON.parse(result.stdout).data;
+        assert.strictEqual(payload.source, 'cloud');
+        assert.strictEqual(payload.review_flow, 'legacy');
+      }
     });
   });
 

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -166,7 +166,11 @@ describe('commands/context', () => {
       assert.ok(dataCall);
       assert.strictEqual(dataCall.args[0].resource, 'build_context');
       assert.strictEqual(dataCall.args[0].build.id, 'build-1');
-      assert.strictEqual(dataCall.args[0], context);
+      assert.strictEqual(dataCall.args[0].source, 'cloud');
+      assert.deepStrictEqual(dataCall.args[0], {
+        ...context,
+        source: 'cloud',
+      });
       assert.strictEqual(capturedQuery, undefined);
     });
 

--- a/tests/utils/visual-context-normalizers.test.js
+++ b/tests/utils/visual-context-normalizers.test.js
@@ -145,6 +145,73 @@ describe('visual context normalizers', () => {
     );
   });
 
+  it('joins grouped variants to exact API comparison evidence by ID', () => {
+    let context = normalizeBuildContext({
+      groups: [
+        {
+          name: 'Public build detail',
+          total_variants: 1,
+          comparisons: [
+            {
+              id: 'comparison-1',
+              result: 'changed',
+              status: 'completed',
+              approval_status: 'pending',
+              diff_percentage: 0.52,
+            },
+          ],
+        },
+      ],
+      comparisons: [
+        {
+          id: 'comparison-1',
+          screenshot_name: 'public-build-detail-approved',
+          result: 'changed',
+          approval_status: 'pending',
+          needs_review: true,
+          is_flaky: false,
+          screenshot: {
+            id: 'screenshot-1',
+            name: 'public-build-detail-approved',
+            browser: 'chrome',
+            signature: 'public-build-detail-approved|1440|chrome',
+            url: 'https://cdn.test/current.png',
+            baseline: {
+              id: 'baseline-1',
+              build_id: 'baseline-build',
+              name: 'public-build-detail-approved',
+              url: 'https://cdn.test/baseline.png',
+            },
+          },
+          diff: {
+            percentage: 0.52,
+            changed_pixels: 120,
+            total_pixels: 2221440,
+            fingerprint_hash: 'fingerprint-1',
+          },
+        },
+      ],
+    });
+
+    let comparison = context.groups[0].variants[0];
+    assert.strictEqual(comparison.id, 'comparison-1');
+    assert.strictEqual(comparison.name, 'public-build-detail-approved');
+    assert.strictEqual(comparison.status, 'completed');
+    assert.strictEqual(comparison.is_flaky, false);
+    assert.strictEqual(comparison.screenshot.id, 'screenshot-1');
+    assert.strictEqual(
+      comparison.screenshot.signature,
+      'public-build-detail-approved|1440|chrome'
+    );
+    assert.strictEqual(comparison.baseline.id, 'baseline-1');
+    assert.strictEqual(
+      comparison.baseline.name,
+      'public-build-detail-approved'
+    );
+    assert.strictEqual(comparison.diff.total_pixels, 2221440);
+    assert.strictEqual(comparison.diff.fingerprint_hash, 'fingerprint-1');
+  });
+
   it('preserves aggregate-only review facts and failed capture evidence', () => {
     let context = normalizeBuildContext({
       groups: [


### PR DESCRIPTION
## Why

Compact build context was using the API’s intentionally slim grouped variants as if they were complete comparison records. That dropped the screenshot identity, baseline, and Honeydiff evidence an agent needs to understand and act on a visual change.

Cloud drill-down commands also did not consistently say which provider produced their payload.

## What changed

- Join grouped variants to the exact top-level comparison record by the API-owned comparison ID while preserving server ordering and aggregates.
- Carry the selected cloud source across every context resource and pass through the API-provided review flow.
- Exercise the real slim-group plus rich-comparison response shape at the CLI boundary.

## Confidence

Focused context coverage passes with 47 tests, and the full CLI suite, type checks, build, and lint are clean. A packaged CLI completed a fresh 332-test, 208-screenshot dogfood run, then returned complete compact evidence on the legacy path and preserved Cricket review state on the current path.