### PR TITLE
🔐 Isolate CLI credentials by environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "cli": "source .envrc && node bin/vizzly.js",
+    "cli": "node bin/vizzly.js",
+    "cli:local": "VIZZLY_API_URL=http://localhost:3000 node bin/vizzly.js",
     "start": "node src/index.js",
     "build": "pnpm run clean && pnpm run compile && pnpm run build:reporter && pnpm run build:reporter-ssr && pnpm run copy-types",
     "clean": "rimraf dist",

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -140,7 +140,7 @@ export function createApiClient(options = {}) {
    * Check if refresh token is available
    */
   async function hasRefreshToken() {
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokens({ apiUrl: baseUrl });
     return !!auth?.refreshToken;
   }
 
@@ -149,7 +149,7 @@ export function createApiClient(options = {}) {
    * @returns {Promise<string|null>} New token or null if refresh failed
    */
   async function attemptTokenRefresh() {
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokens({ apiUrl: baseUrl });
     if (!auth?.refreshToken) return null;
 
     try {
@@ -168,14 +168,17 @@ export function createApiClient(options = {}) {
       let data = await response.json();
 
       // Save new tokens
-      await saveAuthTokens({
-        accessToken: data.accessToken,
-        refreshToken: data.refreshToken,
-        expiresAt:
-          data.expiresAt ||
-          new Date(Date.now() + data.expiresIn * 1000).toISOString(),
-        user: auth.user,
-      });
+      await saveAuthTokens(
+        {
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+          expiresAt:
+            data.expiresAt ||
+            new Date(Date.now() + data.expiresIn * 1000).toISOString(),
+          user: auth.user,
+        },
+        { apiUrl: baseUrl }
+      );
 
       return data.accessToken;
     } catch {

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -45,10 +45,10 @@ export { clearAuthTokens, getAuthTokens, saveAuthTokens };
  * Create a token store adapter from global-config functions
  * Used by auth operations that need tokenStore parameter
  */
-export function createTokenStore() {
+export function createTokenStore(options = {}) {
   return {
-    getTokens: getAuthTokens,
-    saveTokens: saveAuthTokens,
-    clearTokens: clearAuthTokens,
+    getTokens: () => getAuthTokens(options),
+    saveTokens: tokens => saveAuthTokens(tokens, options),
+    clearTokens: () => clearAuthTokens(options),
   };
 }

--- a/src/commands/login.js
+++ b/src/commands/login.js
@@ -171,10 +171,9 @@ export async function loginCommand(
     output.header('login');
 
     // Create auth client and token store
-    let client = createAuthClient({
-      baseUrl: options.apiUrl || getApiUrl(),
-    });
-    let tokenStore = createTokenStore();
+    let apiUrl = options.apiUrl || getApiUrl();
+    let client = createAuthClient({ baseUrl: apiUrl });
+    let tokenStore = createTokenStore({ apiUrl });
 
     // Initiate device flow
     output.startSpinner('Connecting to Vizzly...');

--- a/src/commands/logout.js
+++ b/src/commands/logout.js
@@ -40,8 +40,10 @@ export async function logoutCommand(
   });
 
   try {
+    let apiUrl = options.apiUrl || getApiUrl();
+
     // Check if user is logged in
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokens({ apiUrl });
 
     if (!auth?.accessToken) {
       if (globalOptions.json) {
@@ -57,10 +59,8 @@ export async function logoutCommand(
     // Logout
     output.startSpinner('Logging out...');
 
-    let client = createAuthClient({
-      baseUrl: options.apiUrl || getApiUrl(),
-    });
-    let tokenStore = createTokenStore();
+    let client = createAuthClient({ baseUrl: apiUrl });
+    let tokenStore = createTokenStore({ apiUrl });
 
     await logout(client, tokenStore);
 

--- a/src/commands/orgs.js
+++ b/src/commands/orgs.js
@@ -39,7 +39,10 @@ export async function orgsCommand(
 
     // Prefer user auth token for listing orgs (project tokens are org-scoped).
     // Falls back to config.apiKey which may be: VIZZLY_TOKEN, --token flag, or project token.
-    let token = (await getAccessToken()) || config.apiKey;
+    let token =
+      config.userToken ||
+      (await getAccessToken({ apiUrl: config.apiUrl })) ||
+      config.apiKey;
 
     if (!token) {
       output.error(

--- a/src/commands/project.js
+++ b/src/commands/project.js
@@ -72,8 +72,11 @@ export async function projectLinkCommand(
 
   try {
     let config = await loadConfig(globalOptions.config, globalOptions);
+    let apiUrl = config.apiUrl || getApiUrl();
     let userToken =
-      config.userToken || globalOptions.token || (await getAccessToken());
+      config.userToken ||
+      globalOptions.token ||
+      (await getAccessToken({ apiUrl }));
 
     if (!userToken) {
       output.error('Login required before linking a project');
@@ -85,7 +88,6 @@ export async function projectLinkCommand(
 
     output.startSpinner(`Linking ${organizationSlug}/${projectSlug}...`);
 
-    let apiUrl = config.apiUrl || getApiUrl();
     let client = createApiClient({
       baseUrl: apiUrl,
       token: userToken,

--- a/src/commands/projects.js
+++ b/src/commands/projects.js
@@ -39,7 +39,10 @@ export async function projectsCommand(
 
     // Prefer user auth token for listing projects (project tokens are org-scoped).
     // Falls back to config.apiKey which may be: VIZZLY_TOKEN, --token flag, or project token.
-    let token = (await getAccessToken()) || config.apiKey;
+    let token =
+      config.userToken ||
+      (await getAccessToken({ apiUrl: config.apiUrl })) ||
+      config.apiKey;
 
     if (!token) {
       output.error(

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -39,7 +39,7 @@ async function getReviewToken(config, getAccessToken) {
     return config.userToken;
   }
 
-  let userToken = await getAccessToken();
+  let userToken = await getAccessToken({ apiUrl: config.apiUrl });
   if (userToken) {
     return userToken;
   }

--- a/src/commands/whoami.js
+++ b/src/commands/whoami.js
@@ -83,8 +83,10 @@ export async function whoamiCommand(
   });
 
   try {
+    let apiUrl = options.apiUrl || getApiUrl();
+
     // Check if user is logged in
-    let auth = await getAuthTokens();
+    let auth = await getAuthTokens({ apiUrl });
 
     if (!auth?.accessToken) {
       if (globalOptions.json) {
@@ -102,10 +104,8 @@ export async function whoamiCommand(
     // Get current user info
     output.startSpinner('Fetching user information...');
 
-    let client = createAuthClient({
-      baseUrl: options.apiUrl || getApiUrl(),
-    });
-    let tokenStore = createTokenStore();
+    let client = createAuthClient({ baseUrl: apiUrl });
+    let tokenStore = createTokenStore({ apiUrl });
 
     let response = await whoami(client, tokenStore);
 

--- a/src/services/auth-service.js
+++ b/src/services/auth-service.js
@@ -45,9 +45,9 @@ export function createAuthService(options = {}) {
   // Create token store adapter for global config
   // Allow injection for testing
   let tokenStore = options.tokenStore || {
-    getTokens: getAuthTokens,
-    saveTokens: saveAuthTokens,
-    clearTokens: clearAuthTokens,
+    getTokens: () => getAuthTokens({ apiUrl }),
+    saveTokens: tokens => saveAuthTokens(tokens, { apiUrl }),
+    clearTokens: () => clearAuthTokens({ apiUrl }),
   };
 
   return {

--- a/src/services/project-service.js
+++ b/src/services/project-service.js
@@ -31,7 +31,7 @@ export function createProjectService(options = {}) {
   let httpClient = options.httpClient || createAuthClient({ baseUrl: apiUrl });
 
   // Allow injection of getAuthTokens for testing
-  let tokenGetter = options.getAuthTokens || getAuthTokens;
+  let tokenGetter = options.getAuthTokens || (() => getAuthTokens({ apiUrl }));
 
   /**
    * Create an OAuth client with current access token

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -86,7 +86,7 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
   }
 
   // 6. Keep user auth separate from upload credentials.
-  let userToken = await getAccessToken();
+  let userToken = await getAccessToken({ apiUrl: config.apiUrl });
   if (userToken) {
     config.userToken = userToken;
     output.debug('config', 'using user login for user-authenticated commands');

--- a/src/utils/environment-config.js
+++ b/src/utils/environment-config.js
@@ -1,3 +1,6 @@
+import { resolveEnvironment } from './environment-profile.js';
+import { loadGlobalConfigSync } from './global-config.js';
+
 /**
  * Environment Configuration Utility
  * Centralized access to environment variables with proper defaults
@@ -26,7 +29,22 @@ export function getApiToken() {
  * @returns {string} API URL with default
  */
 export function getApiUrl() {
-  return process.env.VIZZLY_API_URL || 'https://app.vizzly.dev';
+  return getEnvironmentContext().apiUrl;
+}
+
+/**
+ * Resolve the active environment before any command chooses credentials.
+ *
+ * @param {Object} options - Optional config, environment, or URL overrides.
+ * @returns {Object} Environment name, API base URL, origin, and source.
+ */
+export function getEnvironmentContext(options = {}) {
+  let config = options.config || loadGlobalConfigSync();
+  return resolveEnvironment({
+    config,
+    env: options.env || process.env,
+    apiUrl: options.apiUrl,
+  });
 }
 
 /**

--- a/src/utils/environment-profile.js
+++ b/src/utils/environment-profile.js
@@ -1,0 +1,197 @@
+export let PRODUCTION_API_URL = 'https://app.vizzly.dev';
+export let LOCAL_API_URL = 'http://localhost:3000';
+export let ENVIRONMENT_NAMES = ['production', 'local'];
+
+/**
+ * Keep equivalent API base URLs from creating different credential identities.
+ *
+ * @param {string} apiUrl - API base URL selected by the command.
+ * @returns {string} Stable API base URL without query, hash, or trailing slash.
+ */
+export function normalizeApiUrl(apiUrl) {
+  let url = new URL(apiUrl);
+  url.hash = '';
+  url.search = '';
+  url.pathname = url.pathname.replace(/\/+$/, '');
+  return url.toString().replace(/\/$/, '');
+}
+
+/**
+ * Use the network origin as the security boundary for stored credentials.
+ *
+ * API base paths still belong in request URLs, but they must not create
+ * parallel Keychain identities for the same origin.
+ *
+ * @param {string} apiUrl - Normalized or user-provided API base URL.
+ * @returns {string} URL origin used to partition credentials.
+ */
+export function getApiOrigin(apiUrl) {
+  return new URL(normalizeApiUrl(apiUrl)).origin;
+}
+
+/**
+ * Give known origins stable human names without restricting explicit URLs.
+ *
+ * @param {string} apiUrl - API URL to identify.
+ * @returns {'production'|'local'|'custom'} Display environment name.
+ */
+export function getEnvironmentName(apiUrl) {
+  let origin = getApiOrigin(apiUrl);
+
+  if (origin === PRODUCTION_API_URL) {
+    return 'production';
+  }
+
+  if (origin === LOCAL_API_URL) {
+    return 'local';
+  }
+
+  return 'custom';
+}
+
+/**
+ * Resolve the API URL and credential origin as one decision.
+ *
+ * Keeping these values together prevents a persisted local selection, an
+ * explicit URL, and the production default from choosing credentials
+ * independently.
+ *
+ * @param {Object} options - Config, process environment, and optional URL.
+ * @returns {Object} Selected environment, API base, origin, and source.
+ */
+export function resolveEnvironment({
+  config = {},
+  env = process.env,
+  apiUrl,
+} = {}) {
+  if (apiUrl || env.VIZZLY_API_URL) {
+    let resolvedApiUrl = normalizeApiUrl(apiUrl || env.VIZZLY_API_URL);
+    let origin = getApiOrigin(resolvedApiUrl);
+    return {
+      name: getEnvironmentName(resolvedApiUrl),
+      apiUrl: resolvedApiUrl,
+      origin,
+      source: apiUrl ? 'explicit' : 'environment-variable',
+    };
+  }
+
+  let selectedName = config.environment?.active || 'production';
+  if (!ENVIRONMENT_NAMES.includes(selectedName)) {
+    throw new Error(
+      `Unknown Vizzly environment "${selectedName}". Use "production" or "local".`
+    );
+  }
+  let selectedApiUrl =
+    selectedName === 'local' ? LOCAL_API_URL : PRODUCTION_API_URL;
+  let origin = getApiOrigin(selectedApiUrl);
+
+  return {
+    name: selectedName,
+    apiUrl: origin,
+    origin,
+    source: config.environment?.active ? 'global-config' : 'default',
+  };
+}
+
+/**
+ * Read only credentials owned by the selected API origin.
+ *
+ * @param {Object} config - Global Vizzly configuration.
+ * @param {string} origin - API origin that will receive the credential.
+ * @returns {Object} Origin-scoped credential state.
+ */
+export function getCredentialState(config, origin) {
+  return config.credentials?.[getApiOrigin(origin)] || {};
+}
+
+/**
+ * Replace one origin bucket without disturbing credentials for other origins.
+ *
+ * @param {Object} config - Global Vizzly configuration.
+ * @param {string} origin - API origin that owns the state.
+ * @param {Object} credentialState - Complete state for that origin.
+ * @returns {Object} Updated immutable global configuration.
+ */
+export function setCredentialState(config, origin, credentialState) {
+  let normalizedOrigin = getApiOrigin(origin);
+
+  return {
+    ...config,
+    credentials: {
+      ...config.credentials,
+      [normalizedOrigin]: credentialState,
+    },
+  };
+}
+
+/**
+ * Cut released root credentials over to origin-scoped storage once.
+ *
+ * User auth belonged to the historical production default. Project links
+ * already recorded their API URL, so they can be partitioned without changing
+ * opaque Keychain account IDs or keeping a permanent legacy read path.
+ *
+ * This is a temporary external-config cutover, not part of the permanent
+ * environment architecture. Delete this helper and its legacy-shape tests once
+ * the supported CLI upgrade window no longer includes releases that wrote
+ * root-level `auth` or `projectLink`.
+ *
+ * @param {Object} config - Parsed global configuration.
+ * @returns {{config: Object, changed: boolean}} Cut-over config and write flag.
+ */
+export function migrateCredentialState(config = {}) {
+  let hasLegacyAuth = Boolean(config.auth);
+  let hasLegacyProjectLink = Boolean(config.projectLink);
+
+  if (!hasLegacyAuth && !hasLegacyProjectLink) {
+    return { config, changed: false };
+  }
+
+  let nextConfig = { ...config };
+  let credentials = { ...config.credentials };
+
+  if (hasLegacyAuth) {
+    let productionState = {
+      ...getCredentialState({ credentials }, PRODUCTION_API_URL),
+      auth: config.auth,
+    };
+    credentials[PRODUCTION_API_URL] = productionState;
+    delete nextConfig.auth;
+  }
+
+  if (hasLegacyProjectLink) {
+    let links = config.projectLink?.links || {};
+    let activeAccount = config.projectLink?.active || null;
+
+    for (let [account, link] of Object.entries(links)) {
+      let apiUrl = normalizeApiUrl(link.apiUrl || PRODUCTION_API_URL);
+      let origin = getApiOrigin(apiUrl);
+      let originState = credentials[origin] || {};
+      let projectLink = originState.projectLink || {
+        active: null,
+        links: {},
+      };
+      credentials[origin] = {
+        ...originState,
+        projectLink: {
+          active:
+            account === activeAccount || !projectLink.active
+              ? account
+              : projectLink.active,
+          links: {
+            ...projectLink.links,
+            [account]: {
+              ...link,
+              apiUrl,
+            },
+          },
+        },
+      };
+    }
+
+    delete nextConfig.projectLink;
+  }
+
+  nextConfig.credentials = credentials;
+  return { config: nextConfig, changed: true };
+}

--- a/src/utils/global-config.js
+++ b/src/utils/global-config.js
@@ -3,10 +3,16 @@
  * Manages ~/.vizzly/config.json for storing authentication tokens
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import {
+  getCredentialState,
+  migrateCredentialState,
+  resolveEnvironment,
+  setCredentialState,
+} from './environment-profile.js';
 import * as output from './output.js';
 
 export function expandHomePath(path) {
@@ -59,7 +65,7 @@ export function getGlobalConfigPath() {
  * @returns {Promise<void>}
  */
 async function ensureGlobalConfigDir() {
-  const dir = getGlobalConfigDir();
+  let dir = getGlobalConfigDir();
 
   if (!existsSync(dir)) {
     await mkdir(dir, { recursive: true, mode: 0o700 });
@@ -71,15 +77,17 @@ async function ensureGlobalConfigDir() {
  * @returns {Promise<Object>} Global config object
  */
 export async function loadGlobalConfig() {
+  let parsedConfig;
+
   try {
-    const configPath = getGlobalConfigPath();
+    let configPath = getGlobalConfigPath();
 
     if (!existsSync(configPath)) {
       return {};
     }
 
-    const content = await readFile(configPath, 'utf-8');
-    return JSON.parse(content);
+    let content = await readFile(configPath, 'utf-8');
+    parsedConfig = JSON.parse(content);
   } catch (error) {
     // If file doesn't exist or is corrupted, return empty config
     if (error.code === 'ENOENT') {
@@ -89,6 +97,38 @@ export async function loadGlobalConfig() {
     // Log warning about corrupted config but don't crash
     output.warn('Global config file is corrupted, ignoring');
     return {};
+  }
+
+  let migration = migrateCredentialState(parsedConfig);
+  if (migration.changed) {
+    await saveGlobalConfig(migration.config);
+  }
+
+  return migration.config;
+}
+
+/**
+ * Read environment selection synchronously for commands created before config
+ * services are available.
+ *
+ * Corrupt state fails loudly so the CLI cannot silently fall back to
+ * production and select production credentials.
+ *
+ * @returns {Object} Parsed global configuration.
+ */
+export function loadGlobalConfigSync() {
+  try {
+    let configPath = getGlobalConfigPath();
+    if (!existsSync(configPath)) {
+      return {};
+    }
+
+    return JSON.parse(readFileSync(configPath, 'utf-8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return {};
+    }
+    throw new Error('Global Vizzly config is corrupted', { cause: error });
   }
 }
 
@@ -100,8 +140,8 @@ export async function loadGlobalConfig() {
 export async function saveGlobalConfig(config) {
   await ensureGlobalConfigDir();
 
-  const configPath = getGlobalConfigPath();
-  const content = JSON.stringify(config, null, 2);
+  let configPath = getGlobalConfigPath();
+  let content = JSON.stringify(config, null, 2);
 
   // Write file with secure permissions (owner read/write only)
   await writeFile(configPath, content, { mode: 0o600 });
@@ -156,14 +196,20 @@ export async function getUserPath() {
  * Get authentication tokens from global config
  * @returns {Promise<Object|null>} Token object with accessToken, refreshToken, expiresAt, user, or null if not found
  */
-export async function getAuthTokens() {
-  const config = await loadGlobalConfig();
+export async function getAuthTokens(options = {}) {
+  let config = await loadGlobalConfig();
+  let environment = resolveEnvironment({
+    config,
+    env: options.env,
+    apiUrl: options.apiUrl,
+  });
+  let credentials = getCredentialState(config, environment.origin);
 
-  if (!config.auth?.accessToken) {
+  if (!credentials.auth?.accessToken) {
     return null;
   }
 
-  return config.auth;
+  return credentials.auth;
 }
 
 /**
@@ -171,35 +217,55 @@ export async function getAuthTokens() {
  * @param {Object} auth - Auth object with accessToken, refreshToken, expiresAt, user
  * @returns {Promise<void>}
  */
-export async function saveAuthTokens(auth) {
-  const config = await loadGlobalConfig();
+export async function saveAuthTokens(auth, options = {}) {
+  let config = await loadGlobalConfig();
+  let environment = resolveEnvironment({
+    config,
+    env: options.env,
+    apiUrl: options.apiUrl,
+  });
+  let credentials = getCredentialState(config, environment.origin);
+  let nextConfig = setCredentialState(config, environment.origin, {
+    ...credentials,
+    auth: {
+      accessToken: auth.accessToken,
+      refreshToken: auth.refreshToken,
+      expiresAt: auth.expiresAt,
+      user: auth.user,
+    },
+  });
 
-  config.auth = {
-    accessToken: auth.accessToken,
-    refreshToken: auth.refreshToken,
-    expiresAt: auth.expiresAt,
-    user: auth.user,
-  };
-
-  await saveGlobalConfig(config);
+  await saveGlobalConfig(nextConfig);
 }
 
 /**
  * Clear authentication tokens from global config
  * @returns {Promise<void>}
  */
-export async function clearAuthTokens() {
-  const config = await loadGlobalConfig();
-  delete config.auth;
-  await saveGlobalConfig(config);
+export async function clearAuthTokens(options = {}) {
+  let config = await loadGlobalConfig();
+  let environment = resolveEnvironment({
+    config,
+    env: options.env,
+    apiUrl: options.apiUrl,
+  });
+  let credentials = getCredentialState(config, environment.origin);
+  let nextCredentials = { ...credentials };
+  delete nextCredentials.auth;
+  let nextConfig = setCredentialState(
+    config,
+    environment.origin,
+    nextCredentials
+  );
+  await saveGlobalConfig(nextConfig);
 }
 
 /**
  * Check if authentication tokens exist and are not expired
  * @returns {Promise<boolean>} True if valid tokens exist
  */
-export async function hasValidTokens() {
-  const auth = await getAuthTokens();
+export async function hasValidTokens(options = {}) {
+  let auth = await getAuthTokens(options);
 
   if (!auth?.accessToken) {
     return false;
@@ -207,11 +273,11 @@ export async function hasValidTokens() {
 
   // Check if token is expired
   if (auth.expiresAt) {
-    const expiresAt = new Date(auth.expiresAt);
-    const now = new Date();
+    let expiresAt = new Date(auth.expiresAt);
+    let now = new Date();
 
     // Consider expired if within 5 minutes of expiry
-    const bufferMs = 5 * 60 * 1000;
+    let bufferMs = 5 * 60 * 1000;
     if (now.getTime() >= expiresAt.getTime() - bufferMs) {
       return false;
     }
@@ -224,10 +290,10 @@ export async function hasValidTokens() {
  * Get the access token from global config if valid and not expired
  * @returns {Promise<string|null>} Access token or null
  */
-export async function getAccessToken() {
-  let valid = await hasValidTokens();
+export async function getAccessToken(options = {}) {
+  let valid = await hasValidTokens(options);
   if (!valid) return null;
 
-  let auth = await getAuthTokens();
+  let auth = await getAuthTokens(options);
   return auth?.accessToken || null;
 }

--- a/src/utils/project-link-store.js
+++ b/src/utils/project-link-store.js
@@ -1,3 +1,9 @@
+import {
+  getApiOrigin,
+  getCredentialState,
+  resolveEnvironment,
+  setCredentialState,
+} from './environment-profile.js';
 import { loadGlobalConfig, saveGlobalConfig } from './global-config.js';
 import {
   deleteSecret as defaultDeleteSecret,
@@ -10,11 +16,21 @@ export function buildProjectLinkAccount({
   organizationSlug,
   projectSlug,
 }) {
-  return `${apiUrl || 'https://app.vizzly.dev'}|${organizationSlug}/${projectSlug}`;
+  let origin = getApiOrigin(apiUrl || 'https://app.vizzly.dev');
+  return `${origin}|${organizationSlug}/${projectSlug}`;
 }
 
-function getProjectLinkConfig(config) {
-  return config.projectLink || { active: null, links: {} };
+function getProjectLinkConfig(config, origin) {
+  let credentials = getCredentialState(config, origin);
+  return credentials.projectLink || { active: null, links: {} };
+}
+
+function setProjectLinkConfig(config, origin, projectLink) {
+  let credentials = getCredentialState(config, origin);
+  return setCredentialState(config, origin, {
+    ...credentials,
+    projectLink,
+  });
 }
 
 export async function saveProjectLink(link, deps = {}) {
@@ -26,15 +42,19 @@ export async function saveProjectLink(link, deps = {}) {
   } = deps;
 
   let config = await loadConfig();
-  let projectLink = getProjectLinkConfig(config);
-  let account = buildProjectLinkAccount(link);
+  let environment = resolveEnvironment({ config, apiUrl: link.apiUrl });
+  let projectLink = getProjectLinkConfig(config, environment.origin);
+  let account = buildProjectLinkAccount({
+    ...link,
+    apiUrl: environment.origin,
+  });
   let storedInKeychain = await saveSecret(account, link.token);
 
   projectLink.active = account;
   projectLink.links = {
     ...projectLink.links,
     [account]: {
-      apiUrl: link.apiUrl,
+      apiUrl: environment.apiUrl,
       organizationSlug: link.organizationSlug,
       organizationName: link.organizationName,
       projectSlug: link.projectSlug,
@@ -48,8 +68,12 @@ export async function saveProjectLink(link, deps = {}) {
     },
   };
 
-  config.projectLink = projectLink;
-  await saveConfig(config);
+  let nextConfig = setProjectLinkConfig(
+    config,
+    environment.origin,
+    projectLink
+  );
+  await saveConfig(nextConfig);
 
   return {
     ...projectLink.links[account],
@@ -62,7 +86,12 @@ export async function getActiveProjectLink(options = {}, deps = {}) {
   let { loadConfig = loadGlobalConfig, getSecret = defaultGetSecret } = deps;
 
   let config = await loadConfig();
-  let projectLink = getProjectLinkConfig(config);
+  let environment = resolveEnvironment({
+    config,
+    env: options.env,
+    apiUrl: options.apiUrl,
+  });
+  let projectLink = getProjectLinkConfig(config, environment.origin);
   let account = options.account || projectLink.active;
   let link = account ? projectLink.links?.[account] : null;
 
@@ -72,7 +101,10 @@ export async function getActiveProjectLink(options = {}, deps = {}) {
     options.organizationSlug &&
     options.projectSlug
   ) {
-    account = buildProjectLinkAccount(options);
+    account = buildProjectLinkAccount({
+      ...options,
+      apiUrl: environment.origin,
+    });
     link = projectLink.links?.[account] || null;
   }
 
@@ -80,7 +112,7 @@ export async function getActiveProjectLink(options = {}, deps = {}) {
     return null;
   }
 
-  if (options.apiUrl && link.apiUrl && link.apiUrl !== options.apiUrl) {
+  if (link.apiUrl && getApiOrigin(link.apiUrl) !== environment.origin) {
     return null;
   }
 
@@ -105,7 +137,12 @@ export async function clearActiveProjectLink(deps = {}) {
   } = deps;
 
   let config = await loadConfig();
-  let projectLink = getProjectLinkConfig(config);
+  let environment = resolveEnvironment({
+    config,
+    env: deps.env,
+    apiUrl: deps.apiUrl,
+  });
+  let projectLink = getProjectLinkConfig(config, environment.origin);
   let account = projectLink.active;
 
   if (!account || !projectLink.links?.[account]) {
@@ -119,8 +156,12 @@ export async function clearActiveProjectLink(deps = {}) {
 
   delete projectLink.links[account];
   projectLink.active = null;
-  config.projectLink = projectLink;
-  await saveConfig(config);
+  let nextConfig = setProjectLinkConfig(
+    config,
+    environment.origin,
+    projectLink
+  );
+  await saveConfig(nextConfig);
 
   return {
     ...link,

--- a/tests/api/client.test.js
+++ b/tests/api/client.test.js
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it, mock } from 'node:test';
 import { createApiClient, DEFAULT_API_URL } from '../../src/api/client.js';
-import { saveAuthTokens } from '../../src/utils/global-config.js';
+import {
+  getAuthTokens,
+  saveAuthTokens,
+} from '../../src/utils/global-config.js';
 
 describe('api/client', () => {
   describe('DEFAULT_API_URL', () => {
@@ -253,6 +256,69 @@ describe('api/client', () => {
         name: 'AuthError',
       });
       assert.strictEqual(mockFetch.mock.calls.length, 1);
+    });
+
+    it('refreshes and persists user auth only for the client API origin', async () => {
+      await saveAuthTokens(
+        {
+          accessToken: 'production-access',
+          refreshToken: 'production-refresh',
+          expiresAt: '2999-01-01T00:00:00.000Z',
+        },
+        { apiUrl: 'https://app.vizzly.dev' }
+      );
+      await saveAuthTokens(
+        {
+          accessToken: 'local-access',
+          refreshToken: 'local-refresh',
+          expiresAt: '2999-01-01T00:00:00.000Z',
+        },
+        { apiUrl: 'http://localhost:3000' }
+      );
+      let client = createApiClient({
+        token: 'local-access',
+        baseUrl: 'http://localhost:3000',
+      });
+      let buildRequests = 0;
+
+      mockFetch.mock.mockImplementation(async url => {
+        if (url.endsWith('/api/auth/cli/refresh')) {
+          return {
+            ok: true,
+            json: async () => ({
+              accessToken: 'refreshed-local-access',
+              refreshToken: 'refreshed-local-refresh',
+              expiresAt: '2999-02-01T00:00:00.000Z',
+            }),
+          };
+        }
+
+        buildRequests += 1;
+        if (buildRequests === 1) {
+          return {
+            ok: false,
+            status: 401,
+            headers: new Map(),
+            text: async () => 'Unauthorized',
+          };
+        }
+
+        return {
+          ok: true,
+          json: async () => ({ builds: [] }),
+        };
+      });
+
+      await client.request('/api/sdk/builds');
+
+      let localAuth = await getAuthTokens({
+        apiUrl: 'http://localhost:3000',
+      });
+      let productionAuth = await getAuthTokens({
+        apiUrl: 'https://app.vizzly.dev',
+      });
+      assert.strictEqual(localAuth.accessToken, 'refreshed-local-access');
+      assert.strictEqual(productionAuth.accessToken, 'production-access');
     });
 
     it('throws VizzlyError for server errors', async () => {

--- a/tests/utils/config-loader.test.js
+++ b/tests/utils/config-loader.test.js
@@ -6,7 +6,16 @@ import {
   getScreenshotPaths,
   loadConfig,
 } from '../../src/utils/config-loader.js';
-import { saveGlobalConfig } from '../../src/utils/global-config.js';
+import {
+  LOCAL_API_URL,
+  PRODUCTION_API_URL,
+} from '../../src/utils/environment-profile.js';
+import {
+  loadGlobalConfig,
+  saveAuthTokens,
+  saveGlobalConfig,
+} from '../../src/utils/global-config.js';
+import { saveProjectLink } from '../../src/utils/project-link-store.js';
 
 describe('utils/config-loader', () => {
   describe('getScreenshotPaths', () => {
@@ -60,6 +69,7 @@ describe('utils/config-loader', () => {
         VIZZLY_THRESHOLD: process.env.VIZZLY_THRESHOLD,
         VIZZLY_MIN_CLUSTER_SIZE: process.env.VIZZLY_MIN_CLUSTER_SIZE,
         VIZZLY_HOME: process.env.VIZZLY_HOME,
+        VIZZLY_DISABLE_KEYCHAIN: process.env.VIZZLY_DISABLE_KEYCHAIN,
       };
 
       // Clean env
@@ -68,6 +78,7 @@ describe('utils/config-loader', () => {
       delete process.env.VIZZLY_PARALLEL_ID;
       delete process.env.VIZZLY_THRESHOLD;
       delete process.env.VIZZLY_MIN_CLUSTER_SIZE;
+      process.env.VIZZLY_DISABLE_KEYCHAIN = 'true';
 
       // Create test directory
       if (existsSync(testDir)) {
@@ -192,6 +203,60 @@ describe('utils/config-loader', () => {
       assert.strictEqual(config.apiKey, 'vzt_linked_secret');
       assert.strictEqual(config.linkedProject.organizationSlug, 'vizzly');
       assert.strictEqual(config.linkedProject.projectSlug, 'storybook');
+    });
+
+    it('switches API, user auth, and project token together without changing VIZZLY_HOME', async () => {
+      await saveAuthTokens(
+        {
+          accessToken: 'production-user',
+          expiresAt: '2999-01-01T00:00:00.000Z',
+        },
+        { apiUrl: PRODUCTION_API_URL }
+      );
+      await saveProjectLink({
+        apiUrl: PRODUCTION_API_URL,
+        organizationSlug: 'vizzly',
+        projectSlug: 'production-project',
+        token: 'vzt_production_project',
+        tokenPrefix: 'vzt_prod',
+      });
+      await saveAuthTokens(
+        {
+          accessToken: 'local-user',
+          expiresAt: '2999-01-01T00:00:00.000Z',
+        },
+        { apiUrl: LOCAL_API_URL }
+      );
+      await saveProjectLink({
+        apiUrl: LOCAL_API_URL,
+        organizationSlug: 'vizzly',
+        projectSlug: 'local-project',
+        token: 'vzt_local_project',
+        tokenPrefix: 'vzt_local',
+      });
+
+      let productionConfig = await loadConfig();
+      let globalConfig = await loadGlobalConfig();
+      await saveGlobalConfig({
+        ...globalConfig,
+        environment: { active: 'local' },
+      });
+      let localConfig = await loadConfig();
+
+      assert.strictEqual(productionConfig.apiUrl, PRODUCTION_API_URL);
+      assert.strictEqual(productionConfig.userToken, 'production-user');
+      assert.strictEqual(productionConfig.apiKey, 'vzt_production_project');
+      assert.strictEqual(
+        productionConfig.linkedProject.projectSlug,
+        'production-project'
+      );
+      assert.strictEqual(localConfig.apiUrl, LOCAL_API_URL);
+      assert.strictEqual(localConfig.userToken, 'local-user');
+      assert.strictEqual(localConfig.apiKey, 'vzt_local_project');
+      assert.strictEqual(
+        localConfig.linkedProject.projectSlug,
+        'local-project'
+      );
     });
 
     it('applies VIZZLY_BUILD_NAME environment variable', async () => {

--- a/tests/utils/environment-profile.test.js
+++ b/tests/utils/environment-profile.test.js
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  getApiOrigin,
+  LOCAL_API_URL,
+  normalizeApiUrl,
+  PRODUCTION_API_URL,
+  resolveEnvironment,
+} from '../../src/utils/environment-profile.js';
+
+describe('utils/environment-profile', () => {
+  it('uses production without configuration', () => {
+    assert.deepStrictEqual(resolveEnvironment({ config: {}, env: {} }), {
+      name: 'production',
+      apiUrl: PRODUCTION_API_URL,
+      origin: PRODUCTION_API_URL,
+      source: 'default',
+    });
+  });
+
+  it('selects local only when explicitly requested', () => {
+    assert.deepStrictEqual(
+      resolveEnvironment({
+        config: { environment: { active: 'local' } },
+        env: {},
+      }),
+      {
+        name: 'local',
+        apiUrl: LOCAL_API_URL,
+        origin: LOCAL_API_URL,
+        source: 'global-config',
+      }
+    );
+  });
+
+  it('uses an explicit API URL as both the request base and credential origin', () => {
+    let environment = resolveEnvironment({
+      config: { environment: { active: 'local' } },
+      env: { VIZZLY_API_URL: 'https://preview.example.test/api/' },
+    });
+
+    assert.strictEqual(environment.name, 'custom');
+    assert.strictEqual(environment.apiUrl, 'https://preview.example.test/api');
+    assert.strictEqual(environment.origin, 'https://preview.example.test');
+  });
+
+  it('normalizes URLs without collapsing an API base path into its origin', () => {
+    assert.strictEqual(
+      normalizeApiUrl('https://preview.example.test/api/?ignored=true#hash'),
+      'https://preview.example.test/api'
+    );
+    assert.strictEqual(
+      getApiOrigin('https://preview.example.test/api'),
+      'https://preview.example.test'
+    );
+  });
+
+  it('rejects unknown selected environments instead of falling back to production', () => {
+    assert.throws(
+      () =>
+        resolveEnvironment({
+          config: { environment: { active: 'prodution' } },
+          env: {},
+        }),
+      /Unknown Vizzly environment "prodution"/
+    );
+  });
+
+  it('rejects malformed explicit API URLs', () => {
+    assert.throws(
+      () =>
+        resolveEnvironment({
+          config: {},
+          env: { VIZZLY_API_URL: 'not a URL' },
+        }),
+      /Invalid URL/
+    );
+  });
+});

--- a/tests/utils/global-config.test.js
+++ b/tests/utils/global-config.test.js
@@ -10,6 +10,10 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
+  LOCAL_API_URL,
+  PRODUCTION_API_URL,
+} from '../../src/utils/environment-profile.js';
+import {
   clearAuthTokens,
   clearGlobalConfig,
   expandHomePath,
@@ -19,9 +23,11 @@ import {
   getGlobalConfigPath,
   hasValidTokens,
   loadGlobalConfig,
+  loadGlobalConfigSync,
   saveAuthTokens,
   saveGlobalConfig,
 } from '../../src/utils/global-config.js';
+import { getActiveProjectLink } from '../../src/utils/project-link-store.js';
 
 describe('utils/global-config', () => {
   let testDir = join(process.cwd(), '.test-global-config');
@@ -121,6 +127,16 @@ describe('utils/global-config', () => {
 
       assert.deepStrictEqual(config, {});
     });
+
+    it('fails loudly when synchronous environment selection reads corrupt config', () => {
+      mkdirSync(testDir, { recursive: true });
+      writeFileSync(join(testDir, 'config.json'), 'not valid json');
+
+      assert.throws(
+        () => loadGlobalConfigSync(),
+        /Global Vizzly config is corrupted/
+      );
+    });
   });
 
   describe('saveGlobalConfig', () => {
@@ -185,6 +201,94 @@ describe('utils/global-config', () => {
       assert.strictEqual(tokens.accessToken, 'abc123');
       assert.strictEqual(tokens.refreshToken, 'xyz789');
     });
+
+    it('cuts released auth over to production once without exposing it locally', async () => {
+      await saveGlobalConfig({
+        auth: {
+          accessToken: 'released-production-token',
+          refreshToken: 'released-refresh-token',
+        },
+      });
+
+      let localTokens = await getAuthTokens({ apiUrl: LOCAL_API_URL });
+      let productionTokens = await getAuthTokens({
+        apiUrl: PRODUCTION_API_URL,
+      });
+      let persistedConfig = JSON.parse(
+        readFileSync(join(testDir, 'config.json'), 'utf-8')
+      );
+
+      assert.strictEqual(localTokens, null);
+      assert.strictEqual(
+        productionTokens.accessToken,
+        'released-production-token'
+      );
+      assert.strictEqual(persistedConfig.auth, undefined);
+      assert.strictEqual(
+        persistedConfig.credentials[PRODUCTION_API_URL].auth.accessToken,
+        'released-production-token'
+      );
+    });
+
+    it('partitions released project links without changing Keychain accounts', async () => {
+      let productionAccount = 'https://app.vizzly.dev|vizzly/storybook';
+      let localAccount = 'http://localhost:3000|vizzly/storybook';
+      await saveGlobalConfig({
+        projectLink: {
+          active: localAccount,
+          links: {
+            [productionAccount]: {
+              apiUrl: PRODUCTION_API_URL,
+              organizationSlug: 'vizzly',
+              projectSlug: 'storybook',
+              storage: 'keychain',
+              tokenPrefix: 'vzt_prod',
+            },
+            [localAccount]: {
+              apiUrl: LOCAL_API_URL,
+              organizationSlug: 'vizzly',
+              projectSlug: 'storybook',
+              storage: 'keychain',
+              tokenPrefix: 'vzt_local',
+            },
+          },
+        },
+      });
+
+      let config = await loadGlobalConfig();
+      let secrets = new Map([
+        [productionAccount, 'vzt_production_secret'],
+        [localAccount, 'vzt_local_secret'],
+      ]);
+      let productionLink = await getActiveProjectLink(
+        { apiUrl: PRODUCTION_API_URL },
+        { getSecret: async account => secrets.get(account) || null }
+      );
+      let localLink = await getActiveProjectLink(
+        { apiUrl: LOCAL_API_URL },
+        { getSecret: async account => secrets.get(account) || null }
+      );
+      let productionProjectLink =
+        config.credentials[PRODUCTION_API_URL].projectLink;
+      let localProjectLink = config.credentials[LOCAL_API_URL].projectLink;
+      assert.strictEqual(productionProjectLink.active, productionAccount);
+      assert.strictEqual(
+        productionProjectLink.links[productionAccount].apiUrl,
+        PRODUCTION_API_URL
+      );
+      assert.strictEqual(localProjectLink.active, localAccount);
+      assert.strictEqual(
+        localProjectLink.links[localAccount].apiUrl,
+        LOCAL_API_URL
+      );
+      assert.strictEqual(productionLink.token, 'vzt_production_secret');
+      assert.strictEqual(localLink.token, 'vzt_local_secret');
+
+      let persistedConfig = JSON.parse(
+        readFileSync(join(testDir, 'config.json'), 'utf-8')
+      );
+      assert.strictEqual(persistedConfig.projectLink, undefined);
+    });
   });
 
   describe('saveAuthTokens', () => {
@@ -198,10 +302,11 @@ describe('utils/global-config', () => {
 
       let config = await loadGlobalConfig();
 
-      assert.strictEqual(config.auth.accessToken, 'token123');
-      assert.strictEqual(config.auth.refreshToken, 'refresh456');
-      assert.strictEqual(config.auth.expiresAt, '2025-06-01T00:00:00Z');
-      assert.strictEqual(config.auth.user.email, 'test@example.com');
+      let auth = config.credentials[PRODUCTION_API_URL].auth;
+      assert.strictEqual(auth.accessToken, 'token123');
+      assert.strictEqual(auth.refreshToken, 'refresh456');
+      assert.strictEqual(auth.expiresAt, '2025-06-01T00:00:00Z');
+      assert.strictEqual(auth.user.email, 'test@example.com');
     });
 
     it('preserves other config when saving tokens', async () => {
@@ -211,7 +316,30 @@ describe('utils/global-config', () => {
       let config = await loadGlobalConfig();
 
       assert.strictEqual(config.other, 'data');
-      assert.strictEqual(config.auth.accessToken, 'token');
+      assert.strictEqual(
+        config.credentials[PRODUCTION_API_URL].auth.accessToken,
+        'token'
+      );
+    });
+
+    it('keeps production and local user auth isolated in one Vizzly home', async () => {
+      await saveAuthTokens(
+        { accessToken: 'production-user' },
+        { apiUrl: PRODUCTION_API_URL }
+      );
+      await saveAuthTokens(
+        { accessToken: 'local-user' },
+        { apiUrl: LOCAL_API_URL }
+      );
+
+      assert.strictEqual(
+        (await getAuthTokens({ apiUrl: PRODUCTION_API_URL })).accessToken,
+        'production-user'
+      );
+      assert.strictEqual(
+        (await getAuthTokens({ apiUrl: LOCAL_API_URL })).accessToken,
+        'local-user'
+      );
     });
   });
 

--- a/tests/utils/project-link-store.test.js
+++ b/tests/utils/project-link-store.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  LOCAL_API_URL,
+  PRODUCTION_API_URL,
+} from '../../src/utils/environment-profile.js';
+import {
   buildProjectLinkAccount,
   clearActiveProjectLink,
   getActiveProjectLink,
@@ -59,13 +63,11 @@ describe('utils/project-link-store', () => {
     assert.strictEqual(savedLink.token, 'vzt_linked_secret');
 
     let config = store.getConfig();
-    let account = 'https://app.vizzly.dev|vizzly/storybook';
-    assert.strictEqual(config.projectLink.active, account);
-    assert.strictEqual(config.projectLink.links[account].storage, 'file');
-    assert.strictEqual(
-      config.projectLink.links[account].token,
-      'vzt_linked_secret'
-    );
+    let account = `${PRODUCTION_API_URL}|vizzly/storybook`;
+    let projectLink = config.credentials[PRODUCTION_API_URL].projectLink;
+    assert.strictEqual(projectLink.active, account);
+    assert.strictEqual(projectLink.links[account].storage, 'file');
+    assert.strictEqual(projectLink.links[account].token, 'vzt_linked_secret');
 
     let activeLink = await getActiveProjectLink(
       { apiUrl: 'https://app.vizzly.dev' },
@@ -111,11 +113,12 @@ describe('utils/project-link-store', () => {
       },
     });
 
-    let account = 'https://app.vizzly.dev|vizzly/storybook';
+    let account = `${PRODUCTION_API_URL}|vizzly/storybook`;
     let config = store.getConfig();
+    let projectLink = config.credentials[PRODUCTION_API_URL].projectLink;
     assert.strictEqual(savedLink.storage, 'keychain');
-    assert.strictEqual(config.projectLink.links[account].storage, 'keychain');
-    assert.strictEqual(config.projectLink.links[account].token, undefined);
+    assert.strictEqual(projectLink.links[account].storage, 'keychain');
+    assert.strictEqual(projectLink.links[account].token, undefined);
     assert.strictEqual(secrets.get(account), 'vzt_linked_secret');
 
     let activeLink = await getActiveProjectLink(
@@ -130,17 +133,21 @@ describe('utils/project-link-store', () => {
   });
 
   it('clears the active secure-store link and deletes its saved secret', async () => {
-    let account = 'https://app.vizzly.dev|vizzly/storybook';
+    let account = `${PRODUCTION_API_URL}|vizzly/storybook`;
     let store = createConfigStore({
-      projectLink: {
-        active: account,
-        links: {
-          [account]: {
-            apiUrl: 'https://app.vizzly.dev',
-            organizationSlug: 'vizzly',
-            projectSlug: 'storybook',
-            storage: 'keychain',
-            tokenPrefix: 'vzt_lin',
+      credentials: {
+        [PRODUCTION_API_URL]: {
+          projectLink: {
+            active: account,
+            links: {
+              [account]: {
+                apiUrl: PRODUCTION_API_URL,
+                organizationSlug: 'vizzly',
+                projectSlug: 'storybook',
+                storage: 'keychain',
+                tokenPrefix: 'vzt_lin',
+              },
+            },
           },
         },
       },
@@ -158,7 +165,43 @@ describe('utils/project-link-store', () => {
 
     assert.strictEqual(clearedLink.account, account);
     assert.deepStrictEqual(deletedAccounts, [account]);
-    assert.strictEqual(store.getConfig().projectLink.active, null);
-    assert.deepStrictEqual(store.getConfig().projectLink.links, {});
+    let projectLink =
+      store.getConfig().credentials[PRODUCTION_API_URL].projectLink;
+    assert.strictEqual(projectLink.active, null);
+    assert.deepStrictEqual(projectLink.links, {});
+  });
+
+  it('keeps one active project credential per API origin across restarts', async () => {
+    let store = createConfigStore();
+
+    await saveProjectLink(createLink({ token: 'production-project' }), {
+      loadConfig: store.loadConfig,
+      saveConfig: store.saveConfig,
+      saveSecret: async () => false,
+    });
+    await saveProjectLink(
+      createLink({
+        apiUrl: LOCAL_API_URL,
+        token: 'local-project',
+        tokenPrefix: 'vzt_loc',
+      }),
+      {
+        loadConfig: store.loadConfig,
+        saveConfig: store.saveConfig,
+        saveSecret: async () => false,
+      }
+    );
+
+    let productionLink = await getActiveProjectLink(
+      { apiUrl: PRODUCTION_API_URL },
+      { loadConfig: store.loadConfig }
+    );
+    let localLink = await getActiveProjectLink(
+      { apiUrl: LOCAL_API_URL },
+      { loadConfig: store.loadConfig }
+    );
+
+    assert.strictEqual(productionLink.token, 'production-project');
+    assert.strictEqual(localLink.token, 'local-project');
   });
 });


### PR DESCRIPTION
## Why

Local dogfood and production currently share one global auth record and one active project link. The development package script also silently sources `.envrc`, so a localhost API can be paired with production config—or production can inherit a localhost project—depending on how the CLI was launched.

## Approach

Treat the normalized API origin as the credential boundary inside one Vizzly home. User auth, the active project link, file-backed tokens, Keychain account selection, and refresh-token persistence now resolve through that same origin; production remains the zero-config default and local development is an explicit `cli:local` choice.

Released root-level auth is cut over to production once. Existing project-link metadata is partitioned by its recorded API URL while preserving its opaque Keychain account exactly, then the old root shape is removed. There is no permanent dual-read path.

## Evidence

The real configuration boundary proves production and localhost credentials coexist in one home, survive reloads, and switch as a unit without crossing user or project tokens. Refresh-token coverage verifies an API client only reads and updates auth for its own origin, while the cutover coverage verifies released metadata remains reachable through its unchanged Keychain accounts.

The complete CLI suite passes with 2,338 outcomes and 6 intentional skips. The published build and type surfaces also remain valid.