### PR TITLE
🐛 Preserve artifacts in agent context

### DIFF
--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -206,9 +206,10 @@ function getBaselineScreenshot(comparison = {}) {
 /**
  * Project compact Honeydiff facts without making raw geometry the default.
  *
- * Agents need stable counts, fingerprints, URLs, and the API projection for
- * first-pass diagnosis. Raw regions and scoring details stay behind an
- * explicit include because they can dominate an otherwise bounded handoff.
+ * Agents need stable counts, fingerprints, URLs, the API projection, and the
+ * server's authoritative artifact manifest for first-pass diagnosis. Raw
+ * regions and scoring details stay behind an explicit include because they
+ * can dominate an otherwise bounded handoff.
  *
  * @param {Object} comparison - Comparison record from the API.
  * @param {boolean} includeDiffs - Whether to include raw Honeydiff diagnostics.
@@ -231,6 +232,8 @@ function getComparisonDiff(comparison = {}, includeDiffs = false) {
     comparison.analysis_projection ||
     comparison.projection ||
     null;
+  let artifacts =
+    diff.artifacts ?? analysis.artifacts ?? comparison.artifacts ?? null;
 
   let compact = {
     percentage:
@@ -271,6 +274,12 @@ function getComparisonDiff(comparison = {}, includeDiffs = false) {
       comparison.diff_image_url ||
       null,
   };
+
+  // Preserve server-owned evidence exactly so agents can verify and download
+  // artifacts without the CLI recreating identities, digests, or availability.
+  if (artifacts != null) {
+    compact.artifacts = artifacts;
+  }
 
   if (includeDiffs) {
     compact.regions = regions || [];

--- a/tests/commands/context-cli.test.js
+++ b/tests/commands/context-cli.test.js
@@ -173,6 +173,32 @@ async function withBuildContextApi(callback) {
       image_url: `https://cdn.test/diff-${index + 1}.png`,
       fingerprint_hash: `fingerprint-${index + 1}`,
       projection: { clusters: { count: 1 } },
+      artifacts: {
+        analysis: {
+          available: true,
+          schema_version: 2,
+          size_bytes: 1024,
+          content_encoding: 'gzip',
+        },
+        effective_mask: {
+          evidence_status: 'complete',
+          available: true,
+          complete: true,
+          download_url: `/api/sdk/context/comparisons/comparison-${index + 1}/effective-mask`,
+          digest: `sha256:mask-${index + 1}`,
+          width: 2880,
+          height: 1800,
+          pixel_count: index + 10,
+          size_bytes: 2048,
+          mime_type: 'image/png',
+          honeydiff_version: '0.13.1',
+          mask_semantics_version: 'effective-mask-v1',
+          capture_identity_hash: `capture:v2:${index + 1}`,
+          render_profile_hash: 'render-profile:v2:shared',
+          analysis_contract_hash: 'analysis-contract:v1:shared',
+          coordinate_space_version: 'bitmap-top-left-v1',
+        },
+      },
       regions: [{ x: 10, y: 20, width: 30, height: 40 }],
     },
   }));
@@ -200,11 +226,17 @@ async function withBuildContextApi(callback) {
     res.setHeader('content-type', 'application/json');
 
     if (req.url.startsWith('/api/sdk/context/comparisons/')) {
+      let comparison = {
+        ...comparisons[0],
+        diff: undefined,
+        analysis: comparisons[0].diff,
+      };
+
       res.end(
         JSON.stringify({
           resource: 'comparison_context',
           review_flow: 'legacy',
-          comparison: comparisons[0],
+          comparison,
         })
       );
       return;
@@ -342,6 +374,33 @@ describe('context CLI integration', () => {
         compactPayload.evidence[0].diff.image_url,
         'https://cdn.test/diff-1.png'
       );
+      assert.deepStrictEqual(compactPayload.evidence[0].diff.artifacts, {
+        analysis: {
+          available: true,
+          schema_version: 2,
+          size_bytes: 1024,
+          content_encoding: 'gzip',
+        },
+        effective_mask: {
+          evidence_status: 'complete',
+          available: true,
+          complete: true,
+          download_url:
+            '/api/sdk/context/comparisons/comparison-1/effective-mask',
+          digest: 'sha256:mask-1',
+          width: 2880,
+          height: 1800,
+          pixel_count: 10,
+          size_bytes: 2048,
+          mime_type: 'image/png',
+          honeydiff_version: '0.13.1',
+          mask_semantics_version: 'effective-mask-v1',
+          capture_identity_hash: 'capture:v2:1',
+          render_profile_hash: 'render-profile:v2:shared',
+          analysis_contract_hash: 'analysis-contract:v1:shared',
+          coordinate_space_version: 'bitmap-top-left-v1',
+        },
+      });
       assert.ok(!compactPayload.evidence[0].diff.regions);
       assert.ok(!compactPayload.groups);
       assert.ok(!compactPayload.next_actions);
@@ -421,6 +480,14 @@ describe('context CLI integration', () => {
       assert.deepStrictEqual(payload.comparison.diff.regions, [
         { x: 10, y: 20, width: 30, height: 40 },
       ]);
+      assert.strictEqual(
+        payload.comparison.diff.artifacts.effective_mask.digest,
+        'sha256:mask-1'
+      );
+      assert.strictEqual(
+        payload.comparison.diff.artifacts.effective_mask.capture_identity_hash,
+        'capture:v2:1'
+      );
     });
   });
 


### PR DESCRIPTION
## Why

A production context check showed that raw API responses contain complete Honeydiff artifact evidence, but the compact `--agent` projection drops that manifest. That leaves an agent without the authoritative mask URL, digest, dimensions, and versioned identities it needs to inspect a diff.

## Approach

Preserve the API-owned artifact manifest in compact diff output for both build-context and focused-comparison response shapes. The CLI passes the object through only when the server supplied it; it does not infer availability, identities, digests, or other evidence.

## Confidence

CLI-level regression coverage exercises both cloud context commands through an HTTP boundary and confirms the complete manifest survives while raw region arrays remain opt-in. The broader context and normalizer coverage, full CLI suite, build, and a read-only production check are all clean.