### PR TITLE
✨ Make CLI environments explicit

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -27,6 +27,11 @@ import {
 } from './commands/context.js';
 import { doctorCommand, validateDoctorOptions } from './commands/doctor.js';
 import {
+  environmentShowCommand,
+  environmentUseCommand,
+  validateEnvironmentName,
+} from './commands/environment.js';
+import {
   finalizeCommand,
   validateFinalizeOptions,
 } from './commands/finalize.js';
@@ -142,7 +147,14 @@ const formatHelp = (cmd, helper) => {
           key: 'setup',
           icon: '▸',
           title: 'Setup',
-          names: ['init', 'doctor', 'config', 'baselines', 'project'],
+          names: [
+            'init',
+            'doctor',
+            'config',
+            'environment',
+            'baselines',
+            'project',
+          ],
         },
         { key: 'advanced', icon: '▸', title: 'Advanced', names: ['api'] },
         {
@@ -1166,6 +1178,32 @@ program
     }
 
     await configCommand(key, options, globalOptions);
+  });
+
+let environmentCommand = program
+  .command('environment')
+  .description('Select and inspect the Vizzly API environment')
+  .showHelpAfterError('(Run vizzly environment --help for available commands)')
+  .showSuggestionAfterError();
+
+environmentCommand
+  .command('show')
+  .description('Show the selected API environment and credential')
+  .action(async options => {
+    await environmentShowCommand(options, getGlobalOptions());
+  });
+
+environmentCommand
+  .command('use')
+  .description('Persist the production or local API environment')
+  .argument('<name>', 'Environment name: production or local')
+  .action(async (name, options) => {
+    let validationErrors = validateEnvironmentName(name);
+    if (validationErrors.length > 0) {
+      reportValidationErrors(validationErrors);
+    }
+
+    await environmentUseCommand(name, options, getGlobalOptions());
   });
 
 program

