### PR TITLE
✨ Preserve visual evidence in agent context

### DIFF
--- a/src/commands/context.js
+++ b/src/commands/context.js
@@ -681,6 +681,7 @@ function buildAgentBuildPayload(
     },
     status: normalized.status || null,
     summary: normalized.summary || null,
+    dynamic_regions: normalized.dynamic_regions ?? null,
     signature_properties: normalized.signature_properties ?? null,
     evidence_limit: evidenceLimit,
     evidence_offset: evidenceOffset,
@@ -741,6 +742,7 @@ function buildAgentComparisonPayload(context = {}) {
     comparison: normalizeComparisonRecord(context.comparison || {}, {
       includeDiffs: true,
     }),
+    dynamic_regions: context.dynamic_regions ?? null,
     dynamic_content: context.dynamic_content ?? null,
     history: {
       ...history,

--- a/src/utils/visual-context-normalizers.js
+++ b/src/utils/visual-context-normalizers.js
@@ -207,9 +207,10 @@ function getBaselineScreenshot(comparison = {}) {
  * Project compact Honeydiff facts without making raw geometry the default.
  *
  * Agents need stable counts, fingerprints, URLs, the API projection, and the
- * server's authoritative artifact manifest for first-pass diagnosis. Raw
- * regions and scoring details stay behind an explicit include because they
- * can dominate an otherwise bounded handoff.
+ * server's authoritative artifact manifest for first-pass diagnosis. Keeping
+ * that manifest intact prevents the CLI from becoming less authoritative than
+ * the API. Raw regions and scoring details stay behind an explicit include
+ * because they can dominate an otherwise bounded handoff.
  *
  * @param {Object} comparison - Comparison record from the API.
  * @param {boolean} includeDiffs - Whether to include raw Honeydiff diagnostics.

--- a/tests/commands/context-cli.test.js
+++ b/tests/commands/context-cli.test.js
@@ -180,19 +180,19 @@ async function withBuildContextApi(callback) {
           size_bytes: 1024,
           content_encoding: 'gzip',
         },
-        effective_mask: {
+        diff_mask: {
           evidence_status: 'complete',
           available: true,
           complete: true,
-          download_url: `/api/sdk/context/comparisons/comparison-${index + 1}/effective-mask`,
-          digest: `sha256:mask-${index + 1}`,
+          download_url: `/api/sdk/context/comparisons/comparison-${index + 1}/diff-mask`,
+          digest: `sha256:${'a'.repeat(64)}`,
           width: 2880,
           height: 1800,
           pixel_count: index + 10,
           size_bytes: 2048,
           mime_type: 'image/png',
-          honeydiff_version: '0.13.1',
-          mask_semantics_version: 'effective-mask-v1',
+          honeydiff_version: '0.14.0',
+          mask_semantics_version: 'diff-mask-v1',
           capture_identity_hash: `capture:v2:${index + 1}`,
           render_profile_hash: 'render-profile:v2:shared',
           analysis_contract_hash: 'analysis-contract:v1:shared',
@@ -381,20 +381,19 @@ describe('context CLI integration', () => {
           size_bytes: 1024,
           content_encoding: 'gzip',
         },
-        effective_mask: {
+        diff_mask: {
           evidence_status: 'complete',
           available: true,
           complete: true,
-          download_url:
-            '/api/sdk/context/comparisons/comparison-1/effective-mask',
-          digest: 'sha256:mask-1',
+          download_url: '/api/sdk/context/comparisons/comparison-1/diff-mask',
+          digest: `sha256:${'a'.repeat(64)}`,
           width: 2880,
           height: 1800,
           pixel_count: 10,
           size_bytes: 2048,
           mime_type: 'image/png',
-          honeydiff_version: '0.13.1',
-          mask_semantics_version: 'effective-mask-v1',
+          honeydiff_version: '0.14.0',
+          mask_semantics_version: 'diff-mask-v1',
           capture_identity_hash: 'capture:v2:1',
           render_profile_hash: 'render-profile:v2:shared',
           analysis_contract_hash: 'analysis-contract:v1:shared',
@@ -480,14 +479,24 @@ describe('context CLI integration', () => {
       assert.deepStrictEqual(payload.comparison.diff.regions, [
         { x: 10, y: 20, width: 30, height: 40 },
       ]);
-      assert.strictEqual(
-        payload.comparison.diff.artifacts.effective_mask.digest,
-        'sha256:mask-1'
-      );
-      assert.strictEqual(
-        payload.comparison.diff.artifacts.effective_mask.capture_identity_hash,
-        'capture:v2:1'
-      );
+      assert.deepStrictEqual(payload.comparison.diff.artifacts.diff_mask, {
+        evidence_status: 'complete',
+        available: true,
+        complete: true,
+        download_url: '/api/sdk/context/comparisons/comparison-1/diff-mask',
+        digest: `sha256:${'a'.repeat(64)}`,
+        width: 2880,
+        height: 1800,
+        pixel_count: 10,
+        size_bytes: 2048,
+        mime_type: 'image/png',
+        honeydiff_version: '0.14.0',
+        mask_semantics_version: 'diff-mask-v1',
+        capture_identity_hash: 'capture:v2:1',
+        render_profile_hash: 'render-profile:v2:shared',
+        analysis_contract_hash: 'analysis-contract:v1:shared',
+        coordinate_space_version: 'bitmap-top-left-v1',
+      });
     });
   });
 

--- a/tests/commands/context-cli.test.js
+++ b/tests/commands/context-cli.test.js
@@ -6,6 +6,53 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { parseJSONOutput, runCLI } from '../helpers/cli-runner.js';
 
+function createDynamicRegionResolutionContext() {
+  return {
+    systemResolution: {
+      type: 'dynamic_region_containment',
+      contractVersion: 'dynamic-region-containment-v1',
+      evidence: {
+        id: 'c5b6c137-39d7-4c8b-a7c0-b3a5e41d85da',
+        diffImageId: '64b2873e-3f76-43a1-9ff4-577c7f312ce2',
+        maskDigest: `sha256:${'a'.repeat(64)}`,
+        captureIdentityHash: `capture:v2:${'b'.repeat(64)}`,
+        analysisContractHash: `diff-mask-analysis-v1:${'c'.repeat(64)}`,
+        renderProfileHash: `render-profile:v2:${'d'.repeat(64)}`,
+        componentCount: 20,
+        containedComponentCount: 20,
+      },
+      policies: [
+        {
+          id: 'cf919da4-a9d0-4f7e-8c09-99c9f47138ce',
+          revision: 3,
+          revisionEvent: {
+            id: '9c2a7037-2a69-4ccb-bd4f-7b497bc23fca',
+            type: 'region.revised',
+            occurredAt: '2026-07-25T12:00:00.000Z',
+          },
+          geometry: {
+            anchorX: 'right',
+            anchorY: 'bottom',
+            coordinateSpaceVersion: 'bitmap-anchor-v1',
+            width: 361,
+            height: 15,
+            insetX: 352,
+            insetY: 49,
+          },
+          assignment: {
+            id: '2f07a9a1-b0c6-4bd6-a1dc-ac63812703c9',
+            captureIdentityHash: `capture:v2:${'b'.repeat(64)}`,
+            analysisContractHash: `diff-mask-analysis-v1:${'c'.repeat(64)}`,
+            screenshotName: 'Screenshot 1',
+            assignedAt: '2026-07-25T11:00:00.000Z',
+          },
+        },
+      ],
+      resolvedAt: '2026-07-25T12:05:00.000Z',
+    },
+  };
+}
+
 function createWorkspaceFixture() {
   let cwd = join(
     tmpdir(),
@@ -235,8 +282,9 @@ async function withBuildContextApi(callback) {
       res.end(
         JSON.stringify({
           resource: 'comparison_context',
-          review_flow: 'legacy',
+          review_flow: 'cricket_v1',
           comparison,
+          dynamic_regions: createDynamicRegionResolutionContext(),
         })
       );
       return;
@@ -497,6 +545,10 @@ describe('context CLI integration', () => {
         analysis_contract_hash: 'analysis-contract:v1:shared',
         coordinate_space_version: 'bitmap-top-left-v1',
       });
+      assert.deepStrictEqual(
+        payload.dynamic_regions,
+        createDynamicRegionResolutionContext()
+      );
     });
   });
 
@@ -523,7 +575,10 @@ describe('context CLI integration', () => {
         assert.strictEqual(result.code, 0, result.stderr);
         let payload = JSON.parse(result.stdout).data;
         assert.strictEqual(payload.source, 'cloud');
-        assert.strictEqual(payload.review_flow, 'legacy');
+        assert.strictEqual(
+          payload.review_flow,
+          command[0] === 'comparison' ? 'cricket_v1' : 'legacy'
+        );
       }
     });
   });

--- a/tests/commands/context.test.js
+++ b/tests/commands/context.test.js
@@ -230,6 +230,15 @@ describe('commands/context', () => {
             summary: {
               comparisons: { total: 2, changed: 1, new: 1, identical: 0 },
             },
+            dynamic_regions: {
+              policies: [
+                {
+                  region: { id: 'region-1', status: 'confirmed' },
+                  assignments: [{ screenshotName: 'Dashboard' }],
+                },
+              ],
+              proposals: { proposals: [] },
+            },
             screenshots: [{ id: 'ss-1', name: 'Dashboard' }],
             comparisons: [
               {
@@ -295,6 +304,15 @@ describe('commands/context', () => {
       assert.strictEqual(payload.build.id, 'build-1');
       assert.strictEqual(payload.baseline.selected.name, 'Approved Main');
       assert.strictEqual(payload.status.needs_review, true);
+      assert.deepStrictEqual(payload.dynamic_regions, {
+        policies: [
+          {
+            region: { id: 'region-1', status: 'confirmed' },
+            assignments: [{ screenshotName: 'Dashboard' }],
+          },
+        ],
+        proposals: { proposals: [] },
+      });
       assert.strictEqual(payload.evidence.length, 2);
       assert.strictEqual(payload.evidence_limit, 10);
       assert.strictEqual(payload.evidence_returned, 2);
@@ -1237,6 +1255,32 @@ describe('commands/context', () => {
               project: { slug: 'web' },
             },
             build: { id: 'build-1' },
+            dynamic_regions: {
+              systemResolution: {
+                type: 'dynamic_region_containment',
+                contractVersion: 'dynamic-region-containment-v1',
+                evidence: {
+                  id: 'evidence-1',
+                  maskDigest: 'sha256:mask-1',
+                },
+                policies: [
+                  {
+                    id: 'region-1',
+                    revision: 3,
+                    geometry: {
+                      anchorX: 'right',
+                      anchorY: 'bottom',
+                      width: 361,
+                      height: 15,
+                    },
+                    assignment: {
+                      id: 'assignment-1',
+                      screenshotName: 'Dashboard',
+                    },
+                  },
+                ],
+              },
+            },
             comparison: {
               id: 'comparison-1',
               result: 'changed',
@@ -1286,6 +1330,32 @@ describe('commands/context', () => {
       ]);
       assert.deepStrictEqual(payload.comparison.diff.cluster_metadata, {
         classification: 'dynamic_content',
+      });
+      assert.deepStrictEqual(payload.dynamic_regions, {
+        systemResolution: {
+          type: 'dynamic_region_containment',
+          contractVersion: 'dynamic-region-containment-v1',
+          evidence: {
+            id: 'evidence-1',
+            maskDigest: 'sha256:mask-1',
+          },
+          policies: [
+            {
+              id: 'region-1',
+              revision: 3,
+              geometry: {
+                anchorX: 'right',
+                anchorY: 'bottom',
+                width: 361,
+                height: 15,
+              },
+              assignment: {
+                id: 'assignment-1',
+                screenshotName: 'Dashboard',
+              },
+            },
+          ],
+        },
       });
       assert.strictEqual(payload.dynamic_content, null);
       assert.deepStrictEqual(payload.history.confirmed_regions, []);

--- a/tests/utils/visual-context-normalizers.test.js
+++ b/tests/utils/visual-context-normalizers.test.js
@@ -27,6 +27,18 @@ describe('visual context normalizers', () => {
           baseline_screenshot_id: 'baseline-mobile',
           baseline_build_id: 'baseline-build',
           baseline_original_url: 'https://cdn.test/baseline.png',
+          analysis: {
+            artifacts: {
+              diff_mask: {
+                available: true,
+                complete: true,
+                download_url:
+                  '/api/sdk/context/comparisons/comparison-mobile/diff-mask',
+                digest: `sha256:${'a'.repeat(64)}`,
+                pixel_count: 321,
+              },
+            },
+          },
           diff_image_url: 'https://cdn.test/diff.png',
           diff_percentage: 2.5,
           fingerprint_hash: 'fp-checkout',
@@ -79,6 +91,16 @@ describe('visual context normalizers', () => {
     assert.strictEqual(comparison.diff.region_count, 2);
     assert.deepStrictEqual(comparison.diff.projection, {
       clusters: { count: 2 },
+    });
+    assert.deepStrictEqual(comparison.diff.artifacts, {
+      diff_mask: {
+        available: true,
+        complete: true,
+        download_url:
+          '/api/sdk/context/comparisons/comparison-mobile/diff-mask',
+        digest: `sha256:${'a'.repeat(64)}`,
+        pixel_count: 321,
+      },
     });
   });
 


### PR DESCRIPTION
## Why

The context API exposes the evidence an agent needs to explain a visual change: Honeydiff artifact manifests for downloading and verifying the exact diff mask, build-wide dynamic-region review data, and a compact comparison proof naming the policy facts that caused automatic resolution. The CLI’s compact `--agent` projection dropped those API-owned objects, so agents received less evidence than the server had already established.

## Approach

Keep both boundaries deliberately passive. Comparison normalization preserves the API’s `artifacts` manifest, while build and comparison agent payloads pass `dynamic_regions` through unchanged. The CLI does not calculate, rename, summarize, correlate, or fill in any digest, geometry, assignment, status, or completion value; omitted API evidence remains `null`.

## Evidence

Real CLI-process coverage carries the complete diff-mask manifest and the compact dynamic-region system resolution through JSON output, including policy revision, revision event, geometry, matching assignment, hashes, counts, and timestamps. Build context separately preserves its policy/proposal review projection. The complete CLI suite, production build, and full lint pass are clean.