--- a/src/commands/config-cmd.js
+++ b/src/commands/config-cmd.js
@@ -41,6 +41,8 @@ export async function configCommand(
 
     // Build the config object to display
     let displayConfig = {
+      environment: config.environmentContext,
+      credential: config.credential,
       server: config.server || CONFIG_DEFAULTS.server,
       build: config.build || {},
       upload: config.upload || {},
@@ -53,7 +55,7 @@ export async function configCommand(
       displayConfig.api = {
         url: config.apiUrl || config.baseUrl,
         tokenConfigured: true,
-        tokenPrefix: `${config.apiKey.substring(0, 8)}...`,
+        tokenPrefix: config.credential.tokenPrefix,
       };
     }
 

--- a/src/commands/doctor.js
+++ b/src/commands/doctor.js
@@ -17,6 +17,11 @@ export function createDoctorDiagnostics() {
       nodeVersionValid: null,
     },
     configuration: {
+      environment: null,
+      origin: null,
+      environmentSource: null,
+      credentialKind: null,
+      tokenPrefix: null,
       apiUrl: null,
       apiUrlValid: null,
       threshold: null,
@@ -153,6 +158,28 @@ export async function doctorCommand(
 
     // Load configuration (apply global CLI overrides like --config only)
     let config = await loadConfig(globalOptions.config);
+    diagnostics.configuration.environment =
+      config.environmentContext?.name || null;
+    diagnostics.configuration.origin =
+      config.environmentContext?.origin || null;
+    diagnostics.configuration.environmentSource =
+      config.environmentContext?.source || null;
+    diagnostics.configuration.credentialKind =
+      config.credential?.kind || 'none';
+    diagnostics.configuration.tokenPrefix =
+      config.credential?.tokenPrefix || null;
+    checks.push({
+      name: 'Environment',
+      value: config.environmentContext?.name || 'unknown',
+      ok: Boolean(config.environmentContext?.name),
+    });
+    checks.push({
+      name: 'Credential',
+      value: config.credential?.tokenPrefix
+        ? `${config.credential.kind} (${config.credential.tokenPrefix})`
+        : config.credential?.kind || 'none',
+      ok: true,
+    });
 
     let apiUrlCheck = getApiUrlCheck(config.apiUrl);
     diagnostics.configuration.apiUrl = apiUrlCheck.apiUrl;

--- a/src/commands/environment.js
+++ b/src/commands/environment.js
@@ -1,0 +1,146 @@
+import { loadConfig as defaultLoadConfig } from '../utils/config-loader.js';
+import {
+  ENVIRONMENT_NAMES,
+  selectEnvironment,
+} from '../utils/environment-profile.js';
+import {
+  loadGlobalConfig as defaultLoadGlobalConfig,
+  saveGlobalConfig as defaultSaveGlobalConfig,
+} from '../utils/global-config.js';
+import * as defaultOutput from '../utils/output.js';
+
+/**
+ * Keep environment and credential diagnostics on the same resolved state used
+ * by API commands.
+ *
+ * @param {Object} config - Fully resolved CLI configuration.
+ * @returns {Object} Safe environment and credential facts.
+ */
+export function createEnvironmentStatus(config) {
+  return {
+    environment: config.environmentContext,
+    credential: config.credential,
+    userAuthAvailable: Boolean(config.userToken),
+    linkedProject: config.linkedProject
+      ? {
+          organization: config.linkedProject.organizationSlug,
+          project: config.linkedProject.projectSlug,
+          storage: config.linkedProject.storage,
+        }
+      : null,
+  };
+}
+
+function configureOutput(output, globalOptions) {
+  output.configure({
+    json: globalOptions.json,
+    verbose: globalOptions.verbose,
+    color: !globalOptions.noColor,
+  });
+}
+
+function writeEnvironmentStatus(output, status) {
+  output.header('environment');
+  output.keyValue({
+    Environment: status.environment.name,
+    'API URL': status.environment.apiUrl,
+    Origin: status.environment.origin,
+    Source: status.environment.source,
+    Credential: status.credential.kind,
+    'Token prefix': status.credential.tokenPrefix || 'not configured',
+    'User login': status.userAuthAvailable ? 'valid' : 'not available',
+  });
+
+  if (status.linkedProject) {
+    output.blank();
+    output.labelValue(
+      'Linked project',
+      `${status.linkedProject.organization}/${status.linkedProject.project}`
+    );
+    output.hint(`Credential storage: ${status.linkedProject.storage}`);
+  }
+}
+
+export async function environmentShowCommand(
+  _options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    loadConfig = defaultLoadConfig,
+    output = defaultOutput,
+    exit = code => process.exit(code),
+  } = deps;
+
+  configureOutput(output, globalOptions);
+
+  try {
+    let config = await loadConfig(globalOptions.config, globalOptions);
+    let status = createEnvironmentStatus(config);
+
+    if (globalOptions.json) {
+      output.data(status);
+    } else {
+      writeEnvironmentStatus(output, status);
+    }
+  } catch (error) {
+    output.error('Failed to read the Vizzly environment', error);
+    exit(1);
+  } finally {
+    output.cleanup();
+  }
+}
+
+export async function environmentUseCommand(
+  name,
+  _options = {},
+  globalOptions = {},
+  deps = {}
+) {
+  let {
+    env = process.env,
+    loadConfig = defaultLoadConfig,
+    loadGlobalConfig = defaultLoadGlobalConfig,
+    output = defaultOutput,
+    saveGlobalConfig = defaultSaveGlobalConfig,
+    exit = code => process.exit(code),
+  } = deps;
+
+  configureOutput(output, globalOptions);
+
+  try {
+    if (env.VIZZLY_API_URL) {
+      throw new Error(
+        'Clear VIZZLY_API_URL before changing the persisted environment'
+      );
+    }
+
+    let globalConfig = await loadGlobalConfig();
+    await saveGlobalConfig(selectEnvironment(globalConfig, name));
+    let config = await loadConfig(globalOptions.config, globalOptions);
+    let status = createEnvironmentStatus(config);
+
+    if (globalOptions.json) {
+      output.data({ changed: true, ...status });
+    } else {
+      output.complete(`Using the ${name} environment`);
+      output.blank();
+      writeEnvironmentStatus(output, status);
+    }
+  } catch (error) {
+    output.error('Failed to change the Vizzly environment', error);
+    exit(1);
+  } finally {
+    output.cleanup();
+  }
+}
+
+export function validateEnvironmentName(name) {
+  if (ENVIRONMENT_NAMES.includes(name)) {
+    return [];
+  }
+
+  return [
+    `Unknown environment "${name}". Use ${ENVIRONMENT_NAMES.join(' or ')}.`,
+  ];
+}

--- a/src/utils/config-loader.js
+++ b/src/utils/config-loader.js
@@ -4,12 +4,17 @@ import { CONFIG_DEFAULTS, deepMerge } from '../config/core.js';
 import { validateVizzlyConfigWithDefaults } from './config-schema.js';
 import {
   getApiToken,
-  getApiUrl,
   getBuildName,
+  getEnvironmentContext,
   getMinClusterSize,
   getParallelId,
   getThreshold,
 } from './environment-config.js';
+import {
+  getApiOrigin,
+  getEnvironmentName,
+  normalizeApiUrl,
+} from './environment-profile.js';
 import { getAccessToken } from './global-config.js';
 import * as output from './output.js';
 import { getActiveProjectLink } from './project-link-store.js';
@@ -27,16 +32,29 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
 
   // 2. Validate config file using Zod schema
   let validatedFileConfig = validateVizzlyConfigWithDefaults(fileConfig);
+  let environmentContext = getEnvironmentContext();
+
+  if (fileConfig.apiUrl && environmentContext.source === 'default') {
+    let apiUrl = normalizeApiUrl(fileConfig.apiUrl);
+    environmentContext = {
+      name: getEnvironmentName(apiUrl),
+      apiUrl,
+      origin: getApiOrigin(apiUrl),
+      source: 'project-config',
+    };
+  }
 
   // Create a proper clone of the default config to avoid shared object references
   let config = deepMerge(CONFIG_DEFAULTS, {});
+  let credential = fileConfig.apiKey
+    ? createCredentialSummary('config-token', fileConfig.apiKey)
+    : createCredentialSummary('none');
 
   // Merge validated file config
   mergeConfig(config, validatedFileConfig);
 
   // 3. Override with environment variables (higher priority than fallbacks)
   let envApiKey = getApiToken();
-  let envApiUrl = getApiUrl();
   let envBuildName = getBuildName();
   let envParallelId = getParallelId();
   let envThreshold = getThreshold();
@@ -44,9 +62,10 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
 
   if (envApiKey) {
     config.apiKey = envApiKey;
+    credential = createCredentialSummary('environment-token', envApiKey);
     output.debug('config', 'using token from environment');
   }
-  if (envApiUrl !== 'https://app.vizzly.dev') config.apiUrl = envApiUrl;
+  config.apiUrl = environmentContext.apiUrl;
   if (envBuildName) {
     config.build.name = envBuildName;
     output.debug('config', 'using build name from environment');
@@ -59,6 +78,7 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
 
   // 4. Apply CLI overrides (highest priority)
   if (cliOverrides.token) {
+    credential = createCredentialSummary('command-token', cliOverrides.token);
     output.debug('config', 'using token from --token flag');
   }
 
@@ -81,6 +101,11 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
         expiresAt: linkedProject.expiresAt,
         storage: linkedProject.storage,
       };
+      credential = createCredentialSummary(
+        'linked-project',
+        linkedProject.token,
+        linkedProject.tokenPrefix
+      );
       output.debug('config', 'using linked project token');
     }
   }
@@ -89,12 +114,39 @@ export async function loadConfig(configPath = null, cliOverrides = {}) {
   let userToken = await getAccessToken({ apiUrl: config.apiUrl });
   if (userToken) {
     config.userToken = userToken;
+    if (credential.kind === 'none') {
+      credential = createCredentialSummary('user-login', userToken);
+    }
     output.debug('config', 'using user login for user-authenticated commands');
   }
 
   config._configPath = result?.filepath || null;
+  config.environmentContext = environmentContext;
+  config.credential = credential;
 
   return config;
+}
+
+/**
+ * Describe the credential source without exposing the credential itself.
+ *
+ * Tracking this at config resolution avoids diagnostics guessing from token
+ * syntax after precedence has already been applied.
+ *
+ * @param {string} kind - Exact config source that selected the token.
+ * @param {string|null} token - Selected credential, when present.
+ * @param {string|null} knownPrefix - API-provided safe token prefix.
+ * @returns {{kind: string, tokenPrefix: string|null}} Safe credential facts.
+ */
+export function createCredentialSummary(
+  kind,
+  token = null,
+  knownPrefix = null
+) {
+  return {
+    kind,
+    tokenPrefix: knownPrefix || (token ? `${token.substring(0, 8)}...` : null),
+  };
 }
 
 /**

--- a/src/utils/environment-profile.js
+++ b/src/utils/environment-profile.js
@@ -125,6 +125,30 @@ export function setCredentialState(config, origin, credentialState) {
 }
 
 /**
+ * Persist an explicit environment choice without touching either credential
+ * bucket.
+ *
+ * @param {Object} config - Global Vizzly configuration.
+ * @param {'production'|'local'} name - Environment to select.
+ * @returns {Object} Updated immutable global configuration.
+ */
+export function selectEnvironment(config, name) {
+  if (!ENVIRONMENT_NAMES.includes(name)) {
+    throw new Error(
+      `Unknown Vizzly environment "${name}". Use "production" or "local".`
+    );
+  }
+
+  return {
+    ...config,
+    environment: {
+      ...config.environment,
+      active: name,
+    },
+  };
+}
+
+/**
  * Cut released root credentials over to origin-scoped storage once.
  *
  * User auth belonged to the historical production default. Project links

--- a/tests/commands/config-cmd.test.js
+++ b/tests/commands/config-cmd.test.js
@@ -43,6 +43,16 @@ describe('commands/config', () => {
         { json: true },
         {
           loadConfig: async () => ({
+            environmentContext: {
+              name: 'production',
+              apiUrl: 'https://app.vizzly.dev',
+              origin: 'https://app.vizzly.dev',
+              source: 'default',
+            },
+            credential: {
+              kind: 'none',
+              tokenPrefix: null,
+            },
             server: { port: 47392, timeout: 30000 },
             comparison: { threshold: 2.0, minClusterSize: 2 },
             tdd: { openReport: false },
@@ -55,6 +65,10 @@ describe('commands/config', () => {
       let dataCall = output.calls.find(c => c.method === 'data');
       assert.ok(dataCall);
       assert.strictEqual(dataCall.args[0].config.server.port, 47392);
+      assert.strictEqual(
+        dataCall.args[0].config.environment.name,
+        'production'
+      );
       assert.strictEqual(dataCall.args[0].config.comparison.threshold, 2.0);
       assert.strictEqual(dataCall.args[0].config.comparison.minClusterSize, 2);
     });
@@ -164,6 +178,10 @@ describe('commands/config', () => {
           loadConfig: async () => ({
             apiKey: 'vzt_supersecrettoken12345',
             apiUrl: 'https://api.vizzly.dev',
+            credential: {
+              kind: 'config-token',
+              tokenPrefix: 'vzt_supe...',
+            },
             server: { port: 47392 },
           }),
           output,
@@ -195,6 +213,10 @@ describe('commands/config', () => {
           loadConfig: async () => ({
             apiKey: 'vzt_supersecrettoken12345',
             apiUrl: 'https://app.vizzly.dev',
+            credential: {
+              kind: 'linked-project',
+              tokenPrefix: 'vzt_123',
+            },
             server: { port: 47392 },
             linkedProject: {
               organizationSlug: 'vizzly',

--- a/tests/commands/doctor.test.js
+++ b/tests/commands/doctor.test.js
@@ -50,6 +50,16 @@ function createMockOutput() {
 let validConfig = {
   apiUrl: 'https://api.example.test',
   apiKey: 'token-123',
+  environmentContext: {
+    name: 'custom',
+    apiUrl: 'https://api.example.test',
+    origin: 'https://api.example.test',
+    source: 'project-config',
+  },
+  credential: {
+    kind: 'config-token',
+    tokenPrefix: 'token-12...',
+  },
   comparison: { threshold: 2 },
   server: { port: 47888 },
 };
@@ -69,6 +79,11 @@ describe('commands/doctor', () => {
           nodeVersionValid: null,
         },
         configuration: {
+          environment: null,
+          origin: null,
+          environmentSource: null,
+          credentialKind: null,
+          tokenPrefix: null,
           apiUrl: null,
           apiUrlValid: null,
           threshold: null,

--- a/tests/commands/environment-cli.test.js
+++ b/tests/commands/environment-cli.test.js
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { runCLI } from '../helpers/cli-runner.js';
+
+let PRODUCTION_API_URL = 'https://app.vizzly.dev';
+let LOCAL_API_URL = 'http://localhost:3000';
+let PRODUCTION_TOKEN = 'vzt_production_secret';
+let LOCAL_TOKEN = 'vzt_local_secret';
+
+function createWorkspace() {
+  let cwd = mkdtempSync(join(tmpdir(), 'vizzly-cli-environment-'));
+  let vizzlyHome = join(cwd, '.vizzly-home');
+  mkdirSync(vizzlyHome, { recursive: true });
+  return {
+    cwd,
+    vizzlyHome,
+    configPath: join(vizzlyHome, 'config.json'),
+  };
+}
+
+function createEnvironmentState() {
+  let productionAccount = `${PRODUCTION_API_URL}|vizzly/frontend`;
+  let localAccount = `${LOCAL_API_URL}|dogfood/app`;
+
+  return {
+    credentials: {
+      [PRODUCTION_API_URL]: {
+        projectLink: {
+          active: productionAccount,
+          links: {
+            [productionAccount]: {
+              apiUrl: PRODUCTION_API_URL,
+              organizationSlug: 'vizzly',
+              projectSlug: 'frontend',
+              storage: 'file',
+              token: PRODUCTION_TOKEN,
+              tokenPrefix: 'vzt_prod',
+            },
+          },
+        },
+      },
+      [LOCAL_API_URL]: {
+        projectLink: {
+          active: localAccount,
+          links: {
+            [localAccount]: {
+              apiUrl: LOCAL_API_URL,
+              organizationSlug: 'dogfood',
+              projectSlug: 'app',
+              storage: 'file',
+              token: LOCAL_TOKEN,
+              tokenPrefix: 'vzt_local',
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+function writeEnvironmentState(workspace) {
+  writeFileSync(
+    workspace.configPath,
+    JSON.stringify(createEnvironmentState(), null, 2)
+  );
+}
+
+function createEnv(workspace, overrides = {}) {
+  return {
+    VIZZLY_API_URL: undefined,
+    VIZZLY_DISABLE_KEYCHAIN: 'true',
+    VIZZLY_HOME: workspace.vizzlyHome,
+    ...overrides,
+  };
+}
+
+function parseData(stdout) {
+  return JSON.parse(stdout).data;
+}
+
+describe('commands/environment CLI', () => {
+  it('defaults to production without persisting a selection', async () => {
+    let workspace = createWorkspace();
+    let result = await runCLI(['--no-color', '--json', 'environment', 'show'], {
+      cwd: workspace.cwd,
+      env: createEnv(workspace),
+    });
+
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(parseData(result.stdout), {
+      environment: {
+        name: 'production',
+        apiUrl: PRODUCTION_API_URL,
+        origin: PRODUCTION_API_URL,
+        source: 'default',
+      },
+      credential: {
+        kind: 'none',
+        tokenPrefix: null,
+      },
+      userAuthAvailable: false,
+      linkedProject: null,
+    });
+    let persisted = JSON.parse(readFileSync(workspace.configPath, 'utf8'));
+    assert.strictEqual(persisted.environment, undefined);
+  });
+
+  it('switches API and project credentials together in one VIZZLY_HOME', async () => {
+    let workspace = createWorkspace();
+    writeEnvironmentState(workspace);
+    let env = createEnv(workspace);
+
+    let production = await runCLI(
+      ['--no-color', '--json', 'environment', 'show'],
+      { cwd: workspace.cwd, env }
+    );
+    let local = await runCLI(
+      ['--no-color', '--json', 'environment', 'use', 'local'],
+      { cwd: workspace.cwd, env }
+    );
+    let localHuman = await runCLI(['--no-color', 'environment', 'show'], {
+      cwd: workspace.cwd,
+      env,
+    });
+    let productionAgain = await runCLI(
+      ['--no-color', '--json', 'environment', 'use', 'production'],
+      { cwd: workspace.cwd, env }
+    );
+
+    let productionStatus = parseData(production.stdout);
+    let localStatus = parseData(local.stdout);
+    let productionAgainStatus = parseData(productionAgain.stdout);
+    assert.strictEqual(productionStatus.environment.name, 'production');
+    assert.strictEqual(productionStatus.credential.tokenPrefix, 'vzt_prod');
+    assert.deepStrictEqual(productionStatus.linkedProject, {
+      organization: 'vizzly',
+      project: 'frontend',
+      storage: 'file',
+    });
+    assert.strictEqual(localStatus.changed, true);
+    assert.strictEqual(localStatus.environment.name, 'local');
+    assert.strictEqual(localStatus.environment.apiUrl, LOCAL_API_URL);
+    assert.strictEqual(localStatus.credential.tokenPrefix, 'vzt_local');
+    assert.deepStrictEqual(localStatus.linkedProject, {
+      organization: 'dogfood',
+      project: 'app',
+      storage: 'file',
+    });
+    assert.match(localHuman.stdout, /Token prefix\s+vzt_local/);
+    assert.match(localHuman.stdout, /dogfood\/app/);
+    assert.strictEqual(productionAgainStatus.environment.name, 'production');
+    assert.strictEqual(
+      productionAgainStatus.credential.tokenPrefix,
+      'vzt_prod'
+    );
+
+    let persisted = JSON.parse(readFileSync(workspace.configPath, 'utf8'));
+    assert.strictEqual(persisted.environment.active, 'production');
+    assert.deepStrictEqual(
+      persisted.credentials,
+      createEnvironmentState().credentials
+    );
+
+    let output = [
+      production.stdout,
+      local.stdout,
+      localHuman.stdout,
+      productionAgain.stdout,
+    ].join('\n');
+    assert.ok(!output.includes(PRODUCTION_TOKEN));
+    assert.ok(!output.includes(LOCAL_TOKEN));
+  });
+
+  it('reports the same safe credential facts from environment, config, and doctor', async () => {
+    let workspace = createWorkspace();
+    let state = {
+      ...createEnvironmentState(),
+      environment: { active: 'local' },
+    };
+    writeFileSync(workspace.configPath, JSON.stringify(state, null, 2));
+    let env = createEnv(workspace);
+
+    let environment = parseData(
+      (
+        await runCLI(['--no-color', '--json', 'environment', 'show'], {
+          cwd: workspace.cwd,
+          env,
+        })
+      ).stdout
+    );
+    let config = parseData(
+      (
+        await runCLI(['--no-color', '--json', 'config'], {
+          cwd: workspace.cwd,
+          env,
+        })
+      ).stdout
+    ).config;
+    let doctor = parseData(
+      (
+        await runCLI(['--no-color', '--json', 'doctor'], {
+          cwd: workspace.cwd,
+          env,
+        })
+      ).stdout
+    ).diagnostics.configuration;
+
+    assert.deepStrictEqual(environment.credential, {
+      kind: 'linked-project',
+      tokenPrefix: 'vzt_local',
+    });
+    assert.deepStrictEqual(config.credential, environment.credential);
+    assert.strictEqual(config.api.tokenPrefix, 'vzt_local');
+    assert.strictEqual(config.environment.name, 'local');
+    assert.strictEqual(doctor.environment, 'local');
+    assert.strictEqual(doctor.origin, LOCAL_API_URL);
+    assert.strictEqual(doctor.credentialKind, 'linked-project');
+    assert.strictEqual(doctor.tokenPrefix, 'vzt_local');
+  });
+
+  it('does not persist a selection hidden by VIZZLY_API_URL', async () => {
+    let workspace = createWorkspace();
+    let result = await runCLI(['--no-color', 'environment', 'use', 'local'], {
+      cwd: workspace.cwd,
+      env: createEnv(workspace, {
+        VIZZLY_API_URL: 'https://preview.example.test',
+      }),
+    });
+
+    assert.strictEqual(result.code, 1);
+    assert.match(result.stderr, /Clear VIZZLY_API_URL/);
+    if (existsSync(workspace.configPath)) {
+      let persisted = JSON.parse(readFileSync(workspace.configPath, 'utf8'));
+      assert.strictEqual(persisted.environment, undefined);
+    }
+  });
+});

--- a/tests/utils/environment-profile.test.js
+++ b/tests/utils/environment-profile.test.js
@@ -6,6 +6,7 @@ import {
   normalizeApiUrl,
   PRODUCTION_API_URL,
   resolveEnvironment,
+  selectEnvironment,
 } from '../../src/utils/environment-profile.js';
 
 describe('utils/environment-profile', () => {
@@ -74,6 +75,27 @@ describe('utils/environment-profile', () => {
           env: { VIZZLY_API_URL: 'not a URL' },
         }),
       /Invalid URL/
+    );
+  });
+
+  it('changes only the selected environment and preserves credentials', () => {
+    let credentials = {
+      [PRODUCTION_API_URL]: { auth: { storage: 'keychain' } },
+      [LOCAL_API_URL]: { projectLink: { active: 'local-project' } },
+    };
+    let config = {
+      credentials,
+      unrelated: { preserved: true },
+    };
+
+    let selected = selectEnvironment(config, 'local');
+
+    assert.strictEqual(selected.environment.active, 'local');
+    assert.strictEqual(selected.credentials, credentials);
+    assert.strictEqual(selected.unrelated, config.unrelated);
+    assert.throws(
+      () => selectEnvironment(config, 'preview'),
+      /Unknown Vizzly environment "preview"/
     );
   });
 });


### PR DESCRIPTION
## Why

Local dogfooding and production use the same CLI, but the selected API, project link, and credential have been too easy to drift apart. The CLI needs one intentional switch that keeps those decisions together without making production setup more complicated.

This is stacked on #328, which establishes the origin-scoped credential storage this workflow selects from.

## What changed

- Adds `vizzly environment show` and `vizzly environment use <production|local>`.
- Keeps production as the zero-config default and persists a choice only when `environment use` is called.
- Preserves `VIZZLY_API_URL` for explicit and custom URLs; a persisted switch is rejected while that override is active so the CLI cannot claim a hidden change took effect.
- Resolves API URL, origin, project link, and credential source once, then shares the same safe summary with `environment`, `config`, and `doctor`.
- Uses the API-provided project token prefix when available and never prints the full credential.

## Confidence

The real spawned CLI is covered across production → local → production switches in one `VIZZLY_HOME`, including persisted config, linked project selection, JSON and human output, and secret non-disclosure. The focused command/config suite is green, along with lint, the production build, and published type checks.